### PR TITLE
Add direct/global gateway routing to s0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,22 @@ current-profile: default
 profiles:
   default:
     api-url: https://api.sandbox0.ai
+    gateway-mode: direct
     token: ${SANDBOX0_TOKEN}
 output:
   format: table
 ```
+
+`gateway-mode` supports:
+
+- `direct`: `api-url` is the working control-plane entrypoint.
+- `global`: `api-url` is a Global Gateway entrypoint and workload commands are routed through the active team's home region.
+
+Mode resolution order:
+
+1. Explicit `gateway-mode` in the profile
+2. `GET /metadata` returned by the API entrypoint
+3. Fallback to `direct`
 
 ## Environment Variables
 
@@ -123,7 +135,15 @@ Flags:
   --token string     Override API token
 ```
 
+In `global` mode, `auth`, `user`, and `team` commands stay on the configured entrypoint. Workload-facing commands such as `sandbox`, `template`, `volume`, `credential`, `apikey`, and registry credential flows resolve the active team and switch to the home-region gateway automatically.
+
 ## Commands
+
+### Team
+
+```bash
+s0 team create --name <name> [--slug <slug>] [--home-region <region-id>]
+```
 
 ### Sandbox
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.1.9
+	github.com/sandbox0-ai/sdk-go v0.1.10
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.1.8
+	github.com/sandbox0-ai/sdk-go v0.1.9
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.1.8 h1:6v5avhh/IcmTsza6NB2EHI4A3a11DSPnpETTMjmyevs=
-github.com/sandbox0-ai/sdk-go v0.1.8/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.1.9 h1:Wljv4uriZVuxAUlzy5XePz4ArWNeO5uYM78Ob1bnKBw=
+github.com/sandbox0-ai/sdk-go v0.1.9/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.1.9 h1:Wljv4uriZVuxAUlzy5XePz4ArWNeO5uYM78Ob1bnKBw=
-github.com/sandbox0-ai/sdk-go v0.1.9/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.1.10 h1:ltRpvCGwCkrkzrO6Y23EbOyljJ3MC9JIxFMw8OG9UB4=
+github.com/sandbox0-ai/sdk-go v0.1.10/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/s0/internal/config"
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+type RouteScope string
+
+const (
+	RouteScopeEntrypoint RouteScope = "entrypoint"
+	RouteScopeHomeRegion RouteScope = "home-region"
+)
+
+type ResolvedTarget struct {
+	BaseURL     string
+	Token       string
+	GatewayMode config.GatewayMode
+}
+
+type ResolveTargetOptions struct {
+	BaseURL               string
+	Token                 string
+	ConfiguredGatewayMode config.GatewayMode
+	Scope                 RouteScope
+	UserAgent             string
+}
+
+type gatewayMetadataEnvelope struct {
+	Success bool `json:"success"`
+	Data    struct {
+		GatewayMode string `json:"gateway_mode"`
+		Service     string `json:"service"`
+	} `json:"data"`
+}
+
+// ResolveTarget resolves the correct API target for the current command scope.
+func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTarget, error) {
+	mode := opts.ConfiguredGatewayMode
+	if mode == "" {
+		if detected, ok := discoverGatewayMode(ctx, opts.BaseURL, opts.UserAgent); ok {
+			mode = detected
+		} else {
+			mode = config.GatewayModeDirect
+		}
+	}
+
+	target := &ResolvedTarget{
+		BaseURL:     opts.BaseURL,
+		Token:       opts.Token,
+		GatewayMode: mode,
+	}
+	if opts.Scope != RouteScopeHomeRegion || mode != config.GatewayModeGlobal {
+		return target, nil
+	}
+
+	globalClient, err := newSDKClient(opts.BaseURL, opts.Token, opts.UserAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	activeTeamRes, err := globalClient.API().TenantActiveGet(ctx, apispec.TenantActiveGetParams{})
+	if err != nil {
+		return nil, fmt.Errorf("resolve active team: %w", err)
+	}
+
+	activeTeamSuccess, ok := activeTeamRes.(*apispec.SuccessActiveTeamResponse)
+	if !ok {
+		return nil, fmt.Errorf("resolve active team: unexpected response type %T", activeTeamRes)
+	}
+
+	activeTeam, ok := activeTeamSuccess.Data.Get()
+	if !ok {
+		return nil, fmt.Errorf("resolve active team: missing response data")
+	}
+
+	regionTokenRes, err := globalClient.API().AuthRegionTokenPost(ctx, apispec.NewOptIssueRegionTokenRequest(apispec.IssueRegionTokenRequest{
+		TeamID: apispec.NewOptString(activeTeam.TeamID),
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("issue region token: %w", err)
+	}
+
+	regionTokenSuccess, ok := regionTokenRes.(*apispec.SuccessIssueRegionTokenResponse)
+	if !ok {
+		return nil, fmt.Errorf("issue region token: unexpected response type %T", regionTokenRes)
+	}
+
+	regionToken, ok := regionTokenSuccess.Data.Get()
+	if !ok {
+		return nil, fmt.Errorf("issue region token: missing response data")
+	}
+
+	regionalGatewayURL, ok := regionToken.RegionalGatewayURL.Get()
+	if !ok || strings.TrimSpace(regionalGatewayURL) == "" {
+		return nil, fmt.Errorf("issue region token: missing regional gateway URL")
+	}
+
+	return &ResolvedTarget{
+		BaseURL:     regionalGatewayURL,
+		Token:       regionToken.Token,
+		GatewayMode: mode,
+	}, nil
+}
+
+func discoverGatewayMode(ctx context.Context, baseURL, userAgent string) (config.GatewayMode, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/metadata", nil)
+	if err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(userAgent) != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", false
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false
+	}
+
+	var envelope gatewayMetadataEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", false
+	}
+	if !envelope.Success {
+		return "", false
+	}
+
+	return config.ParseGatewayMode(envelope.Data.GatewayMode)
+}
+
+func newSDKClient(baseURL, token, userAgent string) (*sandbox0.Client, error) {
+	opts := []sandbox0.Option{
+		sandbox0.WithBaseURL(baseURL),
+		sandbox0.WithToken(token),
+	}
+	if strings.TrimSpace(userAgent) != "" {
+		opts = append(opts, sandbox0.WithUserAgent(userAgent))
+	}
+	return sandbox0.NewClient(opts...)
+}

--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -2,12 +2,8 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
-	"time"
 
 	"github.com/sandbox0-ai/s0/internal/config"
 	sandbox0 "github.com/sandbox0-ai/sdk-go"
@@ -33,14 +29,6 @@ type ResolveTargetOptions struct {
 	ConfiguredGatewayMode config.GatewayMode
 	Scope                 RouteScope
 	UserAgent             string
-}
-
-type gatewayMetadataEnvelope struct {
-	Success bool `json:"success"`
-	Data    struct {
-		GatewayMode string `json:"gateway_mode"`
-		Service     string `json:"service"`
-	} `json:"data"`
 }
 
 // ResolveTarget resolves the correct API target for the current command scope.
@@ -113,40 +101,22 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 }
 
 func discoverGatewayMode(ctx context.Context, baseURL, userAgent string) (config.GatewayMode, bool) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/metadata", nil)
