### PR TITLE
Use regional auth sessions for global routing

### DIFF
--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sandbox0-ai/s0/internal/config"
 	sandbox0 "github.com/sandbox0-ai/sdk-go"
@@ -27,6 +28,7 @@ type ResolveTargetOptions struct {
 	BaseURL               string
 	Token                 string
 	ConfiguredGatewayMode config.GatewayMode
+	RegionalSession       *config.RegionalSession
 	Scope                 RouteScope
 	UserAgent             string
 }
@@ -49,6 +51,10 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 	}
 	if opts.Scope != RouteScopeHomeRegion || mode != config.GatewayModeGlobal {
 		return target, nil
+	}
+
+	if regionalTarget, ok := resolveStoredRegionalTarget(opts.RegionalSession, mode); ok {
+		return regionalTarget, nil
 	}
 
 	globalClient, err := newSDKClient(opts.BaseURL, opts.Token, opts.UserAgent)
@@ -98,6 +104,23 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 		Token:       regionToken.Token,
 		GatewayMode: mode,
 	}, nil
+}
+
+func resolveStoredRegionalTarget(session *config.RegionalSession, mode config.GatewayMode) (*ResolvedTarget, bool) {
+	if session == nil {
+		return nil, false
+	}
+	if strings.TrimSpace(session.Token) == "" || strings.TrimSpace(session.GatewayURL) == "" {
+		return nil, false
+	}
+	if session.ExpiresAt != 0 && time.Now().Unix() >= session.ExpiresAt-30 {
+		return nil, false
+	}
+	return &ResolvedTarget{
+		BaseURL:     session.GatewayURL,
+		Token:       session.Token,
+		GatewayMode: mode,
+	}, true
 }
 
 func discoverGatewayMode(ctx context.Context, baseURL, userAgent string) (config.GatewayMode, bool) {

--- a/internal/client/routing_test.go
+++ b/internal/client/routing_test.go
@@ -103,6 +103,62 @@ func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
 	}
 }
 
+func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T) {
+	var tenantActiveCalls int
+	var regionTokenCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metadata":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"gateway_mode": "global",
+					"service":      "global-gateway",
+				},
+			})
+		case "/tenant/active":
+			tenantActiveCalls++
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		case "/auth/region-token":
+			regionTokenCalls++
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL: server.URL,
+		Token:   "global-token",
+		RegionalSession: &config.RegionalSession{
+			Token:      "regional-token",
+			GatewayURL: "https://regional.example.com",
+			RegionID:   "aws/us-east-1",
+			ExpiresAt:  1893456000,
+		},
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+
+	if target.BaseURL != "https://regional.example.com" {
+		t.Fatalf("BaseURL = %q, want regional gateway URL", target.BaseURL)
+	}
+	if target.Token != "regional-token" {
+		t.Fatalf("Token = %q, want regional-token", target.Token)
+	}
+	if tenantActiveCalls != 0 {
+		t.Fatalf("tenant/active calls = %d, want 0", tenantActiveCalls)
+	}
+	if regionTokenCalls != 0 {
+		t.Fatalf("auth/region-token calls = %d, want 0", regionTokenCalls)
+	}
+}
+
 func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
 	var tenantActiveCalls int
 	var regionTokenCalls int

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -70,7 +70,14 @@ var authLoginCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cfg.SetCredentials(profileName, baseURL, loginData.AccessToken, loginData.RefreshToken, loginData.ExpiresAt)
+		cfg.SetCredentials(
+			profileName,
+			baseURL,
+			loginData.AccessToken,
+			loginData.RefreshToken,
+			loginData.ExpiresAt,
+			toRegionalSessionConfig(loginData),
+		)
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving credentials: %v\n", err)
 			os.Exit(1)

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -26,9 +26,15 @@ type authProvider struct {
 }
 
 type authLoginData struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresAt    int64  `json:"expires_at"`
