### PR TITLE
Add first-team onboarding flow to s0 CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,18 @@ Flags:
 
 In `global` mode, `auth`, `user`, `team`, and `admin` commands stay on the configured entrypoint. Workload-facing commands such as `sandbox`, `template`, `volume`, `credential`, `apikey`, and registry credential flows resolve the active team and switch to the home-region gateway automatically.
 
+If a newly authenticated global-gateway user has no default team yet, finish first-team onboarding with:
+
+```bash
+s0 team create --name <name> --home-region <region-id> --activate
+```
+
 ## Commands
 
 ### Team
 
 ```bash
-s0 team create --name <name> [--slug <slug>] [--home-region <region-id>]
+s0 team create --name <name> [--slug <slug>] [--home-region <region-id>] [--activate]
 ```
 
 ### Admin Region

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.1.10
+	github.com/sandbox0-ai/sdk-go v0.1.11
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.1.10 h1:ltRpvCGwCkrkzrO6Y23EbOyljJ3MC9JIxFMw8OG9UB4=
 github.com/sandbox0-ai/sdk-go v0.1.10/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.1.11 h1:aTjZdDWcMJ1pj/lzJe0IQLlbrokN5Ow34659cB8Pflo=
+github.com/sandbox0-ai/sdk-go v0.1.11/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -11,9 +11,8 @@ import (
 )
 
 var (
-	authEmail      string
-	authPassword   string
-	authHomeRegion string
+	authEmail    string
+	authPassword string
 )
 
 var authCmd = &cobra.Command{
@@ -54,7 +53,7 @@ var authLoginCmd = &cobra.Command{
 		var loginData *authLoginData
 		switch provider.Type {
 		case "oidc":
-			loginData, err = oidcLoginViaBrowser(cmd.Context(), baseURL, provider.ID, authHomeRegion)
+			loginData, err = oidcLoginViaBrowser(cmd.Context(), baseURL, provider.ID)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "OIDC login failed: %v\n", err)
 				os.Exit(1)
@@ -85,6 +84,10 @@ var authLoginCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Login successful via provider %q (profile: %s)\n", provider.ID, profileName)
+		if shouldShowFirstTeamOnboardingHint(cmd.Context(), baseURL, loginData) {
+			fmt.Println("No active team is configured yet. Create and activate your first team with:")
+			fmt.Println("  s0 team create --name <name> --home-region <region-id> --activate")
+		}
 	},
 }
 