-	if err != nil {
-		return "", false
-	}
-	if strings.TrimSpace(userAgent) != "" {
-		req.Header.Set("User-Agent", userAgent)
-	}
-
-	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
-	if err != nil {
-		return "", false
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", false
-	}
-
-	body, err := io.ReadAll(resp.Body)
+	client, err := newSDKClient(baseURL, "", userAgent)
 	if err != nil {
 		return "", false
 	}
 
-	var envelope gatewayMetadataEnvelope
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return "", false
-	}
-	if !envelope.Success {
+	metadataRes, err := client.API().MetadataGet(ctx)
+	if err != nil {
 		return "", false
 	}
 
-	return config.ParseGatewayMode(envelope.Data.GatewayMode)
+	metadata, ok := metadataRes.Data.Get()
+	if !ok {
+		return "", false
+	}
+
+	return config.ParseGatewayMode(string(metadata.GatewayMode))
 }
 
 func newSDKClient(baseURL, token, userAgent string) (*sandbox0.Client, error) {

--- a/internal/client/routing_test.go
+++ b/internal/client/routing_test.go
@@ -1,0 +1,216 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sandbox0-ai/s0/internal/config"
+)
+
+func TestResolveTargetDefaultsToDirectWhenMetadataIsMissing(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:   server.URL,
+		Token:     "token-1",
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+
+	if target.BaseURL != server.URL {
+		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, server.URL)
+	}
+	if target.Token != "token-1" {
+		t.Fatalf("Token = %q, want token-1", target.Token)
+	}
+	if target.GatewayMode != config.GatewayModeDirect {
+		t.Fatalf("GatewayMode = %q, want %q", target.GatewayMode, config.GatewayModeDirect)
+	}
+}
+
+func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
+	var tenantActiveCalls int
+	var regionTokenCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metadata":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"gateway_mode": "global",
+					"service":      "global-gateway",
+				},
+			})
+		case "/tenant/active":
+			tenantActiveCalls++
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"user_id":              "user-1",
+					"team_id":              "team-1",
+					"team_role":            "admin",
+					"home_region_id":       "aws/us-east-1",
+					"default_team":         true,
+					"regional_gateway_url": "https://regional.example.com",
+				},
+			})
+		case "/auth/region-token":
+			regionTokenCalls++
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"region_id":            "aws/us-east-1",
+					"regional_gateway_url": "https://regional.example.com",
+					"token":                "region-token",
+					"expires_at":           int64(1893456000),
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:   server.URL,
+		Token:     "global-token",
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+
+	if target.BaseURL != "https://regional.example.com" {
+		t.Fatalf("BaseURL = %q, want regional gateway URL", target.BaseURL)
+	}
+	if target.Token != "region-token" {
+		t.Fatalf("Token = %q, want region-token", target.Token)
+	}
+	if tenantActiveCalls != 1 {
+		t.Fatalf("tenant/active calls = %d, want 1", tenantActiveCalls)
+	}
+	if regionTokenCalls != 1 {
+		t.Fatalf("auth/region-token calls = %d, want 1", regionTokenCalls)
+	}
+}
+
+func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
+	var tenantActiveCalls int
+	var regionTokenCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metadata":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"gateway_mode": "global",
+					"service":      "global-gateway",
+				},
+			})
+		case "/tenant/active":
+			tenantActiveCalls++
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		case "/auth/region-token":
+			regionTokenCalls++
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:   server.URL,
+		Token:     "global-token",
+		Scope:     RouteScopeEntrypoint,
+		UserAgent: "s0/test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+
+	if target.BaseURL != server.URL {
+		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, server.URL)
+	}
+	if target.Token != "global-token" {
+		t.Fatalf("Token = %q, want global-token", target.Token)
+	}
+	if tenantActiveCalls != 0 {
+		t.Fatalf("tenant/active calls = %d, want 0", tenantActiveCalls)
+	}
+	if regionTokenCalls != 0 {
+		t.Fatalf("auth/region-token calls = %d, want 0", regionTokenCalls)
+	}
+}
+
+func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metadata":
+			http.NotFound(w, r)
+		case "/tenant/active":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"user_id":              "user-1",
+					"team_id":              "team-1",
+					"team_role":            "admin",
+					"home_region_id":       "aws/us-east-1",
+					"default_team":         true,
+					"regional_gateway_url": "https://regional.example.com",
+				},
+			})
+		case "/auth/region-token":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"region_id":            "aws/us-east-1",
+					"regional_gateway_url": "https://regional.example.com",
+					"token":                "region-token",
+					"expires_at":           int64(1893456000),
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:               server.URL,
+		Token:                 "global-token",
+		ConfiguredGatewayMode: config.GatewayModeGlobal,
+		Scope:                 RouteScopeHomeRegion,
+		UserAgent:             "s0/test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+
+	if target.BaseURL != "https://regional.example.com" {
+		t.Fatalf("BaseURL = %q, want regional gateway URL", target.BaseURL)
+	}
+	if target.Token != "region-token" {
+		t.Fatalf("Token = %q, want region-token", target.Token)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, payload any) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}

