### PR TITLE
Add versioned skill install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ cp bin/s0 /usr/local/bin/
 
 Configuration file: `~/.s0/config.yaml`
 
+Local skill store: `~/.s0/skills`
+
 ```yaml
 current-profile: default
 profiles:
@@ -203,6 +205,16 @@ s0 sandbox volume status -s <sandbox-id>
 ```bash
 s0 template image build [CONTEXT] -t <tag> [-f Dockerfile] [--platform linux/amd64] [--no-cache] [--pull]
 s0 template image push <local-image> -t <target-tag>
+```
+
+### Skill
+
+```bash
+s0 skill get [sandbox0]
+s0 skill install [sandbox0] [--force] [--activate]
+s0 skill list [sandbox0]
+s0 skill activate sandbox0 <version>
+s0 skill sync sandbox0 [--version <version>] [--agent codex | --target-dir <dir>] [--force]
 ```
 
 ## Examples

--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -1,0 +1,206 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sandbox0-ai/s0/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+var (
+	skillInstallForce  bool
+	skillInstallActive bool
+	skillSyncVersion   string
+	skillSyncAgent     string
+	skillSyncTargetDir string
+	skillSyncForce     bool
+)
+
+var skillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage Sandbox0 coding-agent skills",
+	Long:  `Install, inspect, activate, and sync versioned Sandbox0 skill artifacts.`,
+}
+
+var skillInstallCmd = &cobra.Command{
+	Use:   "install [skill-name]",
+	Short: "Install the deployment-matched skill artifact",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := "sandbox0"
+		if len(args) == 1 {
+			name = args[0]
+		}
+
+		api, store, err := getSkillDependencies()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing skill install: %v\n", err)
+			os.Exit(1)
+		}
+
+		installed, err := store.Install(cmd.Context(), api, name, skillInstallForce, skillInstallActive)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error installing skill: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, []skills.InstalledVersion{*installed}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var skillListCmd = &cobra.Command{
+	Use:   "list [skill-name]",
+	Short: "List installed skill versions",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := ""
+		if len(args) == 1 {
+			name = args[0]
+		}
+		store, err := getSkillStore()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing skill list: %v\n", err)
+			os.Exit(1)
+		}
+
+		installed, err := store.List(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing skills: %v\n", err)
+			os.Exit(1)
+		}
+		if err := getFormatter().Format(os.Stdout, installed); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var skillGetCmd = &cobra.Command{
+	Use:   "get [skill-name]",
+	Short: "Fetch deployment-matched skill metadata from the API",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := "sandbox0"
+		if len(args) == 1 {
+			name = args[0]
+		}
+		api, _, err := getSkillDependencies()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing skill request: %v\n", err)
+			os.Exit(1)
+		}
+		release, err := api.GetRelease(cmd.Context(), name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting skill metadata: %v\n", err)
+			os.Exit(1)
+		}
+		if err := getFormatter().Format(os.Stdout, release); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var skillActivateCmd = &cobra.Command{
+	Use:   "activate <skill-name> <version>",
+	Short: "Set the active local skill version",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		store, err := getSkillStore()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing skill activation: %v\n", err)
+			os.Exit(1)
+		}
+		if err := store.Activate(args[0], args[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error activating skill: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stdout, "Activated %s %s\n", args[0], args[1])
+	},
+}
+
+var skillSyncCmd = &cobra.Command{
+	Use:   "sync <skill-name>",
+	Short: "Sync an installed skill to an agent directory",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		store, err := getSkillStore()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing skill sync: %v\n", err)
+			os.Exit(1)
+		}
+		targetDir, err := resolveSkillSyncTarget(args[0], skillSyncAgent, skillSyncTargetDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving sync target: %v\n", err)
+			os.Exit(1)
+		}
+		if err := store.Sync(args[0], skillSyncVersion, targetDir, skillSyncForce); err != nil {
+			fmt.Fprintf(os.Stderr, "Error syncing skill: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stdout, "Synced %s to %s\n", args[0], targetDir)
+	},
+}
+
+func getSkillDependencies() (*skills.APIClient, *skills.Store, error) {
+	profile, err := getProfileWithFreshToken()
+	if err != nil {
+		return nil, nil, err
+	}
+	store, err := getSkillStore()
+	if err != nil {
+		return nil, nil, err
+	}
+	api := skills.NewAPIClient(profile.GetAPIURL(), profile.GetToken(), fmt.Sprintf("s0/%s", cfgVersion))
+	return api, store, nil
+}
+
+func getSkillStore() (*skills.Store, error) {
+	rootDir, err := skills.DefaultRootDir()
+	if err != nil {
+		return nil, err
+	}
+	return skills.NewStore(rootDir), nil
+}
+
+func resolveSkillSyncTarget(name, agent, targetDir string) (string, error) {
+	if strings.TrimSpace(targetDir) != "" {
+		return filepath.Clean(targetDir), nil
+	}
+	switch strings.TrimSpace(agent) {
+	case "codex":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, ".codex", "skills", name), nil
+	case "":
+		return "", fmt.Errorf("either --agent or --target-dir is required")
+	default:
+		return "", fmt.Errorf("unsupported agent %q", agent)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(skillCmd)
+
+	skillInstallCmd.Flags().BoolVar(&skillInstallForce, "force", false, "reinstall even when the same version is already stored locally")
+	skillInstallCmd.Flags().BoolVar(&skillInstallActive, "activate", true, "mark the installed version as active")
+
+	skillSyncCmd.Flags().StringVar(&skillSyncVersion, "version", "", "installed version to sync (defaults to the active version)")
+	skillSyncCmd.Flags().StringVar(&skillSyncAgent, "agent", "", "agent preset to sync to (supported: codex)")
+	skillSyncCmd.Flags().StringVar(&skillSyncTargetDir, "target-dir", "", "explicit target directory for the synced skill")
+	skillSyncCmd.Flags().BoolVar(&skillSyncForce, "force", false, "replace an existing target directory")
+
+	skillCmd.AddCommand(skillInstallCmd)
+	skillCmd.AddCommand(skillListCmd)
+	skillCmd.AddCommand(skillGetCmd)
+	skillCmd.AddCommand(skillActivateCmd)
+	skillCmd.AddCommand(skillSyncCmd)
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/s0/internal/client"
+	"github.com/sandbox0-ai/s0/internal/skills"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -89,6 +90,10 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatTeamMember(w, &v)
 	case *apispec.TeamMember:
 		return f.formatTeamMember(w, v)
+	case []skills.InstalledVersion:
+		return f.formatInstalledSkills(w, v)
+	case *skills.Release:
+		return f.formatSkillRelease(w, v)
 	case apispec.User:
 		return f.formatUser(w, &v)
 	case *apispec.User:
@@ -138,6 +143,45 @@ func (f *TableFormatter) formatTemplates(w io.Writer, templates []apispec.Templa
 			tmpl.CreatedAt.Format("2006-01-02 15:04:05"),
 		})
 	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatInstalledSkills(w io.Writer, installed []skills.InstalledVersion) error {
+	if len(installed) == 0 {
+		_, _ = fmt.Fprintln(w, "No installed skills found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"SKILL", "VERSION", "ACTIVE", "INSTALLED AT"})
+	for _, item := range installed {
+		active := "no"
+		if item.Active {
+			active = "yes"
+		}
+		_ = t.Append([]string{
+			item.Name,
+			item.Version,
+			active,
+			item.InstalledAt.Format(timeLayout),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSkillRelease(w io.Writer, release *skills.Release) error {
+	if release == nil {
+		_, _ = fmt.Fprintln(w, "No skill release found.")
+		return nil
+	}
+	t := newTable(w)
+	t.Header([]string{"FIELD", "VALUE"})
+	_ = t.Append([]string{"Name", release.Name})
+	_ = t.Append([]string{"Version", release.ReleaseVersion})
+	_ = t.Append([]string{"Tag", release.ReleaseTag})
+	_ = t.Append([]string{"Download URL", release.DownloadURL})
+	_ = t.Append([]string{"Checksum URL", release.ChecksumURL})
+	_ = t.Append([]string{"Manifest URL", release.ManifestURL})
 	return t.Render()
 }
 

--- a/internal/skills/client.go
+++ b/internal/skills/client.go
@@ -1,0 +1,162 @@
+package skills
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Release struct {
+	Name           string   `json:"name"`
+	ReleaseVersion string   `json:"releaseVersion"`
+	ReleaseTag     string   `json:"releaseTag"`
+	ArtifactPrefix string   `json:"artifactPrefix"`
+	SourcePriority []string `json:"sourcePriority"`
+	DownloadURL    string   `json:"downloadUrl"`
+	ChecksumURL    string   `json:"checksumUrl"`
+	ManifestURL    string   `json:"manifestUrl"`
+}
+
+type apiEnvelope struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Error   *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type APIClient struct {
+	baseURL    string
+	token      string
+	userAgent  string
+	httpClient *http.Client
+}
+
+func NewAPIClient(baseURL, token, userAgent string) *APIClient {
+	return &APIClient{
+		baseURL:   strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		token:     strings.TrimSpace(token),
+		userAgent: strings.TrimSpace(userAgent),
+		httpClient: &http.Client{
+			Timeout: 5 * time.Minute,
+		},
+	}
+}
+
+func (c *APIClient) GetRelease(ctx context.Context, name string) (*Release, error) {
+	endpoint := c.baseURL + "/api/v1/agent-skills/" + name
+	req, err := c.newRequest(ctx, http.MethodGet, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request agent skill metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var envelope apiEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("decode agent skill metadata: %w", err)
+	}
+	if !envelope.Success {
+		if envelope.Error != nil && envelope.Error.Message != "" {
+			return nil, fmt.Errorf("%s", envelope.Error.Message)
+		}
+		return nil, fmt.Errorf("agent skill metadata request failed with status %d", resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.Unmarshal(envelope.Data, &release); err != nil {
+		return nil, fmt.Errorf("decode agent skill data: %w", err)
+	}
+	return &release, nil
+}
+
+func (c *APIClient) DownloadArtifact(ctx context.Context, name string, dest io.Writer) (string, error) {
+	endpoint := c.baseURL + "/api/v1/agent-skills/" + name + "/download"
+	return c.download(ctx, endpoint, dest)
+}
+
+func (c *APIClient) DownloadChecksum(ctx context.Context, name string) (string, error) {
+	endpoint := c.baseURL + "/api/v1/agent-skills/" + name + "/checksum"
+	req, err := c.newRequest(ctx, http.MethodGet, endpoint)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request checksum: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("checksum request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read checksum: %w", err)
+	}
+	fields := strings.Fields(string(body))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("checksum response is empty")
+	}
+	return fields[0], nil
+}
+
+func SHA256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func (c *APIClient) download(ctx context.Context, endpoint string, dest io.Writer) (string, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, endpoint)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request artifact: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("artifact request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if _, err := io.Copy(dest, resp.Body); err != nil {
+		return "", fmt.Errorf("write artifact: %w", err)
+	}
+	return resp.Request.URL.String(), nil
+}
+
+func (c *APIClient) newRequest(ctx context.Context, method, endpoint string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	return req, nil
+}

--- a/internal/skills/store.go
+++ b/internal/skills/store.go
@@ -1,0 +1,458 @@
+package skills
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Store struct {
+	root string
+}
+
+type InstallMetadata struct {
+	Name           string    `json:"name"`
+	ReleaseVersion string    `json:"releaseVersion"`
+	ReleaseTag     string    `json:"releaseTag"`
+	ArtifactURL    string    `json:"artifactUrl"`
+	Checksum       string    `json:"checksum"`
+	InstalledAt    time.Time `json:"installedAt"`
+}
+
+type InstalledVersion struct {
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Active      bool      `json:"active"`
+	InstalledAt time.Time `json:"installedAt"`
+	Path        string    `json:"path"`
+}
+
+func DefaultRootDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".s0", "skills"), nil
+}
+
+func NewStore(root string) *Store {
+	return &Store{root: root}
+}
+
+func (s *Store) Root() string {
+	return s.root
+}
+
+func (s *Store) Install(ctx context.Context, api *APIClient, name string, force, activate bool) (*InstalledVersion, error) {
+	release, err := api.GetRelease(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	versionDir := s.versionDir(release.Name, release.ReleaseVersion)
+	if !force {
+		if existing, err := s.GetInstalledVersion(release.Name, release.ReleaseVersion); err == nil {
+			if activate {
+				if err := s.Activate(release.Name, release.ReleaseVersion); err != nil {
+					return nil, err
+				}
+				existing.Active = true
+			}
+			return existing, nil
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(versionDir), 0o755); err != nil {
+		return nil, fmt.Errorf("create version parent dir: %w", err)
+	}
+
+	tempRoot := filepath.Join(s.root, ".tmp")
+	if err := os.MkdirAll(tempRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("create temp root: %w", err)
+	}
+	tmpDir, err := os.MkdirTemp(tempRoot, "install-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, "skill.tar.gz")
+	archiveFile, err := os.Create(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("create artifact file: %w", err)
+	}
+	artifactURL, downloadErr := api.DownloadArtifact(ctx, release.Name, archiveFile)
+	closeErr := archiveFile.Close()
+	if downloadErr != nil {
+		return nil, downloadErr
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close artifact file: %w", closeErr)
+	}
+
+	expectedChecksum, err := api.DownloadChecksum(ctx, release.Name)
+	if err != nil {
+		return nil, err
+	}
+	actualChecksum, err := SHA256File(archivePath)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(expectedChecksum, actualChecksum) {
+		return nil, fmt.Errorf("checksum mismatch: expected %s got %s", expectedChecksum, actualChecksum)
+	}
+
+	extractRoot := filepath.Join(tmpDir, "extract")
+	if err := os.MkdirAll(extractRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("create extract dir: %w", err)
+	}
+	if err := extractTarGz(archivePath, extractRoot); err != nil {
+		return nil, err
+	}
+	bundleDir, err := singleRootDir(extractRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if force {
+		if err := os.RemoveAll(versionDir); err != nil {
+			return nil, fmt.Errorf("remove existing version dir: %w", err)
+		}
+	}
+	if err := os.Rename(bundleDir, versionDir); err != nil {
+		return nil, fmt.Errorf("move installed bundle: %w", err)
+	}
+
+	installedAt := time.Now().UTC().Truncate(time.Second)
+	installMetadata := InstallMetadata{
+		Name:           release.Name,
+		ReleaseVersion: release.ReleaseVersion,
+		ReleaseTag:     release.ReleaseTag,
+		ArtifactURL:    artifactURL,
+		Checksum:       actualChecksum,
+		InstalledAt:    installedAt,
+	}
+	if err := writeJSON(filepath.Join(versionDir, ".install.json"), installMetadata); err != nil {
+		return nil, err
+	}
+
+	if activate {
+		if err := s.Activate(release.Name, release.ReleaseVersion); err != nil {
+			return nil, err
+		}
+	}
+
+	return &InstalledVersion{
+		Name:        release.Name,
+		Version:     release.ReleaseVersion,
+		Active:      activate,
+		InstalledAt: installedAt,
+		Path:        versionDir,
+	}, nil
+}
+
+func (s *Store) List(name string) ([]InstalledVersion, error) {
+	if strings.TrimSpace(name) != "" {
+		return s.listOne(name)
+	}
+
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read skill root: %w", err)
+	}
+	var installed []InstalledVersion
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		items, err := s.listOne(entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		installed = append(installed, items...)
+	}
+	sort.Slice(installed, func(i, j int) bool {
+		if installed[i].Name == installed[j].Name {
+			return installed[i].Version < installed[j].Version
+		}
+		return installed[i].Name < installed[j].Name
+	})
+	return installed, nil
+}
+
+func (s *Store) GetInstalledVersion(name, version string) (*InstalledVersion, error) {
+	path := s.versionDir(name, version)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", path)
+	}
+
+	activeVersion, _ := s.ActiveVersion(name)
+	metadata, err := s.readInstallMetadata(path)
+	if err != nil {
+		return nil, err
+	}
+	return &InstalledVersion{
+		Name:        name,
+		Version:     version,
+		Active:      activeVersion == version,
+		InstalledAt: metadata.InstalledAt,
+		Path:        path,
+	}, nil
+}
+
+func (s *Store) ActiveVersion(name string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(s.skillDir(name), "active_version"))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func (s *Store) Activate(name, version string) error {
+	if _, err := s.GetInstalledVersion(name, version); err != nil {
+		return fmt.Errorf("activate skill: %w", err)
+	}
+	if err := os.MkdirAll(s.skillDir(name), 0o755); err != nil {
+		return fmt.Errorf("create skill dir: %w", err)
+	}
+	return os.WriteFile(filepath.Join(s.skillDir(name), "active_version"), []byte(version+"\n"), 0o644)
+}
+
+func (s *Store) Sync(name, version, targetDir string, force bool) error {
+	if strings.TrimSpace(targetDir) == "" {
+		return fmt.Errorf("target directory is required")
+	}
+	resolvedVersion := strings.TrimSpace(version)
+	if resolvedVersion == "" {
+		active, err := s.ActiveVersion(name)
+		if err != nil {
+			return fmt.Errorf("resolve active version: %w", err)
+		}
+		resolvedVersion = active
+	}
+
+	sourceDir := s.versionDir(name, resolvedVersion)
+	if _, err := os.Stat(sourceDir); err != nil {
+		return fmt.Errorf("stat source skill version: %w", err)
+	}
+
+	if !force {
+		if entries, err := os.ReadDir(targetDir); err == nil && len(entries) > 0 {
+			return fmt.Errorf("target directory %s is not empty; use --force to replace it", targetDir)
+		}
+	}
+	if err := os.RemoveAll(targetDir); err != nil {
+		return fmt.Errorf("remove target dir: %w", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("create target dir: %w", err)
+	}
+
+	if err := copyDir(filepath.Join(sourceDir, "skill"), targetDir); err != nil {
+		return fmt.Errorf("copy skill tree: %w", err)
+	}
+	if err := copyDir(filepath.Join(sourceDir, "bundled-docs"), filepath.Join(targetDir, "bundled-docs")); err != nil {
+		return fmt.Errorf("copy bundled docs: %w", err)
+	}
+	for _, fileName := range []string{"manifest.json", "SHA256SUMS", ".install.json"} {
+		sourcePath := filepath.Join(sourceDir, fileName)
+		if _, err := os.Stat(sourcePath); err == nil {
+			if err := copyFile(sourcePath, filepath.Join(targetDir, fileName), 0o644); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Store) skillDir(name string) string {
+	return filepath.Join(s.root, name)
+}
+
+func (s *Store) versionDir(name, version string) string {
+	return filepath.Join(s.root, name, "versions", version)
+}
+
+func (s *Store) listOne(name string) ([]InstalledVersion, error) {
+	versionRoot := filepath.Join(s.skillDir(name), "versions")
+	entries, err := os.ReadDir(versionRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read versions for %s: %w", name, err)
+	}
+	activeVersion, _ := s.ActiveVersion(name)
+	var installed []InstalledVersion
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		metadata, err := s.readInstallMetadata(filepath.Join(versionRoot, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		installed = append(installed, InstalledVersion{
+			Name:        name,
+			Version:     entry.Name(),
+			Active:      activeVersion == entry.Name(),
+			InstalledAt: metadata.InstalledAt,
+			Path:        filepath.Join(versionRoot, entry.Name()),
+		})
+	}
+	sort.Slice(installed, func(i, j int) bool {
+		return installed[i].Version < installed[j].Version
+	})
+	return installed, nil
+}
+
+func (s *Store) readInstallMetadata(versionDir string) (*InstallMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(versionDir, ".install.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read install metadata: %w", err)
+	}
+	var metadata InstallMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("decode install metadata: %w", err)
+	}
+	return &metadata, nil
+}
+
+func writeJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func singleRootDir(root string) (string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", fmt.Errorf("read extract root: %w", err)
+	}
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			dirs = append(dirs, filepath.Join(root, entry.Name()))
+		}
+	}
+	if len(dirs) != 1 {
+		return "", fmt.Errorf("expected a single extracted root directory, got %d", len(dirs))
+	}
+	return dirs[0], nil
+}
+
+func extractTarGz(archivePath, dest string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer file.Close()
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("read archive entry: %w", err)
+		}
+		target := filepath.Join(dest, filepath.Clean(header.Name))
+		if !strings.HasPrefix(target, filepath.Clean(dest)+string(os.PathSeparator)) && filepath.Clean(target) != filepath.Clean(dest) {
+			return fmt.Errorf("archive entry escapes destination: %s", header.Name)
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", filepath.Dir(target), err)
+			}
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fs.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("create %s: %w", target, err)
+			}
+			if _, err := io.Copy(file, tarReader); err != nil {
+				file.Close()
+				return fmt.Errorf("write %s: %w", target, err)
+			}
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("close %s: %w", target, err)
+			}
+		}
+	}
+}
+
+func copyDir(src, dest string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return copyFile(path, target, info.Mode().Perm())
+	})
+}
+
+func copyFile(src, dest string, perm fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dest), err)
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dest, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return fmt.Errorf("copy %s: %w", dest, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", dest, err)
+	}
+	return nil
+}

--- a/internal/skills/store_test.go
+++ b/internal/skills/store_test.go
@@ -1,0 +1,168 @@
+package skills
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreInstallActivateAndSync(t *testing.T) {
+	archiveBytes := buildArchive(t)
+	sum := sha256.Sum256(archiveBytes)
+	checksum := hex.EncodeToString(sum[:])
+
+	var baseURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/agent-skills/sandbox0":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"name":           "sandbox0",
+					"releaseVersion": "0.1.0",
+					"releaseTag":     "v0.1.0",
+					"artifactPrefix": "sandbox0-agent-skill",
+					"sourcePriority": []string{"source-code"},
+					"downloadUrl":    baseURL + "/release/download",
+					"checksumUrl":    baseURL + "/release/checksum",
+					"manifestUrl":    baseURL + "/release/manifest",
+				},
+			})
+		case "/api/v1/agent-skills/sandbox0/download", "/release/download":
+			_, _ = w.Write(archiveBytes)
+		case "/api/v1/agent-skills/sandbox0/checksum", "/release/checksum":
+			_, _ = w.Write([]byte(checksum + "  sandbox0-agent-skill-0.1.0.tar.gz\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	root := t.TempDir()
+	store := NewStore(root)
+	client := NewAPIClient(server.URL, "token", "s0/test")
+
+	installed, err := store.Install(context.Background(), client, "sandbox0", false, true)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	if !installed.Active {
+		t.Fatalf("expected active install")
+	}
+
+	active, err := store.ActiveVersion("sandbox0")
+	if err != nil {
+		t.Fatalf("active version: %v", err)
+	}
+	if active != "0.1.0" {
+		t.Fatalf("unexpected active version %q", active)
+	}
+
+	list, err := store.List("sandbox0")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(list) != 1 || list[0].Version != "0.1.0" {
+		t.Fatalf("unexpected list %+v", list)
+	}
+
+	target := filepath.Join(t.TempDir(), "codex-skill")
+	if err := store.Sync("sandbox0", "", target, true); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "SKILL.md")); err != nil {
+		t.Fatalf("synced SKILL.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "bundled-docs", "manifest.json")); err != nil {
+		t.Fatalf("synced bundled docs missing: %v", err)
+	}
+}
+
+func buildArchive(t *testing.T) []byte {
+	t.Helper()
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "sandbox0-agent-skill-0.1.0")
+	if err := os.MkdirAll(filepath.Join(root, "skill", "references"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "bundled-docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "skill", "SKILL.md"), []byte("skill\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bundled-docs", "manifest.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write docs manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "manifest.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "SHA256SUMS"), []byte("abc  manifest.json\n"), 0o644); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+
+	archivePath := filepath.Join(tmpDir, "bundle.tar.gz")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(tmpDir, path)
+		if err != nil {
+			return err
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(rel)
+		if info.IsDir() && header.Name[len(header.Name)-1] != '/' {
+			header.Name += "/"
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		input, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer input.Close()
+		_, err = io.Copy(tarWriter, input)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("walk archive: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close file: %v", err)
+	}
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	return data
+}


### PR DESCRIPTION
## Summary
- add a local versioned skill store under `~/.s0/skills`
- add `s0 skill get/install/list/activate/sync` commands with checksum verification and sync support
- extend CLI output and README coverage for skill management

Refs sandbox0-ai/sandbox0#8

## Testing
- `cd s0 && go test ./internal/skills ./internal/commands`
- `cd sdk-go && go test ./...`