@@ -164,6 +167,5 @@ func init() {
 
 	authLoginCmd.Flags().StringVar(&authEmail, "email", "", "email for built-in provider login")
 	authLoginCmd.Flags().StringVar(&authPassword, "password", "", "password for built-in provider login")
-	authLoginCmd.Flags().StringVar(&authHomeRegion, "home-region", "", "home region ID for first-time OIDC provisioning in global mode")
 	authLoginCmd.MarkFlagsRequiredTogether("email", "password")
 }

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	authEmail    string
-	authPassword string
+	authEmail      string
+	authPassword   string
+	authHomeRegion string
 )
 
 var authCmd = &cobra.Command{
@@ -53,7 +54,7 @@ var authLoginCmd = &cobra.Command{
 		var loginData *authLoginData
 		switch provider.Type {
 		case "oidc":
-			loginData, err = oidcLoginViaBrowser(cmd.Context(), baseURL, provider.ID)
+			loginData, err = oidcLoginViaBrowser(cmd.Context(), baseURL, provider.ID, authHomeRegion)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "OIDC login failed: %v\n", err)
 				os.Exit(1)
@@ -163,5 +164,6 @@ func init() {
 
 	authLoginCmd.Flags().StringVar(&authEmail, "email", "", "email for built-in provider login")
 	authLoginCmd.Flags().StringVar(&authPassword, "password", "", "password for built-in provider login")
+	authLoginCmd.Flags().StringVar(&authHomeRegion, "home-region", "", "home region ID for first-time OIDC provisioning in global mode")
 	authLoginCmd.MarkFlagsRequiredTogether("email", "password")
 }

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -187,7 +187,7 @@ func getProfileWithFreshToken() (*config.Profile, error) {
 	return updated, nil
 }
 
-func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID string) (*authLoginData, error) {
+func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID, homeRegionID string) (*authLoginData, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("listen callback: %w", err)
@@ -279,6 +279,9 @@ func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID string) (*auth
 		url.PathEscape(providerID),
 		url.QueryEscape(returnURL),
 	)
+	if trimmedHomeRegion := strings.TrimSpace(homeRegionID); trimmedHomeRegion != "" {
+		loginURL += "&home_region_id=" + url.QueryEscape(trimmedHomeRegion)
+	}
 
 	fmt.Printf("Opening browser for %s login...\n", providerID)
 	if err := openBrowser(loginURL); err != nil {

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -110,6 +110,19 @@ func fetchAuthProviders(ctx context.Context, baseURL string) ([]authProvider, er
 	return data.Providers, nil
 }
 
+func fetchGatewayMode(ctx context.Context, baseURL string) (config.GatewayMode, bool) {
+	var data struct {
+		GatewayMode string `json:"gateway_mode"`
+	}
+
+	err := authRequest(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/metadata", "", nil, &data)
+	if err != nil {
+		return "", false
+	}
+
+	return config.ParseGatewayMode(data.GatewayMode)
+}
+
 func builtinLogin(ctx context.Context, baseURL, email, password string) (*authLoginData, error) {
 	var data authLoginData
 	err := authRequest(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+"/auth/login", "", map[string]string{
@@ -187,7 +200,7 @@ func getProfileWithFreshToken() (*config.Profile, error) {
 	return updated, nil
 }
 
-func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID, homeRegionID string) (*authLoginData, error) {
+func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID string) (*authLoginData, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("listen callback: %w", err)
@@ -274,14 +287,7 @@ func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID, homeRegionID 
 		Host:   ln.Addr().String(),
 		Path:   "/callback",
 	}).String()
-	loginURL := fmt.Sprintf("%s/auth/oidc/%s/login?return_url=%s",
-		strings.TrimRight(baseURL, "/"),
-		url.PathEscape(providerID),
-		url.QueryEscape(returnURL),
-	)
-	if trimmedHomeRegion := strings.TrimSpace(homeRegionID); trimmedHomeRegion != "" {
-		loginURL += "&home_region_id=" + url.QueryEscape(trimmedHomeRegion)
-	}
+	loginURL := buildOIDCLoginURL(baseURL, providerID, returnURL)
 
 	fmt.Printf("Opening browser for %s login...\n", providerID)
 	if err := openBrowser(loginURL); err != nil {
@@ -302,6 +308,23 @@ func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID, homeRegionID 
 		_ = server.Shutdown(context.Background())
 		return nil, fmt.Errorf("oidc login timed out")
 	}
+}
+
+func buildOIDCLoginURL(baseURL, providerID, returnURL string) string {
+	return fmt.Sprintf("%s/auth/oidc/%s/login?return_url=%s",
+		strings.TrimRight(baseURL, "/"),
+		url.PathEscape(providerID),
+		url.QueryEscape(returnURL),
+	)
+}
+
+func shouldShowFirstTeamOnboardingHint(ctx context.Context, baseURL string, data *authLoginData) bool {
+	if data == nil || data.RegionalSession != nil {
+		return false
+	}
+
+	mode, ok := fetchGatewayMode(ctx, baseURL)
+	return ok && mode == config.GatewayModeGlobal
 }
 
 func toRegionalSessionConfig(data *authLoginData) *config.RegionalSession {

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestBuildOIDCLoginURL(t *testing.T) {
+	loginURL := buildOIDCLoginURL("https://global.example.com/", "google", "http://127.0.0.1:38123/callback")
+
+	parsed, err := url.Parse(loginURL)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if parsed.Path != "/auth/oidc/google/login" {
+		t.Fatalf("Path = %q, want /auth/oidc/google/login", parsed.Path)
+	}
+	if got := parsed.Query().Get("return_url"); got != "http://127.0.0.1:38123/callback" {
+		t.Fatalf("return_url = %q, want callback URL", got)
+	}
+	if got := parsed.Query().Get("home_region_id"); got != "" {
+		t.Fatalf("home_region_id = %q, want empty", got)
+	}
+}
+
+func TestShouldShowFirstTeamOnboardingHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metadata" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"gateway_mode":"global","service":"global-gateway"}}`))
+	}))
+	defer server.Close()
+
+	if !shouldShowFirstTeamOnboardingHint(context.Background(), server.URL, &authLoginData{}) {
+		t.Fatal("shouldShowFirstTeamOnboardingHint() = false, want true")
+	}
+}
+
+func TestShouldShowFirstTeamOnboardingHintSkipsWhenRegionalSessionExists(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	if shouldShowFirstTeamOnboardingHint(context.Background(), server.URL, &authLoginData{
+		RegionalSession: &struct {
+			RegionID           string `json:"region_id"`
+			RegionalGatewayURL string `json:"regional_gateway_url"`
+			Token              string `json:"token"`
+			ExpiresAt          int64  `json:"expires_at"`
+		}{
+			RegionID:           "aws/us-east-1",
+			RegionalGatewayURL: "https://regional.example.com",
+			Token:              "region-token",
+			ExpiresAt:          1893456000,
+		},
+	}) {
+		t.Fatal("shouldShowFirstTeamOnboardingHint() = true, want false")
+	}
+}
+
+func TestAuthLoginCommandDoesNotExposeHomeRegionFlag(t *testing.T) {
+	if flag := authLoginCmd.Flags().Lookup("home-region"); flag != nil {
+		t.Fatalf("home-region flag should be removed, got %v", flag)
+	}
+}

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +15,7 @@ var (
 	teamName       string
 	teamSlug       string
 	teamHomeRegion string
+	teamActivate   bool
 
 	teamMemberTeamID string
 	teamMemberEmail  string
@@ -136,9 +139,20 @@ var teamCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if teamActivate {
+			if err := activateCreatedTeam(cmd.Context(), client, data.ID); err != nil {
+				fmt.Fprintf(os.Stderr, "Error activating team: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
 		if err := getFormatter().Format(os.Stdout, data); err != nil {
 			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 			os.Exit(1)
+		}
+
+		if teamActivate {
+			fmt.Fprintf(os.Stderr, "Activated team %s as the default team\n", data.ID)
 		}
 	},
 }
@@ -466,6 +480,30 @@ func buildCreateTeamRequest(name, slug, homeRegion string) *apispec.CreateTeamRe
 	return req
 }
 
+func buildActivateTeamRequest(teamID string) *apispec.UpdateUserRequest {
+	req := &apispec.UpdateUserRequest{}
+	req.DefaultTeamID = apispec.NewOptNilString(strings.TrimSpace(teamID))
+	return req
+}
+
+func activateCreatedTeam(ctx context.Context, client *sandbox0.Client, teamID string) error {
+	res, err := client.API().TenantActivePut(ctx, buildActivateTeamRequest(teamID))
+	if err != nil {
+		return err
+	}
+
+	successRes, ok := res.(*apispec.SuccessUserResponse)
+	if !ok {
+		return fmt.Errorf("unexpected response type %T", res)
+	}
+
+	if _, ok := successRes.Data.Get(); !ok {
+		return fmt.Errorf("missing response data")
+	}
+
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(teamCmd)
 
@@ -486,6 +524,7 @@ func init() {
 	teamCreateCmd.Flags().StringVar(&teamName, "name", "", "team name (required)")
 	teamCreateCmd.Flags().StringVar(&teamSlug, "slug", "", "team slug")
 	teamCreateCmd.Flags().StringVar(&teamHomeRegion, "home-region", "", "team home region ID")
+	teamCreateCmd.Flags().BoolVar(&teamActivate, "activate", false, "set the created team as the default active team")
 
 	teamUpdateCmd.Flags().StringVar(&teamName, "name", "", "new team name")
 	teamUpdateCmd.Flags().StringVar(&teamSlug, "slug", "", "new team slug")

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -30,3 +30,12 @@ func TestBuildCreateTeamRequestOmitsOptionalFieldsWhenBlank(t *testing.T) {
 		t.Fatal("HomeRegionID should be unset")
 	}
 }
+
+func TestBuildActivateTeamRequest(t *testing.T) {
+	req := buildActivateTeamRequest(" team-1 ")
+
+	defaultTeamID, ok := req.DefaultTeamID.Get()
+	if !ok || defaultTeamID != "team-1" {
+		t.Fatalf("DefaultTeamID = %q, want team-1", defaultTeamID)
+	}
+}


### PR DESCRIPTION
## Summary
- remove the old `s0 auth login --home-region` path so CLI auth matches the decoupled first-team onboarding flow
- add `s0 team create --activate` to create and immediately activate the first team for global-gateway users
- bump `sdk-go` to `v0.1.11` and update CLI docs/tests for the new flow

Refs sandbox0-ai/sandbox0#90

## Testing
- `go test ./...`