--- a/internal/commands/apikey.go
+++ b/internal/commands/apikey.go
@@ -30,7 +30,7 @@ var apiKeyListCmd = &cobra.Command{
 	Short: "List API keys",
 	Long:  `List API keys in current scope.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -81,7 +81,7 @@ var apiKeyCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -138,7 +138,7 @@ var apiKeyDeactivateCmd = &cobra.Command{
 	Long:  `Deactivate an API key by ID.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -174,7 +174,7 @@ var apiKeyDeleteCmd = &cobra.Command{
 	Long:  `Delete an API key by ID.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/credential_source.go
+++ b/internal/commands/credential_source.go
@@ -22,7 +22,7 @@ var credentialSourceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List credential sources",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -46,7 +46,7 @@ var credentialSourceGetCmd = &cobra.Command{
 	Short: "Get credential source details",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -80,7 +80,7 @@ var credentialSourceCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -116,7 +116,7 @@ var credentialSourceUpdateCmd = &cobra.Command{
 		}
 		req.Name = args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -140,7 +140,7 @@ var credentialSourceDeleteCmd = &cobra.Command{
 	Short: "Delete a credential source",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/image.go
+++ b/internal/commands/image.go
@@ -85,7 +85,7 @@ var imagePushCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClient()
+		client, err := getClient(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -141,7 +141,7 @@ var imageCredentialsCmd = &cobra.Command{
 	Short: "Show temporary registry credentials",
 	Long:  `Show temporary registry credentials used by s0 template image push.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClient()
+		client, err := getClient(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -65,23 +65,16 @@ func getConfig() (*config.Config, error) {
 }
 
 // getClient creates a new wrapped SDK client from the configuration.
-func getClient() (*client.Client, error) {
-	p, err := getProfileWithFreshToken()
+func getClient(cmd *cobra.Command) (*client.Client, error) {
+	resolved, userAgent, err := resolveClientTarget(cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	token := p.GetToken()
-	if token == "" {
-		return nil, ErrNoToken
-	}
-
 	opts := []sandbox0.Option{
-		sandbox0.WithBaseURL(p.GetAPIURL()),
-		sandbox0.WithToken(token),
+		sandbox0.WithBaseURL(resolved.BaseURL),
+		sandbox0.WithToken(resolved.Token),
 	}
-
-	userAgent := fmt.Sprintf("s0/%s", cfgVersion)
 	if userAgent != "" {
 		opts = append(opts, sandbox0.WithUserAgent(userAgent))
 	}
@@ -90,28 +83,73 @@ func getClient() (*client.Client, error) {
 }
 
 // getClientRaw creates a raw SDK client for operations that don't need the wrapper.
-func getClientRaw() (*sandbox0.Client, error) {
-	p, err := getProfileWithFreshToken()
+func getClientRaw(cmd *cobra.Command) (*sandbox0.Client, error) {
+	resolved, userAgent, err := resolveClientTarget(cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	token := p.GetToken()
-	if token == "" {
-		return nil, ErrNoToken
-	}
-
 	opts := []sandbox0.Option{
-		sandbox0.WithBaseURL(p.GetAPIURL()),
-		sandbox0.WithToken(token),
+		sandbox0.WithBaseURL(resolved.BaseURL),
+		sandbox0.WithToken(resolved.Token),
 	}
-
-	userAgent := fmt.Sprintf("s0/%s", cfgVersion)
 	if userAgent != "" {
 		opts = append(opts, sandbox0.WithUserAgent(userAgent))
 	}
 
 	return sandbox0.NewClient(opts...)
+}
+
+func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, error) {
+	p, err := getProfileWithFreshToken()
+	if err != nil {
+		return nil, "", err
+	}
+
+	token := p.GetToken()
+	if token == "" {
+		return nil, "", ErrNoToken
+	}
+
+	var configuredMode config.GatewayMode
+	if mode, ok := p.GetConfiguredGatewayMode(); ok {
+		configuredMode = mode
+	}
+
+	resolved, err := client.ResolveTarget(
+		cmd.Context(),
+		client.ResolveTargetOptions{
+			BaseURL:               p.GetAPIURL(),
+			Token:                 token,
+			ConfiguredGatewayMode: configuredMode,
+			Scope:                 commandRouteScope(cmd),
+			UserAgent:             buildUserAgent(),
+		},
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return resolved, buildUserAgent(), nil
+}
+
+func buildUserAgent() string {
+	if cfgVersion == "" {
+		return ""
+	}
+	return fmt.Sprintf("s0/%s", cfgVersion)
+}
+
+func commandRouteScope(cmd *cobra.Command) client.RouteScope {
+	for current := cmd; current != nil; current = current.Parent() {
+		switch current.Name() {
+		case "sandbox", "template", "volume", "credential", "apikey", "image":
+			return client.RouteScopeHomeRegion
+		case "auth", "team", "user":
+			return client.RouteScopeEntrypoint
+		}
+	}
+	return client.RouteScopeEntrypoint
 }
 
 // parseInt32 parses a string to int32 with error handling.

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -47,7 +47,7 @@ var sandboxCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -86,7 +86,7 @@ var sandboxGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -114,7 +114,7 @@ var sandboxDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -139,7 +139,7 @@ var sandboxPauseCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -164,7 +164,7 @@ var sandboxResumeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -189,7 +189,7 @@ var sandboxRefreshCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -217,7 +217,7 @@ var sandboxStatusCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -245,7 +245,7 @@ var sandboxUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		sandboxID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -285,7 +285,7 @@ var sandboxListCmd = &cobra.Command{
 	Short: "List sandboxes",
 	Long:  `List all sandboxes for the authenticated team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_context.go
+++ b/internal/commands/sandbox_context.go
@@ -32,7 +32,7 @@ var sandboxContextListCmd = &cobra.Command{
 	Short: "List contexts",
 	Long:  `List all contexts in the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -60,7 +60,7 @@ var sandboxContextGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		contextID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -90,7 +90,7 @@ var sandboxContextCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -160,7 +160,7 @@ var sandboxContextDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		contextID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -185,7 +185,7 @@ var sandboxContextRestartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		contextID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -214,7 +214,7 @@ var sandboxContextSignalCmd = &cobra.Command{
 		contextID := args[0]
 		signal := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -240,7 +240,7 @@ var sandboxContextExecCmd = &cobra.Command{
 		contextID := args[0]
 		input := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -265,7 +265,7 @@ var sandboxContextStatsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		contextID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_exec.go
+++ b/internal/commands/sandbox_exec.go
@@ -65,7 +65,7 @@ Examples:
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_files.go
+++ b/internal/commands/sandbox_files.go
@@ -37,7 +37,7 @@ var sandboxFilesLsCmd = &cobra.Command{
 			path = args[0]
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -65,7 +65,7 @@ var sandboxFilesCatCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		path := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -93,7 +93,7 @@ var sandboxFilesStatCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		path := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -121,7 +121,7 @@ var sandboxFilesMkdirCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		path := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -146,7 +146,7 @@ var sandboxFilesRmCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		path := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -172,7 +172,7 @@ var sandboxFilesMvCmd = &cobra.Command{
 		source := args[0]
 		destination := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -198,7 +198,7 @@ var sandboxFilesUploadCmd = &cobra.Command{
 		localPath := args[0]
 		remotePath := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -230,7 +230,7 @@ var sandboxFilesDownloadCmd = &cobra.Command{
 		remotePath := args[0]
 		localPath := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -281,7 +281,7 @@ var sandboxFilesWriteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -306,7 +306,7 @@ var sandboxFilesWatchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		path := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_network.go
+++ b/internal/commands/sandbox_network.go
@@ -54,7 +54,7 @@ var sandboxNetworkGetCmd = &cobra.Command{
 	Short: "Get network policy",
 	Long:  `Get the network policy configuration for the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -79,7 +79,7 @@ var sandboxNetworkUpdateCmd = &cobra.Command{
 	Short: "Update network policy",
 	Long:  `Update the network policy configuration for the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_ports.go
+++ b/internal/commands/sandbox_ports.go
@@ -25,7 +25,7 @@ var sandboxPortsListCmd = &cobra.Command{
 	Short: "List exposed ports",
 	Long:  `List all exposed ports for the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -53,7 +53,7 @@ var sandboxPortsExposeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		port := parseInt32(args[0], "port")
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -81,7 +81,7 @@ var sandboxPortsUnexposeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		port := parseInt32(args[0], "port")
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -106,7 +106,7 @@ var sandboxPortsClearCmd = &cobra.Command{
 	Short: "Clear all exposed ports",
 	Long:  `Remove all exposed ports from the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_run.go
+++ b/internal/commands/sandbox_run.go
@@ -40,7 +40,7 @@ Examples:
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/sandbox_volume.go
+++ b/internal/commands/sandbox_volume.go
@@ -37,7 +37,7 @@ var sandboxVolumeMountCmd = &cobra.Command{
 	Short: "Mount a volume",
 	Long:  `Mount a volume to the sandbox at the specified path.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -85,7 +85,7 @@ var sandboxVolumeUnmountCmd = &cobra.Command{
 	Short: "Unmount a volume",
 	Long:  `Unmount a volume from the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -107,7 +107,7 @@ var sandboxVolumeMountStatusCmd = &cobra.Command{
 	Short: "Show mount status",
 	Long:  `Show volume mount status for the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	teamName string
-	teamSlug string
+	teamName       string
+	teamSlug       string
+	teamHomeRegion string
 
 	teamMemberTeamID string
 	teamMemberEmail  string
@@ -29,7 +30,7 @@ var teamListCmd = &cobra.Command{
 	Short: "List teams",
 	Long:  `List teams available to the current user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -66,7 +67,7 @@ var teamGetCmd = &cobra.Command{
 	Long:  `Get details of a team by team ID.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -109,18 +110,13 @@ var teamCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
 		}
 
-		req := &apispec.CreateTeamRequest{
-			Name: teamName,
-		}
-		if strings.TrimSpace(teamSlug) != "" {
-			req.Slug = apispec.NewOptString(teamSlug)
-		}
+		req := buildCreateTeamRequest(teamName, teamSlug, teamHomeRegion)
 
 		res, err := client.API().TeamsPost(cmd.Context(), req)
 		if err != nil {
@@ -171,7 +167,7 @@ var teamUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -210,7 +206,7 @@ var teamDeleteCmd = &cobra.Command{
 	Long:  `Delete a team by ID.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -251,7 +247,7 @@ var teamMemberListCmd = &cobra.Command{
 	Short: "List team members",
 	Long:  `List all members of a team.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -300,7 +296,7 @@ var teamMemberAddCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -352,7 +348,7 @@ var teamMemberUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -397,7 +393,7 @@ var teamMemberRemoveCmd = &cobra.Command{
 	Long:  `Remove a member from a team.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -457,6 +453,19 @@ func parseUpdateTeamMemberRole(s string) (apispec.UpdateTeamMemberRequestRole, e
 	}
 }
 
+func buildCreateTeamRequest(name, slug, homeRegion string) *apispec.CreateTeamRequest {
+	req := &apispec.CreateTeamRequest{
+		Name: name,
+	}
+	if trimmedSlug := strings.TrimSpace(slug); trimmedSlug != "" {
+		req.Slug = apispec.NewOptString(trimmedSlug)
+	}
+	if trimmedHomeRegion := strings.TrimSpace(homeRegion); trimmedHomeRegion != "" {
+		req.HomeRegionID = apispec.NewOptNilString(trimmedHomeRegion)
+	}
+	return req
+}
+
 func init() {
 	rootCmd.AddCommand(teamCmd)
 
@@ -476,6 +485,7 @@ func init() {
 
 	teamCreateCmd.Flags().StringVar(&teamName, "name", "", "team name (required)")
 	teamCreateCmd.Flags().StringVar(&teamSlug, "slug", "", "team slug")
+	teamCreateCmd.Flags().StringVar(&teamHomeRegion, "home-region", "", "team home region ID")
 
 	teamUpdateCmd.Flags().StringVar(&teamName, "name", "", "new team name")
 	teamUpdateCmd.Flags().StringVar(&teamSlug, "slug", "", "new team slug")

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -1,0 +1,32 @@
+package commands
+
+import "testing"
+
+func TestBuildCreateTeamRequest(t *testing.T) {
+	req := buildCreateTeamRequest("Team One", " team-one ", " aws/us-east-1 ")
+
+	if req.Name != "Team One" {
+		t.Fatalf("Name = %q, want Team One", req.Name)
+	}
+
+	slug, ok := req.Slug.Get()
+	if !ok || slug != "team-one" {
+		t.Fatalf("Slug = %q, want team-one", slug)
+	}
+
+	homeRegion, ok := req.HomeRegionID.Get()
+	if !ok || homeRegion != "aws/us-east-1" {
+		t.Fatalf("HomeRegionID = %q, want aws/us-east-1", homeRegion)
+	}
+}
+
+func TestBuildCreateTeamRequestOmitsOptionalFieldsWhenBlank(t *testing.T) {
+	req := buildCreateTeamRequest("Team One", "   ", "   ")
+
+	if _, ok := req.Slug.Get(); ok {
+		t.Fatal("Slug should be unset")
+	}
+	if _, ok := req.HomeRegionID.Get(); ok {
+		t.Fatal("HomeRegionID should be unset")
+	}
+}

--- a/internal/commands/template.go
+++ b/internal/commands/template.go
@@ -27,7 +27,7 @@ var templateListCmd = &cobra.Command{
 	Short: "List templates",
 	Long:  `List all available sandbox templates.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -55,7 +55,7 @@ var templateGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		templateID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -102,7 +102,7 @@ var templateCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -153,7 +153,7 @@ var templateUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -185,7 +185,7 @@ var templateDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		templateID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -27,7 +27,7 @@ var userGetCmd = &cobra.Command{
 	Short: "Get current user profile",
 	Long:  `Get profile information for the authenticated user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -90,7 +90,7 @@ var userUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/volume.go
+++ b/internal/commands/volume.go
@@ -33,7 +33,7 @@ var volumeListCmd = &cobra.Command{
 	Short: "List volumes",
 	Long:  `List all sandbox volumes.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -61,7 +61,7 @@ var volumeGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		volumeID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -86,7 +86,7 @@ var volumeCreateCmd = &cobra.Command{
 	Short: "Create a volume",
 	Long:  `Create a new sandbox volume.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -142,7 +142,7 @@ var volumeDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		volumeID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -171,7 +171,7 @@ var volumeForkCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		volumeID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/volume_snapshot.go
+++ b/internal/commands/volume_snapshot.go
@@ -29,7 +29,7 @@ var volumeSnapshotListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		volumeID := args[0]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -58,7 +58,7 @@ var volumeSnapshotGetCmd = &cobra.Command{
 		volumeID := args[0]
 		snapshotID := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -91,7 +91,7 @@ var volumeSnapshotCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -127,7 +127,7 @@ var volumeSnapshotDeleteCmd = &cobra.Command{
 		volumeID := args[0]
 		snapshotID := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -153,7 +153,7 @@ var volumeSnapshotRestoreCmd = &cobra.Command{
 		volumeID := args[0]
 		snapshotID := args[1]
 
-		client, err := getClientRaw()
+		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 // Profile represents a named configuration profile.
 type Profile struct {
 	APIURL       string `yaml:"api-url" mapstructure:"api-url"`
+	GatewayMode  string `yaml:"gateway-mode" mapstructure:"gateway-mode"`
 	Token        string `yaml:"token" mapstructure:"token"`
 	RefreshToken string `yaml:"refresh-token" mapstructure:"refresh-token"`
 	ExpiresAt    int64  `yaml:"expires-at" mapstructure:"expires-at"`
@@ -35,6 +36,13 @@ const (
 	DefaultProfile    = "default"
 	DefaultAPIURL     = "https://api.sandbox0.ai"
 	DefaultFormat     = "table"
+)
+
+type GatewayMode string
+
+const (
+	GatewayModeDirect GatewayMode = "direct"
+	GatewayModeGlobal GatewayMode = "global"
 )
 
 // Environment variables (same as sdk-go/sdk-js/sdk-py).
@@ -165,6 +173,11 @@ func (p *Profile) GetAPIURL() string {
 	return DefaultAPIURL
 }
 
+// GetConfiguredGatewayMode returns the explicitly configured gateway mode, if valid.
+func (p *Profile) GetConfiguredGatewayMode() (GatewayMode, bool) {
+	return ParseGatewayMode(p.GatewayMode)
+}
+
 // GetToken returns the token with override and env support.
 // Priority: --token flag > SANDBOX0_TOKEN env > profile config (with env expansion)
 func (p *Profile) GetToken() string {
@@ -183,6 +196,20 @@ func (p *Profile) GetToken() string {
 // GetRefreshToken returns the refresh token from profile config.
 func (p *Profile) GetRefreshToken() string {
 	return expandEnvVars(p.RefreshToken)
+}
+
+// ParseGatewayMode normalizes a gateway mode string.
+func ParseGatewayMode(raw string) (GatewayMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return "", false
+	case string(GatewayModeDirect):
+		return GatewayModeDirect, true
+	case string(GatewayModeGlobal):
+		return GatewayModeGlobal, true
+	default:
+		return "", false
+	}
 }
 
 // SetCredentials updates profile credentials.

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -53,6 +53,12 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatSDKSandbox(w, v)
 	case *client.RegistryCredentials:
 		return f.formatRegistryCredentials(w, v)
+	case []apispec.CredentialSourceMetadata:
+		return f.formatCredentialSourceList(w, v)
+	case apispec.CredentialSourceMetadata:
+		return f.formatCredentialSource(w, &v)
+	case *apispec.CredentialSourceMetadata:
+		return f.formatCredentialSource(w, v)
 	case []apispec.FileInfo:
 		return f.formatFileList(w, v)
 	case *apispec.FileInfo:
@@ -345,6 +351,38 @@ func (f *TableFormatter) formatRegistryCredentials(w io.Writer, c *client.Regist
 	if c.ExpiresAt != "" {
 		_ = t.Append([]string{"Expires At:", c.ExpiresAt})
 	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatCredentialSourceList(w io.Writer, sources []apispec.CredentialSourceMetadata) error {
+	if len(sources) == 0 {
+		_, _ = fmt.Fprintln(w, "No credential sources found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"NAME", "RESOLVER KIND", "VERSION", "STATUS", "CREATED AT", "UPDATED AT"})
+	for _, source := range sources {
+		_ = t.Append([]string{
+			source.Name,
+			string(source.ResolverKind),
+			formatOptInt64(source.CurrentVersion),
+			formatOptString(source.Status),
+			formatOptNilDateTime(source.CreatedAt),
+			formatOptNilDateTime(source.UpdatedAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatCredentialSource(w io.Writer, source *apispec.CredentialSourceMetadata) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Name:", source.Name})
+	_ = t.Append([]string{"Resolver Kind:", string(source.ResolverKind)})
+	_ = t.Append([]string{"Current Version:", formatOptInt64(source.CurrentVersion)})
+	_ = t.Append([]string{"Status:", formatOptString(source.Status)})
+	_ = t.Append([]string{"Created At:", formatOptNilDateTime(source.CreatedAt)})
+	_ = t.Append([]string{"Updated At:", formatOptNilDateTime(source.UpdatedAt)})
 	return t.Render()
 }
 
@@ -786,6 +824,20 @@ func formatStringSlice(values []string) string {
 	return strings.Join(values, ",")
 }
 
+func formatOptString(v apispec.OptString) string {
+	if s, ok := v.Get(); ok && s != "" {
+		return s
+	}
+	return "-"
+}
+
+func formatOptInt64(v apispec.OptInt64) string {
+	if n, ok := v.Get(); ok {
+		return fmt.Sprintf("%d", n)
+	}
+	return "-"
+}
+
 func formatOptNilString(v apispec.OptNilString) string {
 	if v.IsNull() {
 		return "-"
@@ -797,6 +849,16 @@ func formatOptNilString(v apispec.OptNilString) string {
 }
 
 func formatOptDateTime(v apispec.OptDateTime) string {
+	if ts, ok := v.Get(); ok {
+		return formatTimestamp(ts)
+	}
+	return "-"
+}
+
+func formatOptNilDateTime(v apispec.OptNilDateTime) string {
+	if v.IsNull() {
+		return "-"
+	}
 	if ts, ok := v.Get(); ok {
 		return formatTimestamp(ts)
 	}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,91 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func TestTableFormatterFormatCredentialSourceList(t *testing.T) {
+	formatter := &TableFormatter{}
+	now := time.Date(2026, 3, 23, 12, 34, 56, 0, time.UTC)
+	sources := []apispec.CredentialSourceMetadata{
+		{
+			Name:           "gh-token",
+			ResolverKind:   apispec.CredentialSourceResolverKindStaticHeaders,
+			CurrentVersion: apispec.NewOptInt64(3),
+			Status:         apispec.NewOptString("ready"),
+			CreatedAt:      apispec.NewOptNilDateTime(now),
+			UpdatedAt:      apispec.NewOptNilDateTime(now.Add(2 * time.Hour)),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, sources); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"NAME",
+		"RESOLVER KIND",
+		"gh-token",
+		"static_headers",
+		"ready",
+		"2026-03-23 12:34:56",
+		"2026-03-23 14:34:56",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "{3 true}") {
+		t.Fatalf("output still contains raw OptInt64 formatting:\n%s", output)
+	}
+}
+
+func TestTableFormatterFormatCredentialSource(t *testing.T) {
+	formatter := &TableFormatter{}
+	source := &apispec.CredentialSourceMetadata{
+		Name:         "db-auth",
+		ResolverKind: apispec.CredentialSourceResolverKindStaticUsernamePassword,
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, source); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Name:",
+		"db-auth",
+		"Resolver Kind:",
+		"static_username_password",
+		"Current Version:",
+		"Status:",
+		"Created At:",
+		"Updated At:",
+		"-",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatCredentialSourceListEmpty(t *testing.T) {
+	formatter := &TableFormatter{}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, []apispec.CredentialSourceMetadata{}); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(buf.String()); got != "No credential sources found." {
+		t.Fatalf("empty output = %q, want %q", got, "No credential sources found.")
+	}
+}


### PR DESCRIPTION
## Summary
- add `gateway-mode` config with explicit mode, `/metadata` detection, and `direct` fallback
- route workload commands through the regional gateway in global mode while keeping identity commands on the configured entrypoint
- add `--home-region` support for `team create` and cover the routing behavior with tests

Closes #6

## Testing
- go test ./...