+	AccessToken     string `json:"access_token"`
+	RefreshToken    string `json:"refresh_token"`
+	ExpiresAt       int64  `json:"expires_at"`
+	RegionalSession *struct {
+		RegionID           string `json:"region_id"`
+		RegionalGatewayURL string `json:"regional_gateway_url"`
+		Token              string `json:"token"`
+		ExpiresAt          int64  `json:"expires_at"`
+	} `json:"regional_session,omitempty"`
 }
 
 type authEnvelope struct {
@@ -163,7 +169,14 @@ func getProfileWithFreshToken() (*config.Profile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("token expired and refresh failed: %w (run `s0 auth login`)", err)
 	}
-	cfg.SetCredentials(profileName, p.GetAPIURL(), refreshed.AccessToken, refreshed.RefreshToken, refreshed.ExpiresAt)
+	cfg.SetCredentials(
+		profileName,
+		p.GetAPIURL(),
+		refreshed.AccessToken,
+		refreshed.RefreshToken,
+		refreshed.ExpiresAt,
+		toRegionalSessionConfig(refreshed),
+	)
 	if err := cfg.Save(); err != nil {
 		return nil, fmt.Errorf("save refreshed credentials: %w", err)
 	}
@@ -213,6 +226,23 @@ func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID string) (*auth
 			AccessToken:  q.Get("access_token"),
 			RefreshToken: q.Get("refresh_token"),
 			ExpiresAt:    expiresUnix,
+		}
+		regionalExpiresUnix, err := strconv.ParseInt(q.Get("regional_expires_unix"), 10, 64)
+		if err == nil &&
+			q.Get("regional_access_token") != "" &&
+			q.Get("regional_gateway_url") != "" &&
+			q.Get("region_id") != "" {
+			data.RegionalSession = &struct {
+				RegionID           string `json:"region_id"`
+				RegionalGatewayURL string `json:"regional_gateway_url"`
+				Token              string `json:"token"`
+				ExpiresAt          int64  `json:"expires_at"`
+			}{
+				RegionID:           q.Get("region_id"),
+				RegionalGatewayURL: q.Get("regional_gateway_url"),
+				Token:              q.Get("regional_access_token"),
+				ExpiresAt:          regionalExpiresUnix,
+			}
 		}
 		if data.AccessToken == "" || data.RefreshToken == "" {
 			http.Error(w, "missing tokens in callback", http.StatusBadRequest)
@@ -268,6 +298,24 @@ func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID string) (*auth
 	case <-time.After(3 * time.Minute):
 		_ = server.Shutdown(context.Background())
 		return nil, fmt.Errorf("oidc login timed out")
+	}
+}
+
+func toRegionalSessionConfig(data *authLoginData) *config.RegionalSession {
+	if data == nil || data.RegionalSession == nil {
+		return nil
+	}
+	if data.RegionalSession.Token == "" ||
+		data.RegionalSession.RegionalGatewayURL == "" ||
+		data.RegionalSession.RegionID == "" ||
+		data.RegionalSession.ExpiresAt == 0 {
+		return nil
+	}
+	return &config.RegionalSession{
+		Token:      data.RegionalSession.Token,
+		GatewayURL: data.RegionalSession.RegionalGatewayURL,
+		RegionID:   data.RegionalSession.RegionID,
+		ExpiresAt:  data.RegionalSession.ExpiresAt,
 	}
 }
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -122,8 +122,14 @@ func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, er
 			BaseURL:               p.GetAPIURL(),
 			Token:                 token,
 			ConfiguredGatewayMode: configuredMode,
-			Scope:                 commandRouteScope(cmd),
-			UserAgent:             buildUserAgent(),
+			RegionalSession: func() *config.RegionalSession {
+				if session, ok := p.GetRegionalSession(); ok {
+					return session
+				}
+				return nil
+			}(),
+			Scope:     commandRouteScope(cmd),
+			UserAgent: buildUserAgent(),
 		},
 	)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,11 +18,22 @@ type Config struct {
 
 // Profile represents a named configuration profile.
 type Profile struct {
-	APIURL       string `yaml:"api-url" mapstructure:"api-url"`
-	GatewayMode  string `yaml:"gateway-mode" mapstructure:"gateway-mode"`
-	Token        string `yaml:"token" mapstructure:"token"`
-	RefreshToken string `yaml:"refresh-token" mapstructure:"refresh-token"`
-	ExpiresAt    int64  `yaml:"expires-at" mapstructure:"expires-at"`
+	APIURL             string `yaml:"api-url" mapstructure:"api-url"`
+	GatewayMode        string `yaml:"gateway-mode" mapstructure:"gateway-mode"`
+	Token              string `yaml:"token" mapstructure:"token"`
+	RefreshToken       string `yaml:"refresh-token" mapstructure:"refresh-token"`
+	ExpiresAt          int64  `yaml:"expires-at" mapstructure:"expires-at"`
+	RegionalToken      string `yaml:"regional-token" mapstructure:"regional-token"`
+	RegionalGatewayURL string `yaml:"regional-gateway-url" mapstructure:"regional-gateway-url"`
+	RegionalRegionID   string `yaml:"regional-region-id" mapstructure:"regional-region-id"`
+	RegionalExpiresAt  int64  `yaml:"regional-expires-at" mapstructure:"regional-expires-at"`
+}
+
+type RegionalSession struct {
+	Token      string
+	GatewayURL string
+	RegionID   string
+	ExpiresAt  int64
 }
 
 // OutputConfig represents output formatting configuration.
@@ -198,6 +209,22 @@ func (p *Profile) GetRefreshToken() string {
 	return expandEnvVars(p.RefreshToken)
 }
 
+// GetRegionalSession returns the stored regional session when all required fields are present.
+func (p *Profile) GetRegionalSession() (*RegionalSession, bool) {
+	token := expandEnvVars(p.RegionalToken)
+	gatewayURL := expandEnvVars(p.RegionalGatewayURL)
+	regionID := expandEnvVars(p.RegionalRegionID)
+	if token == "" || gatewayURL == "" || regionID == "" || p.RegionalExpiresAt == 0 {
+		return nil, false
+	}
+	return &RegionalSession{
+		Token:      token,
+		GatewayURL: gatewayURL,
+		RegionID:   regionID,
+		ExpiresAt:  p.RegionalExpiresAt,
+	}, true
+}
+
 // ParseGatewayMode normalizes a gateway mode string.
 func ParseGatewayMode(raw string) (GatewayMode, bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
@@ -213,7 +240,14 @@ func ParseGatewayMode(raw string) (GatewayMode, bool) {
 }
 
 // SetCredentials updates profile credentials.
-func (c *Config) SetCredentials(profileName, apiURL, accessToken, refreshToken string, expiresAt int64) {
+func (c *Config) SetCredentials(
+	profileName,
+	apiURL,
+	accessToken,
+	refreshToken string,
+	expiresAt int64,
+	regionalSession *RegionalSession,
+) {
 	if c.Profiles == nil {
 		c.Profiles = make(map[string]Profile)
 	}
@@ -227,6 +261,17 @@ func (c *Config) SetCredentials(profileName, apiURL, accessToken, refreshToken s
 	p.Token = accessToken
 	p.RefreshToken = refreshToken
 	p.ExpiresAt = expiresAt
+	if regionalSession != nil {
+		p.RegionalToken = regionalSession.Token
+		p.RegionalGatewayURL = regionalSession.GatewayURL
+		p.RegionalRegionID = regionalSession.RegionID
+		p.RegionalExpiresAt = regionalSession.ExpiresAt
+	} else {
+		p.RegionalToken = ""
+		p.RegionalGatewayURL = ""
+		p.RegionalRegionID = ""
+		p.RegionalExpiresAt = 0
+	}
 	c.Profiles[profileName] = p
 	c.CurrentProfile = profileName
 }
@@ -243,6 +288,10 @@ func (c *Config) ClearCredentials(profileName string) {
 	p.Token = ""
 	p.RefreshToken = ""
 	p.ExpiresAt = 0
+	p.RegionalToken = ""
+	p.RegionalGatewayURL = ""
+	p.RegionalRegionID = ""
+	p.RegionalExpiresAt = 0
 	c.Profiles[profileName] = p
 }
 


### PR DESCRIPTION
## Summary
- persist regional session data from global auth responses in the s0 profile
- use stored regional sessions for global workload routing before falling back to the legacy region-token exchange
- keep refresh and OIDC flows in sync so refreshed credentials update both global and regional session state

Refs sandbox0-ai/sandbox0#83

## Testing
- go test ./...