### PR TITLE
Add local-first workspace sync CLI flows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.1.11
+	github.com/sandbox0-ai/sdk-go v0.1.13
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.1.10 h1:ltRpvCGwCkrkzrO6Y23EbOyljJ3MC9JIxFMw8OG9UB4=
-github.com/sandbox0-ai/sdk-go v0.1.10/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.1.11 h1:aTjZdDWcMJ1pj/lzJe0IQLlbrokN5Ow34659cB8Pflo=
-github.com/sandbox0-ai/sdk-go v0.1.11/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.1.13 h1:K1zPqG2aJXrHTcdWJkNxlxJsQYKwt5bL2pfdeCwFr/8=
+github.com/sandbox0-ai/sdk-go v0.1.13/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -149,7 +149,7 @@ func buildUserAgent() string {
 func commandRouteScope(cmd *cobra.Command) client.RouteScope {
 	for current := cmd; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "sandbox", "template", "volume", "credential", "apikey", "image":
+		case "sandbox", "template", "volume", "sync", "credential", "apikey", "image":
 			return client.RouteScopeHomeRegion
 		case "auth", "team", "user":
 			return client.RouteScopeEntrypoint

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -623,7 +624,7 @@ func resolveConflictByPath(ctx context.Context, api *syncapi.Client, attachment 
 	if err != nil {
 		return nil, err
 	}
-	candidate := filepath.ToSlash(strings.TrimSpace(relativePath))
+	candidate := normalizeConflictPath(relativePath)
 	for _, conflict := range conflicts {
 		if conflictMatchesPath(conflict, candidate) {
 			return &conflict, nil
@@ -638,7 +639,7 @@ func conflictMatchesPath(conflict apispec.SyncConflict, candidate string) bool {
 		optNilString(conflict.IncomingPath),
 		optNilString(conflict.IncomingOldPath),
 	} {
-		if path == candidate {
+		if normalizeConflictPath(path) == candidate {
 			return true
 		}
 	}
@@ -653,6 +654,13 @@ func resolveWorkspaceRelativePath(attachment *syncstate.Attachment, value string
 	if candidate == "" {
 		return "", fmt.Errorf("path is empty")
 	}
+	if strings.HasPrefix(candidate, "/") && !isAncestorPath(attachment.WorkspaceRoot, filepath.Clean(candidate)) {
+		logical := normalizeConflictPath(candidate)
+		if logical == "" {
+			return "", fmt.Errorf("%q is outside workspace %s", value, attachment.WorkspaceRoot)
+		}
+		return logical, nil
+	}
 	absolute := candidate
 	if !filepath.IsAbs(absolute) {
 		absolute = filepath.Join(mustGetwd(), candidate)
@@ -666,6 +674,33 @@ func resolveWorkspaceRelativePath(attachment *syncstate.Attachment, value string
 		return "", fmt.Errorf("%q is outside workspace %s", value, attachment.WorkspaceRoot)
 	}
 	return relative, nil
+}
+
+func normalizeConflictPath(path string) string {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	if path == "" {
+		return ""
+	}
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimPrefix(path, "./")
+	path = pathpkg.Clean(path)
+	if path == "." || path == "/" {
+		return ""
+	}
+	return filepath.ToSlash(path)
+}
+
+func isAncestorPath(root, path string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if root == path {
+		return true
+	}
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func optString(value apispec.OptString) string {

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -1,0 +1,685 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/s0/internal/config"
+	"github.com/sandbox0-ai/s0/internal/output"
+	"github.com/sandbox0-ai/s0/internal/syncapi"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/s0/internal/syncview"
+	"github.com/sandbox0-ai/s0/internal/syncworker"
+	syncsdk "github.com/sandbox0-ai/sdk-go"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	syncAttachForeground bool
+	syncAttachInitFrom   string
+	syncAttachName       string
+
+	syncDetachPurgeState bool
+	syncDetachForce      bool
+
+	syncLogsFollow bool
+
+	syncConflictsIgnore bool
+
+	syncWorkerAttachmentID string
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Manage local-first workspace sync attachments",
+	Long:  `Attach a local workspace to a volume and manage the local sync worker lifecycle.`,
+}
+
+var syncAttachCmd = &cobra.Command{
+	Use:   "attach <volume-id> [path]",
+	Short: "Attach the current or specified workspace to a volume",
+	Long:  `Attach a local workspace to a volume and start the local sync worker in the foreground or background.`,
+	Args:  cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		volumeID := strings.TrimSpace(args[0])
+		workspacePath := "."
+		if len(args) == 2 {
+			workspacePath = args[1]
+		}
+
+		attachment, err := upsertAttachment(workspacePath, volumeID, syncAttachName, syncAttachInitFrom)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing attachment: %v\n", err)
+			os.Exit(1)
+		}
+
+		status := syncstate.EffectiveStatus(attachment)
+		if status == "running" {
+			if syncAttachForeground {
+				fmt.Fprintf(os.Stderr, "Sync worker is already running for %s\n", attachment.WorkspaceRoot)
+				os.Exit(1)
+			}
+			if err := renderSyncOutput(os.Stdout, attachment); err != nil {
+				fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+		if needsWorkerRecovery(status) {
+			attachment, err = syncstate.ResetWorkerState(attachment.ID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error preparing local worker recovery: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		if syncAttachForeground {
+			fmt.Fprintf(os.Stdout, "Attached %s to %s. Running sync worker in foreground. Press Ctrl+C to stop.\n", attachment.WorkspaceRoot, attachment.VolumeID)
+			client, err := getClientRaw(cmd)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error preparing API client: %v\n", err)
+				os.Exit(1)
+			}
+			if err := runForegroundSyncWorker(cmd.Context(), client, attachment.ID); err != nil {
+				fmt.Fprintf(os.Stderr, "Error running sync worker: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+
+		if err := startBackgroundSyncWorker(attachment.ID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error starting background sync worker: %v\n", err)
+			os.Exit(1)
+		}
+
+		attachment, err = syncstate.LoadAttachmentByID(attachment.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reloading attachment: %v\n", err)
+			os.Exit(1)
+		}
+		if err := renderSyncOutput(os.Stdout, attachment); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncDetachCmd = &cobra.Command{
+	Use:   "detach [path|volume-id]",
+	Short: "Detach a workspace from sync",
+	Long:  `Stop the local sync worker and remove the local attachment for the current or specified workspace.`,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		attachment, err := resolveSyncAttachment(cmd, args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving attachment: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := stopAttachmentWorker(attachment, syncDetachForce); err != nil {
+			fmt.Fprintf(os.Stderr, "Error stopping sync worker: %v\n", err)
+			os.Exit(1)
+		}
+		if err := syncstate.DeleteAttachment(attachment.ID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error removing attachment: %v\n", err)
+			os.Exit(1)
+		}
+		if syncDetachPurgeState {
+			_ = os.Remove(attachment.Worker.LogPath)
+		}
+
+		fmt.Fprintf(os.Stdout, "Detached %s from volume %s\n", attachment.WorkspaceRoot, attachment.VolumeID)
+	},
+}
+
+var syncListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List local sync attachments",
+	Long:  `List all local workspaces currently attached for sync on this machine.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		attachments, err := syncstate.ListAttachments()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing attachments: %v\n", err)
+			os.Exit(1)
+		}
+		if err := renderSyncOutput(os.Stdout, attachments); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncStatusCmd = &cobra.Command{
+	Use:   "status [path|volume-id]",
+	Short: "Show sync status for the current or specified workspace",
+	Long:  `Show the local attachment state, worker status, and persisted sync checkpoint metadata.`,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		attachment, err := resolveSyncAttachment(cmd, args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving attachment: %v\n", err)
+			os.Exit(1)
+		}
+
+		view := buildStatusView(cmd, attachment)
+		if err := renderSyncOutput(os.Stdout, view); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncLogsCmd = &cobra.Command{
+	Use:   "logs [path|volume-id]",
+	Short: "Read sync worker logs",
+	Long:  `Read the log output for the current or specified sync attachment.`,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		attachment, err := resolveSyncAttachment(cmd, args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving attachment: %v\n", err)
+			os.Exit(1)
+		}
+		if err := printAttachmentLogs(cmd.Context(), attachment, syncLogsFollow); err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading logs: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncConflictsCmd = &cobra.Command{
+	Use:   "conflicts",
+	Short: "Inspect and resolve sync conflicts",
+	Long:  `List and resolve persisted sync conflicts for the current workspace or attached volume.`,
+}
+
+var syncConflictsListCmd = &cobra.Command{
+	Use:   "list [path|volume-id]",
+	Short: "List unresolved sync conflicts",
+	Long:  `List unresolved sync conflicts for the current workspace or attached volume.`,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		attachment, err := resolveSyncAttachment(cmd, args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving attachment: %v\n", err)
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing API client: %v\n", err)
+			os.Exit(1)
+		}
+		conflicts, err := syncapi.New(client).ListConflicts(cmd.Context(), attachment.VolumeID, "open", 256)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing conflicts: %v\n", err)
+			os.Exit(1)
+		}
+		view := syncview.BuildConflictListView(attachment, conflicts, 0)
+		if err := renderSyncOutput(os.Stdout, view); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncConflictsShowCmd = &cobra.Command{
+	Use:   "show <path>",
+	Short: "Show one conflict path",
+	Long:  `Show one unresolved sync conflict addressed by its workspace-relative path.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		attachment, err := syncstate.ResolveAttachmentFromPath(mustGetwd())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving current workspace: %v\n", err)
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing API client: %v\n", err)
+			os.Exit(1)
+		}
+		conflictPath, err := resolveWorkspaceRelativePath(attachment, args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving conflict path: %v\n", err)
+			os.Exit(1)
+		}
+		conflict, err := resolveConflictByPath(cmd.Context(), syncapi.New(client), attachment, conflictPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error showing conflict: %v\n", err)
+			os.Exit(1)
+		}
+		view := syncview.BuildConflictDetailView(conflict)
+		if err := renderSyncOutput(os.Stdout, view); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncConflictsMarkCmd = &cobra.Command{
+	Use:   "mark <path>",
+	Short: "Mark one conflict as resolved or ignored",
+	Long:  `Mark one unresolved sync conflict as resolved or ignored after local repair.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		attachment, err := syncstate.ResolveAttachmentFromPath(mustGetwd())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving current workspace: %v\n", err)
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing API client: %v\n", err)
+			os.Exit(1)
+		}
+		api := syncapi.New(client)
+		conflictPath, err := resolveWorkspaceRelativePath(attachment, args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving conflict path: %v\n", err)
+			os.Exit(1)
+		}
+		conflict, err := resolveConflictByPath(cmd.Context(), api, attachment, conflictPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving conflict path: %v\n", err)
+			os.Exit(1)
+		}
+		conflictID, ok := conflict.ID.Get()
+		if !ok || strings.TrimSpace(conflictID) == "" {
+			fmt.Fprintln(os.Stderr, "Error resolving conflict path: conflict id is missing")
+			os.Exit(1)
+		}
+		resolved, err := api.ResolveConflict(cmd.Context(), attachment.VolumeID, conflictID, syncConflictsIgnore)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error updating conflict: %v\n", err)
+			os.Exit(1)
+		}
+		refreshAttachmentConflictCount(cmd.Context(), api, attachment.ID, attachment.VolumeID)
+		view := syncview.BuildConflictDetailView(resolved)
+		if err := renderSyncOutput(os.Stdout, view); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncWorkerCmd = &cobra.Command{
+	Use:    "__sync-worker",
+	Short:  "Run the internal sync worker",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		if strings.TrimSpace(syncWorkerAttachmentID) == "" {
+			fmt.Fprintln(os.Stderr, "missing attachment id")
+			os.Exit(1)
+		}
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error preparing API client: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runBackgroundSyncWorker(cmd.Context(), client, syncWorkerAttachmentID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error running sync worker: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(syncCmd)
+	rootCmd.AddCommand(syncWorkerCmd)
+
+	syncCmd.AddCommand(syncAttachCmd)
+	syncCmd.AddCommand(syncDetachCmd)
+	syncCmd.AddCommand(syncListCmd)
+	syncCmd.AddCommand(syncStatusCmd)
+	syncCmd.AddCommand(syncLogsCmd)
+	syncCmd.AddCommand(syncConflictsCmd)
+
+	syncConflictsCmd.AddCommand(syncConflictsListCmd)
+	syncConflictsCmd.AddCommand(syncConflictsShowCmd)
+	syncConflictsCmd.AddCommand(syncConflictsMarkCmd)
+
+	syncAttachCmd.Flags().BoolVar(&syncAttachForeground, "foreground", false, "run the sync worker in the foreground")
+	syncAttachCmd.Flags().StringVar(&syncAttachInitFrom, "init-from", "auto", "bootstrap policy (auto, volume, local)")
+	syncAttachCmd.Flags().StringVar(&syncAttachName, "name", "", "human-readable local workspace name")
+
+	syncDetachCmd.Flags().BoolVar(&syncDetachPurgeState, "purge-state", false, "remove local log files while detaching")
+	syncDetachCmd.Flags().BoolVar(&syncDetachForce, "force", false, "forcefully stop a worker even when the local heartbeat is stale")
+
+	syncLogsCmd.Flags().BoolVarP(&syncLogsFollow, "follow", "f", false, "follow log output")
+
+	syncConflictsMarkCmd.Flags().BoolVar(&syncConflictsIgnore, "ignore", false, "mark the conflict placeholder as ignored instead of resolved")
+
+	syncWorkerCmd.Flags().StringVar(&syncWorkerAttachmentID, "attachment-id", "", "internal attachment id")
+	_ = syncWorkerCmd.MarkFlagRequired("attachment-id")
+}
+
+func upsertAttachment(workspacePath, volumeID, displayName, initFrom string) (*syncstate.Attachment, error) {
+	workspaceRoot, err := filepath.Abs(workspacePath)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := syncstate.ResolveAttachmentFromPath(workspaceRoot)
+	if err == nil && filepath.Clean(existing.WorkspaceRoot) == filepath.Clean(workspaceRoot) {
+		if existing.VolumeID != strings.TrimSpace(volumeID) {
+			return nil, fmt.Errorf("workspace %s is already attached to volume %s", existing.WorkspaceRoot, existing.VolumeID)
+		}
+		existing.InitFrom = strings.TrimSpace(initFrom)
+		if strings.TrimSpace(displayName) != "" {
+			existing.DisplayName = strings.TrimSpace(displayName)
+		}
+		if err := syncstate.SaveAttachment(existing); err != nil {
+			return nil, err
+		}
+		return existing, nil
+	}
+
+	attachment, err := syncstate.NewAttachment(workspaceRoot, volumeID, displayName, initFrom)
+	if err != nil {
+		return nil, err
+	}
+	if err := syncstate.SaveAttachment(attachment); err != nil {
+		return nil, err
+	}
+	return attachment, nil
+}
+
+func resolveSyncAttachment(cmd *cobra.Command, args []string) (*syncstate.Attachment, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	target := ""
+	if len(args) > 0 {
+		target = args[0]
+	}
+	return syncstate.ResolveAttachmentTarget(target, cwd)
+}
+
+func renderSyncOutput(w io.Writer, data any) error {
+	if output.ParseFormat(cfgFormat) == output.FormatTable {
+		return getFormatter().Format(w, data)
+	}
+	return getFormatter().Format(w, data)
+}
+
+func runForegroundSyncWorker(parent context.Context, client *syncsdk.Client, attachmentID string) error {
+	ctx, cancel := signal.NotifyContext(parent, forwardingSignals()...)
+	defer cancel()
+	return syncworker.Run(ctx, client, attachmentID, "foreground", os.Stdout)
+}
+
+func runBackgroundSyncWorker(parent context.Context, client *syncsdk.Client, attachmentID string) error {
+	attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return err
+	}
+	if err := syncstate.EnsureLogDir(); err != nil {
+		return err
+	}
+	logFile, err := os.OpenFile(attachment.Worker.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	ctx, cancel := signal.NotifyContext(parent, forwardingSignals()...)
+	defer cancel()
+	return syncworker.Run(ctx, client, attachmentID, "background", logFile)
+}
+
+func startBackgroundSyncWorker(attachmentID string) error {
+	attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return err
+	}
+	if err := syncstate.EnsureLogDir(); err != nil {
+		return err
+	}
+
+	logFile, err := os.OpenFile(attachment.Worker.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	args := backgroundWorkerArgs(attachmentID)
+	command := exec.Command(executable, args...)
+	command.Stdin = nil
+	command.Stdout = logFile
+	command.Stderr = logFile
+	command.Env = backgroundWorkerEnv()
+
+	if err := command.Start(); err != nil {
+		return err
+	}
+	pid := command.Process.Pid
+	if err := command.Process.Release(); err != nil {
+		return err
+	}
+
+	_, err = syncstate.TouchWorkerHeartbeat(attachmentID, "background", pid)
+	return err
+}
+
+func stopAttachmentWorker(attachment *syncstate.Attachment, force bool) error {
+	if attachment == nil {
+		return errors.New("attachment is nil")
+	}
+	if attachment.Worker.PID == 0 {
+		return nil
+	}
+	if syncstate.EffectiveStatus(attachment) == "stale" && !force {
+		return fmt.Errorf("worker heartbeat is stale; rerun with --force to detach anyway")
+	}
+
+	process, err := os.FindProcess(attachment.Worker.PID)
+	if err == nil {
+		_ = process.Kill()
+	}
+	attachment.Worker.Status = "stopped"
+	attachment.Worker.PID = 0
+	attachment.Worker.LastStoppedAt = ptrTime(time.Now().UTC())
+	return syncstate.SaveAttachment(attachment)
+}
+
+func printAttachmentLogs(ctx context.Context, attachment *syncstate.Attachment, follow bool) error {
+	file, err := os.Open(attachment.Worker.LogPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(os.Stdout, file); err != nil {
+		return err
+	}
+	if !follow {
+		return nil
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	buffer := make([]byte, 4096)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			for {
+				n, err := file.Read(buffer)
+				if n > 0 {
+					if _, writeErr := os.Stdout.Write(buffer[:n]); writeErr != nil {
+						return writeErr
+					}
+				}
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					return err
+				}
+				if n == 0 {
+					break
+				}
+			}
+		}
+	}
+}
+
+func mustGetwd() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return cwd
+}
+
+func ptrTime(value time.Time) *time.Time {
+	return &value
+}
+
+func backgroundWorkerArgs(attachmentID string) []string {
+	args := make([]string, 0, 10)
+	if configFile := strings.TrimSpace(*config.GetConfigFile()); configFile != "" {
+		args = append(args, "--config", configFile)
+	}
+	if profile := strings.TrimSpace(*config.GetProfileVar()); profile != "" {
+		args = append(args, "--profile", profile)
+	}
+	if apiURL := strings.TrimSpace(*config.GetAPIURLVar()); apiURL != "" {
+		args = append(args, "--api-url", apiURL)
+	}
+	args = append(args, "__sync-worker", "--attachment-id", attachmentID)
+	return args
+}
+
+func backgroundWorkerEnv() []string {
+	env := os.Environ()
+	if token := strings.TrimSpace(*config.GetTokenVar()); token != "" {
+		env = append(env, config.EnvToken+"="+token)
+	}
+	if apiURL := strings.TrimSpace(*config.GetAPIURLVar()); apiURL != "" {
+		env = append(env, config.EnvBaseURL+"="+apiURL)
+	}
+	return env
+}
+
+func needsWorkerRecovery(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "stale":
+		return true
+	default:
+		return false
+	}
+}
+
+func buildStatusView(cmd *cobra.Command, attachment *syncstate.Attachment) *syncview.StatusView {
+	if attachment == nil {
+		return syncview.BuildStatusView(nil, nil, nil)
+	}
+	client, err := getClientRaw(cmd)
+	if err != nil {
+		return syncview.BuildStatusView(attachment, nil, err)
+	}
+	conflicts, err := syncapi.New(client).ListConflicts(cmd.Context(), attachment.VolumeID, "open", 256)
+	return syncview.BuildStatusView(attachment, conflicts, err)
+}
+
+func refreshAttachmentConflictCount(ctx context.Context, api *syncapi.Client, attachmentID, volumeID string) {
+	conflicts, err := api.ListConflicts(ctx, volumeID, "open", 256)
+	if err != nil {
+		return
+	}
+	_, _ = syncstate.UpdateAttachment(attachmentID, func(attachment *syncstate.Attachment) error {
+		if attachment.LastSync == nil {
+			attachment.LastSync = &syncstate.SyncCheckpoint{}
+		}
+		attachment.LastSync.OpenConflictCount = len(conflicts)
+		return nil
+	})
+}
+
+func resolveConflictByPath(ctx context.Context, api *syncapi.Client, attachment *syncstate.Attachment, relativePath string) (*apispec.SyncConflict, error) {
+	conflicts, err := api.ListConflicts(ctx, attachment.VolumeID, "open", 256)
+	if err != nil {
+		return nil, err
+	}
+	candidate := filepath.ToSlash(strings.TrimSpace(relativePath))
+	for _, conflict := range conflicts {
+		if conflictMatchesPath(conflict, candidate) {
+			return &conflict, nil
+		}
+	}
+	return nil, fmt.Errorf("no open conflict found for %q", candidate)
+}
+
+func conflictMatchesPath(conflict apispec.SyncConflict, candidate string) bool {
+	for _, path := range []string{
+		optString(conflict.Path),
+		optNilString(conflict.IncomingPath),
+		optNilString(conflict.IncomingOldPath),
+	} {
+		if path == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveWorkspaceRelativePath(attachment *syncstate.Attachment, value string) (string, error) {
+	if attachment == nil {
+		return "", fmt.Errorf("attachment is nil")
+	}
+	candidate := strings.TrimSpace(value)
+	if candidate == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	absolute := candidate
+	if !filepath.IsAbs(absolute) {
+		absolute = filepath.Join(mustGetwd(), candidate)
+	}
+	relative, err := filepath.Rel(attachment.WorkspaceRoot, absolute)
+	if err != nil {
+		return "", err
+	}
+	relative = filepath.ToSlash(filepath.Clean(relative))
+	if relative == "." || strings.HasPrefix(relative, "../") {
+		return "", fmt.Errorf("%q is outside workspace %s", value, attachment.WorkspaceRoot)
+	}
+	return relative, nil
+}
+
+func optString(value apispec.OptString) string {
+	v, ok := value.Get()
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+func optNilString(value apispec.OptNilString) string {
+	v, ok := value.Get()
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}

--- a/internal/commands/sync_phase4_test.go
+++ b/internal/commands/sync_phase4_test.go
@@ -1,6 +1,12 @@
 package commands
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
 
 func TestNeedsWorkerRecovery(t *testing.T) {
 	tests := map[string]bool{
@@ -14,5 +20,30 @@ func TestNeedsWorkerRecovery(t *testing.T) {
 		if got := needsWorkerRecovery(input); got != want {
 			t.Fatalf("needsWorkerRecovery(%q) = %t, want %t", input, got, want)
 		}
+	}
+}
+
+func TestConflictMatchesPathNormalizesLogicalPaths(t *testing.T) {
+	conflict := apispec.SyncConflict{
+		Path:            apispec.NewOptString("/conflict.txt"),
+		IncomingPath:    apispec.NewOptNilString("/conflict.txt"),
+		IncomingOldPath: apispec.NewOptNilString("/old-conflict.txt"),
+	}
+
+	for _, candidate := range []string{"conflict.txt", "/conflict.txt", "./conflict.txt"} {
+		if !conflictMatchesPath(conflict, normalizeConflictPath(candidate)) {
+			t.Fatalf("conflictMatchesPath(%q) = false, want true", candidate)
+		}
+	}
+}
+
+func TestResolveWorkspaceRelativePathAcceptsLogicalAbsoluteConflictPath(t *testing.T) {
+	attachment := &syncstate.Attachment{WorkspaceRoot: filepath.Clean("/tmp/work")}
+	got, err := resolveWorkspaceRelativePath(attachment, "/conflict.txt")
+	if err != nil {
+		t.Fatalf("resolveWorkspaceRelativePath() error = %v", err)
+	}
+	if got != "conflict.txt" {
+		t.Fatalf("resolveWorkspaceRelativePath() = %q, want conflict.txt", got)
 	}
 }

--- a/internal/commands/sync_phase4_test.go
+++ b/internal/commands/sync_phase4_test.go
@@ -1,0 +1,18 @@
+package commands
+
+import "testing"
+
+func TestNeedsWorkerRecovery(t *testing.T) {
+	tests := map[string]bool{
+		"running":         false,
+		"stopped":         false,
+		"stale":           true,
+		"error":           false,
+		"reseed_required": false,
+	}
+	for input, want := range tests {
+		if got := needsWorkerRecovery(input); got != want {
+			t.Fatalf("needsWorkerRecovery(%q) = %t, want %t", input, got, want)
+		}
+	}
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/s0/internal/client"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/s0/internal/syncview"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -105,6 +107,20 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatUser(w, &v)
 	case *apispec.User:
 		return f.formatUser(w, v)
+	case []syncstate.Attachment:
+		return f.formatSyncAttachments(w, v)
+	case *syncstate.Attachment:
+		return f.formatSyncAttachment(w, v)
+	case *syncview.StatusView:
+		return f.formatSyncStatusView(w, v)
+	case *syncview.ConflictListView:
+		return f.formatConflictListView(w, v)
+	case *syncview.ConflictDetailView:
+		return f.formatConflictDetailView(w, v)
+	case []apispec.SyncConflict:
+		return f.formatSyncConflicts(w, v)
+	case *apispec.SyncConflict:
+		return f.formatSyncConflict(w, v)
 	case string:
 		_, _ = fmt.Fprintln(w, v)
 		return nil
@@ -200,6 +216,201 @@ func (f *TableFormatter) formatVolume(w io.Writer, v *apispec.SandboxVolume) err
 	return t.Render()
 }
 
+func (f *TableFormatter) formatSyncAttachments(w io.Writer, attachments []syncstate.Attachment) error {
+	if len(attachments) == 0 {
+		_, _ = fmt.Fprintln(w, "No sync attachments found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"WORKSPACE", "VOLUME", "WORKER", "HEALTH", "MODE", "REPLICA", "UPDATED"})
+	for _, attachment := range attachments {
+		t.Append([]string{
+			attachment.WorkspaceRoot,
+			attachment.VolumeID,
+			syncstate.EffectiveStatus(&attachment),
+			syncstate.SyncHealth(&attachment),
+			valueOrDash(attachment.Worker.Mode),
+			attachment.ReplicaID,
+			attachment.UpdatedAt.Format(timeLayout),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSyncAttachment(w io.Writer, attachment *syncstate.Attachment) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Workspace:", attachment.WorkspaceRoot})
+	_ = t.Append([]string{"Volume ID:", attachment.VolumeID})
+	_ = t.Append([]string{"Replica ID:", attachment.ReplicaID})
+	_ = t.Append([]string{"Display Name:", valueOrDash(attachment.DisplayName)})
+	_ = t.Append([]string{"Init From:", attachment.InitFrom})
+	_ = t.Append([]string{"Worker Status:", syncstate.EffectiveStatus(attachment)})
+	_ = t.Append([]string{"Sync Health:", syncstate.SyncHealth(attachment)})
+	_ = t.Append([]string{"Mode:", valueOrDash(attachment.Worker.Mode)})
+	_ = t.Append([]string{"PID:", intOrDash(attachment.Worker.PID)})
+	_ = t.Append([]string{"Log Path:", valueOrDash(attachment.Worker.LogPath)})
+	_ = t.Append([]string{"Last Heartbeat:", timeOrDash(attachment.Worker.LastHeartbeatAt)})
+	_ = t.Append([]string{"Last Started:", timeOrDash(attachment.Worker.LastStartedAt)})
+	_ = t.Append([]string{"Last Stopped:", timeOrDash(attachment.Worker.LastStoppedAt)})
+	_ = t.Append([]string{"Last Error:", valueOrDash(attachment.LastError)})
+	if attachment.LastSync != nil {
+		_ = t.Append([]string{"Head Seq:", fmt.Sprintf("%d", attachment.LastSync.HeadSeq)})
+		_ = t.Append([]string{"Last Applied Seq:", fmt.Sprintf("%d", attachment.LastSync.LastAppliedSeq)})
+		_ = t.Append([]string{"Lag:", fmt.Sprintf("%d", attachment.LastSync.HeadSeq-attachment.LastSync.LastAppliedSeq)})
+		_ = t.Append([]string{"Last Success:", timeOrDash(attachment.LastSync.LastSuccessAt)})
+		_ = t.Append([]string{"Last Failure:", timeOrDash(attachment.LastSync.LastFailureAt)})
+		_ = t.Append([]string{"Replica Refreshed:", timeOrDash(attachment.LastSync.LastReplicaSyncAt)})
+		_ = t.Append([]string{"Consecutive Errors:", fmt.Sprintf("%d", attachment.LastSync.ConsecutiveErrors)})
+		_ = t.Append([]string{"Reseed Required:", fmt.Sprintf("%t", attachment.LastSync.ReseedRequired)})
+		_ = t.Append([]string{"Open Conflicts:", fmt.Sprintf("%d", attachment.LastSync.OpenConflictCount)})
+	}
+	_ = t.Append([]string{"Ignore Defaults:", strings.Join(attachment.Ignore.BuiltinPatterns, ", ")})
+	_ = t.Append([]string{"Created:", attachment.CreatedAt.Format(timeLayout)})
+	_ = t.Append([]string{"Updated:", attachment.UpdatedAt.Format(timeLayout)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSyncStatusView(w io.Writer, view *syncview.StatusView) error {
+	if view == nil || view.Attachment == nil {
+		_, _ = fmt.Fprintln(w, "No sync attachment found.")
+		return nil
+	}
+	if err := f.formatSyncAttachment(w, view.Attachment); err != nil {
+		return err
+	}
+	if view.ConflictSummary != nil && view.ConflictSummary.OpenCount > 0 {
+		_, _ = fmt.Fprintln(w)
+		if err := f.writeConflictListSummary(w, view.ConflictSummary); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(view.ConflictQueryError) != "" {
+		_, _ = fmt.Fprintf(w, "\nConflict Summary Error: %s\n", view.ConflictQueryError)
+	}
+	return nil
+}
+
+func (f *TableFormatter) formatConflictListView(w io.Writer, view *syncview.ConflictListView) error {
+	if view == nil || view.OpenCount == 0 {
+		_, _ = fmt.Fprintln(w, "No sync conflicts found.")
+		return nil
+	}
+
+	if strings.TrimSpace(view.WorkspaceRoot) != "" {
+		_, _ = fmt.Fprintf(w, "Workspace: %s\n", view.WorkspaceRoot)
+	}
+	if strings.TrimSpace(view.VolumeID) != "" {
+		_, _ = fmt.Fprintf(w, "Volume ID: %s\n", view.VolumeID)
+	}
+	return f.writeConflictListSummary(w, view)
+}
+
+func (f *TableFormatter) writeConflictListSummary(w io.Writer, view *syncview.ConflictListView) error {
+	if view == nil {
+		return nil
+	}
+	_, _ = fmt.Fprintf(w, "Open Conflicts: %d\n", view.OpenCount)
+	if len(view.UnmergedPaths) == 0 {
+		_, _ = fmt.Fprintln(w, "Unmerged sync paths: summary unavailable")
+		return nil
+	}
+	_, _ = fmt.Fprintln(w, "Unmerged sync paths:")
+	for _, entry := range view.UnmergedPaths {
+		_, _ = fmt.Fprintf(w, "  %s: %s\n", valueOrDash(entry.Summary), valueOrDash(entry.Path))
+	}
+	if view.Truncated && view.Remaining > 0 {
+		_, _ = fmt.Fprintf(w, "  ... and %d more\n", view.Remaining)
+	}
+	return nil
+}
+
+func (f *TableFormatter) formatConflictDetailView(w io.Writer, view *syncview.ConflictDetailView) error {
+	if view == nil {
+		_, _ = fmt.Fprintln(w, "No sync conflict found.")
+		return nil
+	}
+
+	t := newTable(w)
+	_ = t.Append([]string{"Path:", valueOrDash(view.Path)})
+	_ = t.Append([]string{"Summary:", valueOrDash(view.Summary)})
+	_ = t.Append([]string{"Reason Code:", valueOrDash(view.ReasonCode)})
+	_ = t.Append([]string{"Status:", valueOrDash(view.Status)})
+	_ = t.Append([]string{"Recorded For:", valueOrDash(view.RecordedFor)})
+	_ = t.Append([]string{"Compatibility Impact:", valueOrDash(view.CompatibilityImpact)})
+	_ = t.Append([]string{"Normalized Path:", valueOrDash(view.NormalizedPath)})
+	_ = t.Append([]string{"Artifact Path:", valueOrDash(view.ArtifactPath)})
+	_ = t.Append([]string{"Incoming Path:", valueOrDash(view.IncomingPath)})
+	_ = t.Append([]string{"Incoming Old Path:", valueOrDash(view.IncomingOldPath)})
+	_ = t.Append([]string{"Other Paths:", valueOrDash(strings.Join(view.OtherPaths, ", "))})
+	if view.ExistingSeq != nil {
+		_ = t.Append([]string{"Existing Seq:", fmt.Sprintf("%d", *view.ExistingSeq)})
+	} else {
+		_ = t.Append([]string{"Existing Seq:", "-"})
+	}
+	_ = t.Append([]string{"Latest Remote Path:", valueOrDash(view.LatestRemotePath)})
+	_ = t.Append([]string{"Latest Remote Actor:", valueOrDash(view.LatestRemoteActor)})
+	_ = t.Append([]string{"Latest Remote Event:", valueOrDash(view.LatestRemoteEvent)})
+	_ = t.Append([]string{"Issue:", valueOrDash(view.IssueMessage)})
+	_ = t.Append([]string{"Resolution:", valueOrDash(view.Resolution)})
+	_ = t.Append([]string{"Note:", valueOrDash(view.Note)})
+	_ = t.Append([]string{"Resolved At:", valueOrDash(view.ResolvedAt)})
+	_ = t.Append([]string{"Suggested Next Step:", valueOrDash(view.SuggestedNextStep)})
+	_ = t.Append([]string{"Created:", timeOrDash(view.CreatedAt)})
+	_ = t.Append([]string{"Updated:", timeOrDash(view.UpdatedAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSyncConflicts(w io.Writer, conflicts []apispec.SyncConflict) error {
+	if len(conflicts) == 0 {
+		_, _ = fmt.Fprintln(w, "No sync conflicts found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"PATH", "REASON", "STATUS", "REPLICA", "ARTIFACT"})
+	for _, conflict := range conflicts {
+		path, _ := conflict.Path.Get()
+		reason, _ := conflict.Reason.Get()
+		status, _ := conflict.Status.Get()
+		replicaID, _ := conflict.ReplicaID.Get()
+		artifactPath, _ := conflict.ArtifactPath.Get()
+		_ = t.Append([]string{
+			valueOrDash(path),
+			valueOrDash(reason),
+			valueOrDash(status),
+			valueOrDash(replicaID),
+			valueOrDash(artifactPath),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSyncConflict(w io.Writer, conflict *apispec.SyncConflict) error {
+	t := newTable(w)
+	id, _ := conflict.ID.Get()
+	path, _ := conflict.Path.Get()
+	normalizedPath, _ := conflict.NormalizedPath.Get()
+	artifactPath, _ := conflict.ArtifactPath.Get()
+	incomingPath, _ := conflict.IncomingPath.Get()
+	incomingOldPath, _ := conflict.IncomingOldPath.Get()
+	reason, _ := conflict.Reason.Get()
+	status, _ := conflict.Status.Get()
+	replicaID, _ := conflict.ReplicaID.Get()
+	_ = t.Append([]string{"ID:", valueOrDash(id)})
+	_ = t.Append([]string{"Path:", valueOrDash(path)})
+	_ = t.Append([]string{"Normalized Path:", valueOrDash(normalizedPath)})
+	_ = t.Append([]string{"Artifact Path:", valueOrDash(artifactPath)})
+	_ = t.Append([]string{"Incoming Path:", valueOrDash(incomingPath)})
+	_ = t.Append([]string{"Incoming Old Path:", valueOrDash(incomingOldPath)})
+	_ = t.Append([]string{"Reason:", valueOrDash(reason)})
+	_ = t.Append([]string{"Status:", valueOrDash(status)})
+	_ = t.Append([]string{"Replica ID:", valueOrDash(replicaID)})
+	_ = t.Append([]string{"Created:", timeOrDash(optDateTimePtr(conflict.CreatedAt))})
+	_ = t.Append([]string{"Updated:", timeOrDash(optDateTimePtr(conflict.UpdatedAt))})
+	return t.Render()
+}
+
 func (f *TableFormatter) formatSnapshots(w io.Writer, snapshots []apispec.Snapshot) error {
 	if len(snapshots) == 0 {
 		_, _ = fmt.Fprintln(w, "No snapshots found.")
@@ -222,6 +433,36 @@ func (f *TableFormatter) formatSnapshots(w io.Writer, snapshots []apispec.Snapsh
 		})
 	}
 	return t.Render()
+}
+
+func valueOrDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func intOrDash(value int) string {
+	if value == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", value)
+}
+
+func timeOrDash(value *time.Time) string {
+	if value == nil || value.IsZero() {
+		return "-"
+	}
+	return value.Format(timeLayout)
+}
+
+func optDateTimePtr(value apispec.OptDateTime) *time.Time {
+	v, ok := value.Get()
+	if !ok {
+		return nil
+	}
+	return &v
 }
 
 func (f *TableFormatter) formatSnapshot(w io.Writer, s *apispec.Snapshot) error {

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/s0/internal/syncview"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
@@ -152,6 +154,100 @@ func TestTableFormatterFormatRegion(t *testing.T) {
 		"https://use1.example.com",
 		"false",
 		"-",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatSyncStatusView(t *testing.T) {
+	formatter := &TableFormatter{}
+	view := &syncview.StatusView{
+		Attachment: &syncstate.Attachment{
+			WorkspaceRoot: "/tmp/work",
+			VolumeID:      "vol-123",
+			ReplicaID:     "replica-mac",
+			InitFrom:      "auto",
+			Worker: syncstate.WorkerState{
+				Status: "running",
+				Mode:   "background",
+			},
+			Ignore: syncstate.IgnoreConfig{
+				BuiltinPatterns: []string{".git/"},
+			},
+			CreatedAt: time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 3, 26, 12, 1, 0, 0, time.UTC),
+			LastSync: &syncstate.SyncCheckpoint{
+				HeadSeq:           10,
+				LastAppliedSeq:    8,
+				OpenConflictCount: 2,
+			},
+		},
+		ConflictSummary: &syncview.ConflictListView{
+			OpenCount: 2,
+			UnmergedPaths: []syncview.ConflictListEntry{
+				{Path: "src/main.go", Summary: `modified locally, conflicted with sandbox "sandbox-1"`},
+				{Path: "docs/CON.txt", Summary: "namespace incompatible for Windows-capable replicas"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, view); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Workspace:",
+		"/tmp/work",
+		"Open Conflicts: 2",
+		"Unmerged sync paths:",
+		`modified locally, conflicted with sandbox "sandbox-1": src/main.go`,
+		"namespace incompatible for Windows-capable replicas: docs/CON.txt",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatConflictDetailView(t *testing.T) {
+	formatter := &TableFormatter{}
+	now := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+	view := &syncview.ConflictDetailView{
+		Path:              "src/main.go",
+		Summary:           `modified locally, conflicted with sandbox "sandbox-1"`,
+		ReasonCode:        "concurrent_update",
+		Status:            "open",
+		RecordedFor:       `replica "replica-mac"`,
+		ArtifactPath:      "src/main.sandbox0-conflict-replica-mac-seq-42.go",
+		LatestRemoteActor: `sandbox "sandbox-1"`,
+		LatestRemoteEvent: "write",
+		SuggestedNextStep: "Inspect the artifact and repair the canonical path locally.",
+		CreatedAt:         &now,
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, view); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Path:",
+		"Summary:",
+		"Reason Code:",
+		"Recorded For:",
+		"Latest Remote Actor:",
+		"Latest Remote Event:",
+		"Suggested Next Step:",
+		"src/main.go",
+		"concurrent_update",
+		`replica "replica-mac"`,
+		`sandbox "sandbox-1"`,
+		"write",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)

--- a/internal/syncapi/syncapi.go
+++ b/internal/syncapi/syncapi.go
@@ -1,0 +1,332 @@
+package syncapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	syncsdk "github.com/sandbox0-ai/sdk-go"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+)
+
+const defaultChangeLimit int32 = 256
+
+// Client wraps the low-level sync endpoints needed by the local worker.
+type Client struct {
+	sdk *syncsdk.Client
+}
+
+// ReseedRequiredError reports that the local replica must bootstrap again.
+type ReseedRequiredError struct {
+	RetainedAfterSeq int64
+	HeadSeq          int64
+	Message          string
+}
+
+func (e *ReseedRequiredError) Error() string {
+	if e == nil {
+		return "reseed required"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return "reseed required"
+}
+
+// BootstrapCompatibilityError reports namespace incompatibilities during bootstrap.
+type BootstrapCompatibilityError struct {
+	Message string
+	Details *apispec.VolumeSyncBootstrapCompatibilityConflictDetails
+}
+
+func (e *BootstrapCompatibilityError) Error() string {
+	if e == nil {
+		return "bootstrap compatibility conflict"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return "bootstrap compatibility conflict"
+}
+
+// New creates a sync API wrapper from the shared SDK client.
+func New(client *syncsdk.Client) *Client {
+	return &Client{sdk: client}
+}
+
+// UpsertReplica registers or refreshes the local replica record.
+func (c *Client) UpsertReplica(ctx context.Context, attachment *syncstate.Attachment) (*apispec.VolumeSyncReplicaEnvelope, error) {
+	req := &apispec.UpsertSyncReplicaRequest{
+		DisplayName:   apispec.NewOptString(displayNameFor(attachment)),
+		Platform:      apispec.NewOptString(attachment.Platform),
+		RootPath:      apispec.NewOptString(attachment.WorkspaceRoot),
+		CaseSensitive: apispec.NewOptBool(attachment.Capabilities.CaseSensitive),
+		Capabilities:  apispec.NewOptVolumeSyncFilesystemCapabilities(toSDKCapabilities(attachment.Capabilities)),
+	}
+	resp, err := c.sdk.API().APIV1SandboxvolumesIDSyncReplicasReplicaIDPut(ctx, req, apispec.APIV1SandboxvolumesIDSyncReplicasReplicaIDPutParams{
+		ID:        attachment.VolumeID,
+		ReplicaID: attachment.ReplicaID,
+	})
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	data, ok := resp.Data.Get()
+	if !ok {
+		return nil, errors.New("sync replica response missing data")
+	}
+	return &data, nil
+}
+
+// Bootstrap creates a snapshot seed plus replay anchor.
+func (c *Client) Bootstrap(ctx context.Context, attachment *syncstate.Attachment) (*apispec.VolumeSyncBootstrap, error) {
+	req := apispec.NewOptCreateVolumeSyncBootstrapRequest(apispec.CreateVolumeSyncBootstrapRequest{
+		Capabilities: apispec.NewOptVolumeSyncFilesystemCapabilities(toSDKCapabilities(attachment.Capabilities)),
+	})
+	res, err := c.sdk.API().APIV1SandboxvolumesIDSyncBootstrapPost(ctx, req, apispec.APIV1SandboxvolumesIDSyncBootstrapPostParams{
+		ID: attachment.VolumeID,
+	})
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	success, ok := res.(*apispec.SuccessVolumeSyncBootstrapResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected bootstrap response type %T", res)
+	}
+	data, ok := success.Data.Get()
+	if !ok {
+		return nil, errors.New("sync bootstrap response missing data")
+	}
+	return &data, nil
+}
+
+// DownloadBootstrapArchive downloads the tar.gz archive bytes for one bootstrap snapshot.
+func (c *Client) DownloadBootstrapArchive(ctx context.Context, volumeID, snapshotID string) ([]byte, error) {
+	res, err := c.sdk.API().APIV1SandboxvolumesIDSyncBootstrapArchiveGet(ctx, apispec.APIV1SandboxvolumesIDSyncBootstrapArchiveGetParams{
+		ID:         volumeID,
+		SnapshotID: snapshotID,
+	})
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	okRes, ok := res.(*apispec.APIV1SandboxvolumesIDSyncBootstrapArchiveGetOK)
+	if !ok {
+		return nil, fmt.Errorf("unexpected bootstrap archive response type %T", res)
+	}
+	return ioReadAll(okRes.Data)
+}
+
+// ListChanges lists journal entries after one known sequence.
+func (c *Client) ListChanges(ctx context.Context, volumeID string, after int64, limit int32) (*apispec.ListVolumeSyncChangesResponse, error) {
+	params := apispec.APIV1SandboxvolumesIDSyncChangesGetParams{
+		ID:    volumeID,
+		After: apispec.NewOptInt64(after),
+		Limit: apispec.NewOptInt32(limitOrDefault(limit)),
+	}
+	res, err := c.sdk.API().APIV1SandboxvolumesIDSyncChangesGet(ctx, params)
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	success, ok := res.(*apispec.SuccessVolumeSyncChangeListResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected change list response type %T", res)
+	}
+	data, ok := success.Data.Get()
+	if !ok {
+		return nil, errors.New("sync change list response missing data")
+	}
+	return &data, nil
+}
+
+// AppendChanges pushes one replica mutation batch.
+func (c *Client) AppendChanges(ctx context.Context, attachment *syncstate.Attachment, baseSeq int64, requestID string, changes []apispec.ChangeRequest) (*apispec.AppendReplicaChangesResponse, error) {
+	req := &apispec.AppendReplicaChangesRequest{
+		RequestID: requestID,
+		BaseSeq:   baseSeq,
+		Changes:   changes,
+	}
+	res, err := c.sdk.API().APIV1SandboxvolumesIDSyncReplicasReplicaIDChangesPost(ctx, req, apispec.APIV1SandboxvolumesIDSyncReplicasReplicaIDChangesPostParams{
+		ID:        attachment.VolumeID,
+		ReplicaID: attachment.ReplicaID,
+	})
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	success, ok := res.(*apispec.SuccessVolumeSyncAppendResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected append response type %T", res)
+	}
+	data, ok := success.Data.Get()
+	if !ok {
+		return nil, errors.New("sync append response missing data")
+	}
+	return &data, nil
+}
+
+// UpdateCursor persists the highest fully applied sequence for this replica.
+func (c *Client) UpdateCursor(ctx context.Context, attachment *syncstate.Attachment, lastAppliedSeq int64) (*apispec.VolumeSyncReplicaEnvelope, error) {
+	req := &apispec.UpdateSyncReplicaCursorRequest{LastAppliedSeq: lastAppliedSeq}
+	res, err := c.sdk.API().APIV1SandboxvolumesIDSyncReplicasReplicaIDCursorPut(ctx, req, apispec.APIV1SandboxvolumesIDSyncReplicasReplicaIDCursorPutParams{
+		ID:        attachment.VolumeID,
+		ReplicaID: attachment.ReplicaID,
+	})
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	success, ok := res.(*apispec.SuccessVolumeSyncReplicaResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected cursor response type %T", res)
+	}
+	data, ok := success.Data.Get()
+	if !ok {
+		return nil, errors.New("sync cursor response missing data")
+	}
+	return &data, nil
+}
+
+// ListConflicts lists conflicts for one volume.
+func (c *Client) ListConflicts(ctx context.Context, volumeID, status string, limit int32) ([]apispec.SyncConflict, error) {
+	params := apispec.APIV1SandboxvolumesIDSyncConflictsGetParams{
+		ID:    volumeID,
+		Limit: apispec.NewOptInt32(limitOrDefault(limit)),
+	}
+	if status != "" {
+		params.Status = apispec.NewOptString(status)
+	}
+	resp, err := c.sdk.API().APIV1SandboxvolumesIDSyncConflictsGet(ctx, params)
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	data, ok := resp.Data.Get()
+	if !ok {
+		return nil, nil
+	}
+	return data.Conflicts, nil
+}
+
+// ResolveConflict marks one conflict as resolved or ignored.
+func (c *Client) ResolveConflict(ctx context.Context, volumeID, conflictID string, ignored bool) (*apispec.SyncConflict, error) {
+	status := apispec.ResolveVolumeSyncConflictRequestStatusResolved
+	if ignored {
+		status = apispec.ResolveVolumeSyncConflictRequestStatusIgnored
+	}
+	req := &apispec.ResolveVolumeSyncConflictRequest{Status: status}
+	res, err := c.sdk.API().APIV1SandboxvolumesIDSyncConflictsConflictIDPut(ctx, req, apispec.APIV1SandboxvolumesIDSyncConflictsConflictIDPutParams{
+		ID:         volumeID,
+		ConflictID: conflictID,
+	})
+	if err != nil {
+		return nil, classifySyncError(err)
+	}
+	success, ok := res.(*apispec.SuccessVolumeSyncConflictResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected conflict resolution response type %T", res)
+	}
+	data, ok := success.Data.Get()
+	if !ok {
+		return nil, errors.New("sync conflict response missing data")
+	}
+	return &data, nil
+}
+
+func classifySyncError(err error) error {
+	var apiErr *syncsdk.APIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+
+	if reseed := parseReseedRequired(apiErr); reseed != nil {
+		return reseed
+	}
+	if bootstrap := parseBootstrapConflict(apiErr); bootstrap != nil {
+		return bootstrap
+	}
+	return err
+}
+
+func parseReseedRequired(apiErr *syncsdk.APIError) *ReseedRequiredError {
+	if apiErr == nil {
+		return nil
+	}
+	if apiErr.Code != "conflict" && apiErr.Code != "invalid_request" {
+		// storage-proxy currently uses the generic conflict envelope here.
+	}
+	details := &apispec.VolumeSyncReseedRequiredDetails{}
+	if !decodeAPIErrorDetails(apiErr, details) || details.Reason != apispec.VolumeSyncReseedRequiredDetailsReasonReseedRequired {
+		return nil
+	}
+	return &ReseedRequiredError{
+		RetainedAfterSeq: details.RetainedAfterSeq,
+		HeadSeq:          details.HeadSeq,
+		Message:          apiErr.Message,
+	}
+}
+
+func parseBootstrapConflict(apiErr *syncsdk.APIError) *BootstrapCompatibilityError {
+	if apiErr == nil {
+		return nil
+	}
+	details := &apispec.VolumeSyncBootstrapCompatibilityConflictDetails{}
+	if !decodeAPIErrorDetails(apiErr, details) || details.Reason != apispec.VolumeSyncBootstrapCompatibilityConflictDetailsReasonNamespaceIncompatible {
+		return nil
+	}
+	return &BootstrapCompatibilityError{
+		Message: apiErr.Message,
+		Details: details,
+	}
+}
+
+func decodeAPIErrorDetails(apiErr *syncsdk.APIError, target any) bool {
+	if apiErr == nil || target == nil {
+		return false
+	}
+	if apiErr.Details != nil {
+		if raw, err := json.Marshal(apiErr.Details); err == nil && len(raw) > 0 && json.Unmarshal(raw, target) == nil {
+			return true
+		}
+	}
+	if len(apiErr.Body) == 0 {
+		return false
+	}
+	var envelope struct {
+		Error struct {
+			Details json.RawMessage `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(apiErr.Body, &envelope); err != nil || len(envelope.Error.Details) == 0 {
+		return false
+	}
+	return json.Unmarshal(envelope.Error.Details, target) == nil
+}
+
+func displayNameFor(attachment *syncstate.Attachment) string {
+	if attachment == nil {
+		return ""
+	}
+	if attachment.DisplayName != "" {
+		return attachment.DisplayName
+	}
+	return attachment.ReplicaID
+}
+
+func toSDKCapabilities(caps syncstate.FilesystemCaps) apispec.VolumeSyncFilesystemCapabilities {
+	return apispec.VolumeSyncFilesystemCapabilities{
+		CaseSensitive:                   caps.CaseSensitive,
+		UnicodeNormalizationInsensitive: caps.UnicodeNormalizationInsensitive,
+		WindowsCompatiblePaths:          caps.WindowsCompatiblePaths,
+	}
+}
+
+func limitOrDefault(limit int32) int32 {
+	if limit <= 0 {
+		return defaultChangeLimit
+	}
+	return limit
+}
+
+func ioReadAll(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
+	return io.ReadAll(r)
+}

--- a/internal/syncignore/gitignore.go
+++ b/internal/syncignore/gitignore.go
@@ -1,0 +1,214 @@
+package syncignore
+
+import (
+	"bufio"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Matcher evaluates root-level .gitignore rules for local upload filtering.
+type Matcher struct {
+	rules []rule
+}
+
+type rule struct {
+	baseDir  string
+	negated  bool
+	dirOnly  bool
+	anchored bool
+	pattern  string
+	matcher  *regexp.Regexp
+	basename bool
+}
+
+// Load reads root and nested .gitignore rules plus .git/info/exclude when present.
+func Load(workspaceRoot string) (*Matcher, error) {
+	matcher := &Matcher{}
+	root := strings.ReplaceAll(workspaceRoot, "\\", "/")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		return nil, err
+	}
+
+	for _, relative := range []string{".gitignore", ".git/info/exclude"} {
+		if err := loadRuleFile(matcher, root, relative); err != nil {
+			return nil, err
+		}
+	}
+
+	var ignoreFiles []string
+	err := filepath.WalkDir(workspaceRoot, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() && entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() || entry.Name() != ".gitignore" || current == filepath.Join(workspaceRoot, ".gitignore") {
+			return nil
+		}
+		relative, err := filepath.Rel(workspaceRoot, current)
+		if err != nil {
+			return err
+		}
+		ignoreFiles = append(ignoreFiles, filepath.ToSlash(relative))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(ignoreFiles)
+	for _, relative := range ignoreFiles {
+		if err := loadRuleFile(matcher, root, relative); err != nil {
+			return nil, err
+		}
+	}
+	return matcher, nil
+}
+
+// Match reports whether a relative workspace path should be ignored for local uploads.
+func (m *Matcher) Match(relativePath string, isDir bool) bool {
+	relativePath = normalizePath(relativePath)
+	if relativePath == "" || relativePath == "." {
+		return false
+	}
+
+	ignored := false
+	for _, rule := range m.rules {
+		if rule.matches(relativePath) {
+			ignored = !rule.negated
+		}
+	}
+	return ignored
+}
+
+func parseRule(line string) (rule, bool) {
+	parsed := rule{}
+	if strings.HasPrefix(line, "!") {
+		parsed.negated = true
+		line = strings.TrimSpace(strings.TrimPrefix(line, "!"))
+	}
+	if line == "" {
+		return rule{}, false
+	}
+
+	if strings.HasPrefix(line, "/") {
+		parsed.anchored = true
+		line = strings.TrimPrefix(line, "/")
+	}
+	if strings.HasSuffix(line, "/") {
+		parsed.dirOnly = true
+		line = strings.TrimSuffix(line, "/")
+	}
+	line = normalizePath(line)
+	if line == "" {
+		return rule{}, false
+	}
+	parsed.pattern = line
+	parsed.basename = !strings.Contains(line, "/")
+
+	re, err := regexp.Compile(buildPatternRegex(line, parsed.basename, parsed.dirOnly, parsed.anchored))
+	if err != nil {
+		return rule{}, false
+	}
+	parsed.matcher = re
+	return parsed, true
+}
+
+func (r rule) matches(relativePath string) bool {
+	if r.matcher == nil {
+		return false
+	}
+	if r.baseDir != "" {
+		if relativePath != r.baseDir && !strings.HasPrefix(relativePath, r.baseDir+"/") {
+			return false
+		}
+		relativePath = strings.TrimPrefix(strings.TrimPrefix(relativePath, r.baseDir), "/")
+	}
+	return r.matcher.MatchString(relativePath)
+}
+
+func buildPatternRegex(pattern string, basename, dirOnly, anchored bool) string {
+	var prefix string
+	switch {
+	case anchored:
+		prefix = `^`
+	case basename:
+		prefix = `(^|.*/)`
+	default:
+		prefix = `(^|.*/)`
+	}
+	var suffix string
+	if dirOnly {
+		suffix = `(/.*)?$`
+	} else {
+		suffix = `$`
+	}
+	return prefix + globToRegex(pattern) + suffix
+}
+
+func globToRegex(pattern string) string {
+	var builder strings.Builder
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				builder.WriteString(".*")
+				i++
+				continue
+			}
+			builder.WriteString(`[^/]*`)
+		case '?':
+			builder.WriteString(`[^/]`)
+		case '.', '+', '(', ')', '|', '^', '$', '{', '}', '[', ']', '\\':
+			builder.WriteByte('\\')
+			builder.WriteByte(pattern[i])
+		default:
+			builder.WriteByte(pattern[i])
+		}
+	}
+	return builder.String()
+}
+
+func normalizePath(value string) string {
+	value = strings.ReplaceAll(value, "\\", "/")
+	value = path.Clean(value)
+	if value == "." {
+		return ""
+	}
+	return strings.TrimPrefix(value, "./")
+}
+
+func loadRuleFile(matcher *Matcher, workspaceRoot, relativePath string) error {
+	file, err := os.Open(path.Join(workspaceRoot, relativePath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	baseDir := normalizePath(path.Dir(relativePath))
+	if relativePath == ".git/info/exclude" {
+		baseDir = ""
+	}
+	if baseDir == "." {
+		baseDir = ""
+	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if parsed, ok := parseRule(line); ok {
+			parsed.baseDir = baseDir
+			matcher.rules = append(matcher.rules, parsed)
+		}
+	}
+	return scanner.Err()
+}

--- a/internal/syncignore/gitignore_test.go
+++ b/internal/syncignore/gitignore_test.go
@@ -1,0 +1,88 @@
+package syncignore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMatcher(t *testing.T) {
+	root := t.TempDir()
+	content := "" +
+		"# comment\n" +
+		"*.log\n" +
+		"build/\n" +
+		"/root-only.txt\n" +
+		"!keep.log\n" +
+		"nested/cache/\n"
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	matcher, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	tests := []struct {
+		path    string
+		isDir   bool
+		ignored bool
+	}{
+		{path: "debug.log", ignored: true},
+		{path: "keep.log", ignored: false},
+		{path: "build", isDir: true, ignored: true},
+		{path: "build/output.txt", ignored: true},
+		{path: "root-only.txt", ignored: true},
+		{path: "nested/root-only.txt", ignored: false},
+		{path: "nested/cache", isDir: true, ignored: true},
+		{path: "nested/cache/data.bin", ignored: true},
+		{path: "src/main.go", ignored: false},
+	}
+
+	for _, tt := range tests {
+		if got := matcher.Match(tt.path, tt.isDir); got != tt.ignored {
+			t.Fatalf("Match(%q, %t) = %t, want %t", tt.path, tt.isDir, got, tt.ignored)
+		}
+	}
+}
+
+func TestMatcherLoadsNestedGitignoreAndInfoExclude(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "apps", "web"), 0o755); err != nil {
+		t.Fatalf("mkdir nested app: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0o755); err != nil {
+		t.Fatalf("mkdir .git/info: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "apps", ".gitignore"), []byte("dist/\n!dist/keep.txt\n"), 0o600); err != nil {
+		t.Fatalf("write nested .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "info", "exclude"), []byte("tmp/\n"), 0o600); err != nil {
+		t.Fatalf("write info exclude: %v", err)
+	}
+
+	matcher, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	tests := []struct {
+		path    string
+		isDir   bool
+		ignored bool
+	}{
+		{path: "apps/dist", isDir: true, ignored: true},
+		{path: "apps/dist/app.js", ignored: true},
+		{path: "apps/dist/keep.txt", ignored: false},
+		{path: "dist/app.js", ignored: false},
+		{path: "tmp", isDir: true, ignored: true},
+		{path: "tmp/cache.bin", ignored: true},
+	}
+
+	for _, tt := range tests {
+		if got := matcher.Match(tt.path, tt.isDir); got != tt.ignored {
+			t.Fatalf("Match(%q, %t) = %t, want %t", tt.path, tt.isDir, got, tt.ignored)
+		}
+	}
+}

--- a/internal/syncstate/syncstate.go
+++ b/internal/syncstate/syncstate.go
@@ -1,0 +1,584 @@
+package syncstate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	workerHeartbeatTTL = 8 * time.Second
+)
+
+// Attachment represents one local workspace bound to one Sandbox0 volume.
+type Attachment struct {
+	ID            string          `json:"id" yaml:"id"`
+	DisplayName   string          `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	WorkspaceRoot string          `json:"workspace_root" yaml:"workspace_root"`
+	VolumeID      string          `json:"volume_id" yaml:"volume_id"`
+	ReplicaID     string          `json:"replica_id" yaml:"replica_id"`
+	Platform      string          `json:"platform" yaml:"platform"`
+	Capabilities  FilesystemCaps  `json:"capabilities" yaml:"capabilities"`
+	InitFrom      string          `json:"init_from" yaml:"init_from"`
+	Ignore        IgnoreConfig    `json:"ignore" yaml:"ignore"`
+	Worker        WorkerState     `json:"worker" yaml:"worker"`
+	CreatedAt     time.Time       `json:"created_at" yaml:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at" yaml:"updated_at"`
+	LastError     string          `json:"last_error,omitempty" yaml:"last_error,omitempty"`
+	LastSync      *SyncCheckpoint `json:"last_sync,omitempty" yaml:"last_sync,omitempty"`
+}
+
+// IgnoreConfig stores built-in local ignore defaults for future sync worker phases.
+type IgnoreConfig struct {
+	BuiltinPatterns []string `json:"builtin_patterns" yaml:"builtin_patterns"`
+}
+
+// FilesystemCaps mirrors the server-side capability contract used during replica registration.
+type FilesystemCaps struct {
+	CaseSensitive                   bool `json:"case_sensitive" yaml:"case_sensitive"`
+	UnicodeNormalizationInsensitive bool `json:"unicode_normalization_insensitive" yaml:"unicode_normalization_insensitive"`
+	WindowsCompatiblePaths          bool `json:"windows_compatible_paths" yaml:"windows_compatible_paths"`
+}
+
+// WorkerState tracks the local worker process.
+type WorkerState struct {
+	Mode            string     `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Status          string     `json:"status,omitempty" yaml:"status,omitempty"`
+	PID             int        `json:"pid,omitempty" yaml:"pid,omitempty"`
+	LogPath         string     `json:"log_path,omitempty" yaml:"log_path,omitempty"`
+	LastStartedAt   *time.Time `json:"last_started_at,omitempty" yaml:"last_started_at,omitempty"`
+	LastStoppedAt   *time.Time `json:"last_stopped_at,omitempty" yaml:"last_stopped_at,omitempty"`
+	LastHeartbeatAt *time.Time `json:"last_heartbeat_at,omitempty" yaml:"last_heartbeat_at,omitempty"`
+}
+
+// SyncCheckpoint reserves the persisted shape for later sync phases.
+type SyncCheckpoint struct {
+	HeadSeq           int64      `json:"head_seq" yaml:"head_seq"`
+	LastAppliedSeq    int64      `json:"last_applied_seq" yaml:"last_applied_seq"`
+	LastSuccessAt     *time.Time `json:"last_success_at,omitempty" yaml:"last_success_at,omitempty"`
+	LastFailureAt     *time.Time `json:"last_failure_at,omitempty" yaml:"last_failure_at,omitempty"`
+	LastReplicaSyncAt *time.Time `json:"last_replica_sync_at,omitempty" yaml:"last_replica_sync_at,omitempty"`
+	ConsecutiveErrors int        `json:"consecutive_errors" yaml:"consecutive_errors"`
+	ReseedRequired    bool       `json:"reseed_required" yaml:"reseed_required"`
+	OpenConflictCount int        `json:"open_conflict_count" yaml:"open_conflict_count"`
+}
+
+// Manifest stores the last uploaded local filesystem snapshot for delta generation.
+type Manifest struct {
+	Entries map[string]ManifestEntry `json:"entries" yaml:"entries"`
+}
+
+// ManifestEntry stores one logical workspace entry in slash-separated form.
+type ManifestEntry struct {
+	Path   string `json:"path" yaml:"path"`
+	Kind   string `json:"kind" yaml:"kind"`
+	Mode   uint32 `json:"mode" yaml:"mode"`
+	Size   int64  `json:"size" yaml:"size"`
+	SHA256 string `json:"sha256,omitempty" yaml:"sha256,omitempty"`
+}
+
+// NewAttachment builds the initial persisted attachment record.
+func NewAttachment(workspaceRoot, volumeID, displayName, initFrom string) (*Attachment, error) {
+	root, err := canonicalPath(workspaceRoot)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	id := attachmentID(root)
+	return &Attachment{
+		ID:            id,
+		DisplayName:   strings.TrimSpace(displayName),
+		WorkspaceRoot: root,
+		VolumeID:      strings.TrimSpace(volumeID),
+		ReplicaID:     replicaID(root),
+		Platform:      runtime.GOOS,
+		Capabilities:  defaultCapabilities(runtime.GOOS),
+		InitFrom:      normalizeInitFrom(initFrom),
+		Ignore: IgnoreConfig{
+			BuiltinPatterns: DefaultIgnorePatterns(),
+		},
+		Worker: WorkerState{
+			Status:  "stopped",
+			LogPath: logPath(id),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		LastSync:  &SyncCheckpoint{},
+	}, nil
+}
+
+// DefaultIgnorePatterns returns built-in local-only patterns reserved for future phases.
+func DefaultIgnorePatterns() []string {
+	return []string{
+		".git/",
+	}
+}
+
+// ListAttachments returns all persisted attachments sorted by workspace root.
+func ListAttachments() ([]Attachment, error) {
+	dir, err := attachmentsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	attachments := make([]Attachment, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		attachment, err := LoadAttachmentByID(strings.TrimSuffix(entry.Name(), ".json"))
+		if err != nil {
+			return nil, err
+		}
+		attachments = append(attachments, *attachment)
+	}
+
+	slices.SortFunc(attachments, func(a, b Attachment) int {
+		return strings.Compare(a.WorkspaceRoot, b.WorkspaceRoot)
+	})
+	return attachments, nil
+}
+
+// LoadAttachmentByID loads one attachment record by ID.
+func LoadAttachmentByID(id string) (*Attachment, error) {
+	data, err := os.ReadFile(attachmentPath(id))
+	if err != nil {
+		return nil, err
+	}
+	var attachment Attachment
+	if err := json.Unmarshal(data, &attachment); err != nil {
+		return nil, err
+	}
+	return &attachment, nil
+}
+
+// SaveAttachment persists one attachment atomically.
+func SaveAttachment(attachment *Attachment) error {
+	if attachment == nil {
+		return errors.New("attachment is nil")
+	}
+	dir, err := attachmentsDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	attachment.UpdatedAt = time.Now().UTC()
+	payload, err := json.MarshalIndent(attachment, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := attachmentPath(attachment.ID)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, payload, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// UpdateAttachment loads, mutates, and persists one attachment atomically enough for the local worker.
+func UpdateAttachment(id string, update func(*Attachment) error) (*Attachment, error) {
+	if update == nil {
+		return nil, errors.New("update function is nil")
+	}
+	attachment, err := LoadAttachmentByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if attachment.LastSync == nil {
+		attachment.LastSync = &SyncCheckpoint{}
+	}
+	if err := update(attachment); err != nil {
+		return nil, err
+	}
+	if err := SaveAttachment(attachment); err != nil {
+		return nil, err
+	}
+	return attachment, nil
+}
+
+// DeleteAttachment removes one attachment record.
+func DeleteAttachment(id string) error {
+	err := os.Remove(attachmentPath(id))
+	if errors.Is(err, os.ErrNotExist) {
+		return DeleteManifest(id)
+	}
+	if err != nil {
+		return err
+	}
+	return DeleteManifest(id)
+}
+
+// ResolveAttachmentTarget resolves either an explicit target or the current directory.
+func ResolveAttachmentTarget(target, cwd string) (*Attachment, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ResolveAttachmentFromPath(cwd)
+	}
+
+	if attachment, err := ResolveAttachmentFromPath(target); err == nil {
+		return attachment, nil
+	}
+
+	matches, err := findByVolumeID(target)
+	if err != nil {
+		return nil, err
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no attached workspace found for %q", target)
+	case 1:
+		return &matches[0], nil
+	default:
+		return nil, fmt.Errorf("volume %q is attached to multiple local workspaces; use an explicit path", target)
+	}
+}
+
+// ResolveAttachmentFromPath finds the nearest attached ancestor for the given path.
+func ResolveAttachmentFromPath(path string) (*Attachment, error) {
+	root, err := canonicalPath(path)
+	if err != nil {
+		return nil, err
+	}
+	attachments, err := ListAttachments()
+	if err != nil {
+		return nil, err
+	}
+	var selected *Attachment
+	for _, attachment := range attachments {
+		if !isAncestorPath(attachment.WorkspaceRoot, root) {
+			continue
+		}
+		clone := attachment
+		if selected == nil || len(clone.WorkspaceRoot) > len(selected.WorkspaceRoot) {
+			selected = &clone
+		}
+	}
+	if selected == nil {
+		return nil, fmt.Errorf("current directory is not inside an attached workspace")
+	}
+	return selected, nil
+}
+
+// EffectiveStatus returns the worker state label after stale-heartbeat detection.
+func EffectiveStatus(attachment *Attachment) string {
+	if attachment == nil {
+		return "unknown"
+	}
+	status := strings.TrimSpace(attachment.Worker.Status)
+	if status == "" {
+		status = "stopped"
+	}
+	if status == "running" && heartbeatExpired(attachment.Worker.LastHeartbeatAt) {
+		return "stale"
+	}
+	return status
+}
+
+// SyncHealth returns the latest persisted sync health independent from worker liveness.
+func SyncHealth(attachment *Attachment) string {
+	if attachment == nil {
+		return "unknown"
+	}
+	if attachment.LastSync == nil {
+		return "idle"
+	}
+	switch {
+	case attachment.LastSync.ReseedRequired:
+		return "reseed_required"
+	case attachment.LastSync.ConsecutiveErrors > 0 && strings.TrimSpace(attachment.LastError) != "":
+		return "error"
+	case attachment.LastSync.LastSuccessAt != nil:
+		return "ok"
+	default:
+		return "idle"
+	}
+}
+
+// TouchWorkerHeartbeat updates the worker heartbeat fields on one attachment.
+func TouchWorkerHeartbeat(attachmentID, mode string, pid int) (*Attachment, error) {
+	attachment, err := LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	attachment.Worker.Mode = strings.TrimSpace(mode)
+	attachment.Worker.Status = "running"
+	attachment.Worker.PID = pid
+	if attachment.Worker.LastStartedAt == nil {
+		attachment.Worker.LastStartedAt = &now
+	}
+	attachment.Worker.LastHeartbeatAt = &now
+	attachment.LastError = ""
+	if err := SaveAttachment(attachment); err != nil {
+		return nil, err
+	}
+	return attachment, nil
+}
+
+// MarkWorkerStarted sets the worker start metadata.
+func MarkWorkerStarted(attachmentID, mode string, pid int) (*Attachment, error) {
+	attachment, err := LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	attachment.Worker.Mode = strings.TrimSpace(mode)
+	attachment.Worker.Status = "running"
+	attachment.Worker.PID = pid
+	attachment.Worker.LastStartedAt = &now
+	attachment.Worker.LastHeartbeatAt = &now
+	attachment.LastError = ""
+	if err := SaveAttachment(attachment); err != nil {
+		return nil, err
+	}
+	return attachment, nil
+}
+
+// MarkWorkerStopped updates the worker state after a clean shutdown.
+func MarkWorkerStopped(attachmentID string, workerErr error) (*Attachment, error) {
+	attachment, err := LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	attachment.Worker.PID = 0
+	attachment.Worker.Status = "stopped"
+	attachment.Worker.LastStoppedAt = &now
+	if workerErr != nil {
+		attachment.LastError = workerErr.Error()
+	}
+	if err := SaveAttachment(attachment); err != nil {
+		return nil, err
+	}
+	return attachment, nil
+}
+
+// ResetWorkerState prepares one attachment for local worker takeover after stale or crashed state.
+func ResetWorkerState(attachmentID string) (*Attachment, error) {
+	return UpdateAttachment(attachmentID, func(attachment *Attachment) error {
+		now := time.Now().UTC()
+		attachment.Worker.Status = "stopped"
+		attachment.Worker.PID = 0
+		attachment.Worker.LastStoppedAt = &now
+		return nil
+	})
+}
+
+// attachmentPath returns the JSON record path for one attachment.
+func attachmentPath(id string) string {
+	return filepath.Join(rootDir(), "attachments", id+".json")
+}
+
+// LogPath returns the persisted log file path for one attachment.
+func LogPath(id string) string {
+	return logPath(id)
+}
+
+// LoadManifest loads the last local manifest snapshot for one attachment.
+func LoadManifest(id string) (*Manifest, error) {
+	data, err := os.ReadFile(manifestPath(id))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Manifest{Entries: map[string]ManifestEntry{}}, nil
+		}
+		return nil, err
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest.Entries == nil {
+		manifest.Entries = map[string]ManifestEntry{}
+	}
+	return &manifest, nil
+}
+
+// SaveManifest persists one manifest atomically.
+func SaveManifest(id string, manifest *Manifest) error {
+	if manifest == nil {
+		return errors.New("manifest is nil")
+	}
+	if manifest.Entries == nil {
+		manifest.Entries = map[string]ManifestEntry{}
+	}
+	dir := filepath.Join(rootDir(), "manifests")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := manifestPath(id)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, payload, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// DeleteManifest removes one manifest file.
+func DeleteManifest(id string) error {
+	err := os.Remove(manifestPath(id))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// EnsureLogDir prepares the log directory on disk.
+func EnsureLogDir() error {
+	return os.MkdirAll(filepath.Join(rootDir(), "logs"), 0o755)
+}
+
+func logPath(id string) string {
+	return filepath.Join(rootDir(), "logs", id+".log")
+}
+
+func manifestPath(id string) string {
+	return filepath.Join(rootDir(), "manifests", id+".json")
+}
+
+func attachmentsDir() (string, error) {
+	dir := filepath.Join(rootDir(), "attachments")
+	return dir, nil
+}
+
+func rootDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".s0", "sync")
+	}
+	return filepath.Join(home, ".s0", "sync")
+}
+
+func findByVolumeID(volumeID string) ([]Attachment, error) {
+	attachments, err := ListAttachments()
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]Attachment, 0, 1)
+	for _, attachment := range attachments {
+		if attachment.VolumeID == strings.TrimSpace(volumeID) {
+			matches = append(matches, attachment)
+		}
+	}
+	return matches, nil
+}
+
+func canonicalPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return absolute, nil
+		}
+		return "", err
+	}
+	return resolved, nil
+}
+
+func attachmentID(workspaceRoot string) string {
+	sum := sha256.Sum256([]byte(workspaceRoot))
+	return hex.EncodeToString(sum[:8])
+}
+
+func replicaID(workspaceRoot string) string {
+	host, _ := os.Hostname()
+	host = sanitizeLabel(host)
+	if host == "" {
+		host = "local"
+	}
+	return fmt.Sprintf("s0-%s-%s", host, attachmentID(workspaceRoot))
+}
+
+func normalizeInitFrom(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "volume", "local":
+		return strings.ToLower(strings.TrimSpace(value))
+	default:
+		return "auto"
+	}
+}
+
+func sanitizeLabel(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-' || r == '_':
+			builder.WriteRune('-')
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func defaultCapabilities(platform string) FilesystemCaps {
+	switch strings.ToLower(strings.TrimSpace(platform)) {
+	case "windows":
+		return FilesystemCaps{
+			CaseSensitive:                   false,
+			UnicodeNormalizationInsensitive: true,
+			WindowsCompatiblePaths:          true,
+		}
+	case "darwin", "macos":
+		return FilesystemCaps{
+			CaseSensitive:                   false,
+			UnicodeNormalizationInsensitive: true,
+			WindowsCompatiblePaths:          false,
+		}
+	default:
+		return FilesystemCaps{
+			CaseSensitive:                   true,
+			UnicodeNormalizationInsensitive: false,
+			WindowsCompatiblePaths:          false,
+		}
+	}
+}
+
+func isAncestorPath(root, path string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if root == path {
+		return true
+	}
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func heartbeatExpired(lastHeartbeat *time.Time) bool {
+	if lastHeartbeat == nil {
+		return true
+	}
+	return time.Since(*lastHeartbeat) > workerHeartbeatTTL
+}

--- a/internal/syncstate/syncstate_test.go
+++ b/internal/syncstate/syncstate_test.go
@@ -1,0 +1,139 @@
+package syncstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestResolveAttachmentFromPathSelectsNearestAncestor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, "work", "repo")
+	child := filepath.Join(root, "apps", "dashboard")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	parentAttachment, err := NewAttachment(root, "vol-parent", "repo", "auto")
+	if err != nil {
+		t.Fatalf("NewAttachment(parent) error = %v", err)
+	}
+	if err := SaveAttachment(parentAttachment); err != nil {
+		t.Fatalf("SaveAttachment(parent) error = %v", err)
+	}
+
+	childAttachment, err := NewAttachment(child, "vol-child", "dashboard", "auto")
+	if err != nil {
+		t.Fatalf("NewAttachment(child) error = %v", err)
+	}
+	if err := SaveAttachment(childAttachment); err != nil {
+		t.Fatalf("SaveAttachment(child) error = %v", err)
+	}
+
+	nested := filepath.Join(child, "src")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll(nested) error = %v", err)
+	}
+
+	resolved, err := ResolveAttachmentFromPath(nested)
+	if err != nil {
+		t.Fatalf("ResolveAttachmentFromPath() error = %v", err)
+	}
+	if resolved.ID != childAttachment.ID {
+		t.Fatalf("ResolveAttachmentFromPath() id = %q, want %q", resolved.ID, childAttachment.ID)
+	}
+}
+
+func TestResolveAttachmentTargetFallsBackToVolumeID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, "work", "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	attachment, err := NewAttachment(root, "vol-1", "repo", "auto")
+	if err != nil {
+		t.Fatalf("NewAttachment() error = %v", err)
+	}
+	if err := SaveAttachment(attachment); err != nil {
+		t.Fatalf("SaveAttachment() error = %v", err)
+	}
+
+	resolved, err := ResolveAttachmentTarget("vol-1", home)
+	if err != nil {
+		t.Fatalf("ResolveAttachmentTarget() error = %v", err)
+	}
+	if resolved.ID != attachment.ID {
+		t.Fatalf("ResolveAttachmentTarget() id = %q, want %q", resolved.ID, attachment.ID)
+	}
+}
+
+func TestEffectiveStatusMarksStaleHeartbeat(t *testing.T) {
+	attachment, err := NewAttachment(t.TempDir(), "vol-1", "", "auto")
+	if err != nil {
+		t.Fatalf("NewAttachment() error = %v", err)
+	}
+
+	attachment.Worker.Status = "running"
+	if got := EffectiveStatus(attachment); got != "stale" {
+		t.Fatalf("EffectiveStatus() = %q, want stale", got)
+	}
+}
+
+func TestSyncHealthReportsReseedAndErrorStates(t *testing.T) {
+	attachment, err := NewAttachment(t.TempDir(), "vol-1", "", "auto")
+	if err != nil {
+		t.Fatalf("NewAttachment() error = %v", err)
+	}
+	now := time.Now().UTC()
+	attachment.Worker.Status = "running"
+	attachment.Worker.LastHeartbeatAt = &now
+	attachment.LastSync.ReseedRequired = true
+	if got := SyncHealth(attachment); got != "reseed_required" {
+		t.Fatalf("SyncHealth() = %q, want reseed_required", got)
+	}
+
+	attachment.LastSync.ReseedRequired = false
+	attachment.LastSync.ConsecutiveErrors = 2
+	attachment.LastError = "boom"
+	if got := SyncHealth(attachment); got != "error" {
+		t.Fatalf("SyncHealth() = %q, want error", got)
+	}
+}
+
+func TestResetWorkerStateStopsRunningAttachment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	attachment, err := NewAttachment(filepath.Join(home, "work"), "vol-1", "", "auto")
+	if err != nil {
+		t.Fatalf("NewAttachment() error = %v", err)
+	}
+	now := time.Now().UTC()
+	attachment.Worker.Status = "running"
+	attachment.Worker.Mode = "background"
+	attachment.Worker.PID = 12345
+	attachment.Worker.LastHeartbeatAt = &now
+	if err := SaveAttachment(attachment); err != nil {
+		t.Fatalf("SaveAttachment() error = %v", err)
+	}
+
+	reset, err := ResetWorkerState(attachment.ID)
+	if err != nil {
+		t.Fatalf("ResetWorkerState() error = %v", err)
+	}
+	if reset.Worker.Status != "stopped" {
+		t.Fatalf("Worker.Status = %q, want stopped", reset.Worker.Status)
+	}
+	if reset.Worker.PID != 0 {
+		t.Fatalf("Worker.PID = %d, want 0", reset.Worker.PID)
+	}
+	if reset.Worker.LastStoppedAt == nil {
+		t.Fatalf("Worker.LastStoppedAt = nil, want value")
+	}
+}

--- a/internal/syncview/view.go
+++ b/internal/syncview/view.go
@@ -3,6 +3,8 @@ package syncview
 import (
 	"encoding/json"
 	"fmt"
+	pathpkg "path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -339,11 +341,25 @@ func conflictPrimaryPath(conflict apispec.SyncConflict) string {
 		optNilString(conflict.IncomingPath),
 		optNilString(conflict.IncomingOldPath),
 	} {
-		if strings.TrimSpace(candidate) != "" {
-			return strings.TrimSpace(candidate)
+		if normalized := normalizeConflictPath(candidate); normalized != "" {
+			return normalized
 		}
 	}
 	return "-"
+}
+
+func normalizeConflictPath(path string) string {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	if path == "" {
+		return ""
+	}
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimPrefix(path, "./")
+	path = pathpkg.Clean(path)
+	if path == "." || path == "/" {
+		return ""
+	}
+	return path
 }
 
 func decodeConflictMetadata(conflict apispec.SyncConflict) conflictMetadata {

--- a/internal/syncview/view.go
+++ b/internal/syncview/view.go
@@ -1,0 +1,420 @@
+package syncview
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+const DefaultStatusSummaryLimit = 5
+
+// StatusView renders attachment state plus a short Git-like conflict summary.
+type StatusView struct {
+	Attachment         *syncstate.Attachment `json:"attachment" yaml:"attachment"`
+	ConflictSummary    *ConflictListView     `json:"conflict_summary,omitempty" yaml:"conflict_summary,omitempty"`
+	ConflictQueryError string                `json:"conflict_query_error,omitempty" yaml:"conflict_query_error,omitempty"`
+}
+
+// ConflictListView renders unresolved conflicts grouped around logical paths.
+type ConflictListView struct {
+	WorkspaceRoot string              `json:"workspace_root,omitempty" yaml:"workspace_root,omitempty"`
+	VolumeID      string              `json:"volume_id,omitempty" yaml:"volume_id,omitempty"`
+	OpenCount     int                 `json:"open_count" yaml:"open_count"`
+	UnmergedPaths []ConflictListEntry `json:"unmerged_paths,omitempty" yaml:"unmerged_paths,omitempty"`
+	Remaining     int                 `json:"remaining,omitempty" yaml:"remaining,omitempty"`
+	Truncated     bool                `json:"truncated,omitempty" yaml:"truncated,omitempty"`
+}
+
+// ConflictListEntry is one path-centric summary row.
+type ConflictListEntry struct {
+	Path         string `json:"path" yaml:"path"`
+	Summary      string `json:"summary" yaml:"summary"`
+	ReasonCode   string `json:"reason_code" yaml:"reason_code"`
+	Status       string `json:"status" yaml:"status"`
+	ArtifactPath string `json:"artifact_path,omitempty" yaml:"artifact_path,omitempty"`
+}
+
+// ConflictDetailView renders one conflict with operator-focused context.
+type ConflictDetailView struct {
+	ID                  string     `json:"id,omitempty" yaml:"id,omitempty"`
+	Path                string     `json:"path" yaml:"path"`
+	Summary             string     `json:"summary" yaml:"summary"`
+	ReasonCode          string     `json:"reason_code" yaml:"reason_code"`
+	Status              string     `json:"status" yaml:"status"`
+	RecordedFor         string     `json:"recorded_for,omitempty" yaml:"recorded_for,omitempty"`
+	CompatibilityImpact string     `json:"compatibility_impact,omitempty" yaml:"compatibility_impact,omitempty"`
+	NormalizedPath      string     `json:"normalized_path,omitempty" yaml:"normalized_path,omitempty"`
+	ArtifactPath        string     `json:"artifact_path,omitempty" yaml:"artifact_path,omitempty"`
+	IncomingPath        string     `json:"incoming_path,omitempty" yaml:"incoming_path,omitempty"`
+	IncomingOldPath     string     `json:"incoming_old_path,omitempty" yaml:"incoming_old_path,omitempty"`
+	OtherPaths          []string   `json:"other_paths,omitempty" yaml:"other_paths,omitempty"`
+	ExistingSeq         *int64     `json:"existing_seq,omitempty" yaml:"existing_seq,omitempty"`
+	LatestRemoteActor   string     `json:"latest_remote_actor,omitempty" yaml:"latest_remote_actor,omitempty"`
+	LatestRemotePath    string     `json:"latest_remote_path,omitempty" yaml:"latest_remote_path,omitempty"`
+	LatestRemoteEvent   string     `json:"latest_remote_event,omitempty" yaml:"latest_remote_event,omitempty"`
+	IssueMessage        string     `json:"issue_message,omitempty" yaml:"issue_message,omitempty"`
+	Resolution          string     `json:"resolution,omitempty" yaml:"resolution,omitempty"`
+	Note                string     `json:"note,omitempty" yaml:"note,omitempty"`
+	ResolvedAt          string     `json:"resolved_at,omitempty" yaml:"resolved_at,omitempty"`
+	SuggestedNextStep   string     `json:"suggested_next_step" yaml:"suggested_next_step"`
+	CreatedAt           *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt           *time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+type conflictMetadata struct {
+	LatestSeq       *int64               `json:"latest_seq"`
+	LatestPath      string               `json:"latest_path"`
+	LatestEvent     string               `json:"latest_event"`
+	LatestSource    string               `json:"latest_source"`
+	LatestSandboxID string               `json:"latest_sandbox_id"`
+	LatestReplicaID string               `json:"latest_replica_id"`
+	LatestPlatform  string               `json:"latest_platform"`
+	BaseSeq         *int64               `json:"base_seq"`
+	Issues          []compatibilityIssue `json:"issues"`
+	Capabilities    *filesystemCaps      `json:"capabilities"`
+	Resolution      string               `json:"resolution"`
+	Note            string               `json:"note"`
+	ResolvedAt      string               `json:"resolved_at"`
+}
+
+type compatibilityIssue struct {
+	Code           string   `json:"code"`
+	Path           string   `json:"path"`
+	NormalizedPath string   `json:"normalized_path"`
+	Paths          []string `json:"paths"`
+	Segment        string   `json:"segment"`
+	Message        string   `json:"message"`
+}
+
+type filesystemCaps struct {
+	CaseSensitive                   bool `json:"case_sensitive"`
+	UnicodeNormalizationInsensitive bool `json:"unicode_normalization_insensitive"`
+	WindowsCompatiblePaths          bool `json:"windows_compatible_paths"`
+}
+
+// BuildStatusView combines local attachment state with a short live conflict summary.
+func BuildStatusView(attachment *syncstate.Attachment, conflicts []apispec.SyncConflict, queryErr error) *StatusView {
+	view := &StatusView{
+		Attachment: attachment,
+	}
+	if attachment == nil {
+		if queryErr != nil {
+			view.ConflictQueryError = queryErr.Error()
+		}
+		return view
+	}
+
+	if len(conflicts) > 0 {
+		view.ConflictSummary = BuildConflictListView(attachment, conflicts, DefaultStatusSummaryLimit)
+		return view
+	}
+
+	openCount := 0
+	if attachment.LastSync != nil {
+		openCount = attachment.LastSync.OpenConflictCount
+	}
+	if openCount > 0 {
+		view.ConflictSummary = &ConflictListView{
+			WorkspaceRoot: attachment.WorkspaceRoot,
+			VolumeID:      attachment.VolumeID,
+			OpenCount:     openCount,
+		}
+	}
+	if queryErr != nil && openCount > 0 {
+		view.ConflictQueryError = queryErr.Error()
+	}
+	return view
+}
+
+// BuildConflictListView creates a path-centric conflict listing. Set limit <= 0 to include all entries.
+func BuildConflictListView(attachment *syncstate.Attachment, conflicts []apispec.SyncConflict, limit int) *ConflictListView {
+	view := &ConflictListView{}
+	if attachment != nil {
+		view.WorkspaceRoot = attachment.WorkspaceRoot
+		view.VolumeID = attachment.VolumeID
+	}
+	if len(conflicts) == 0 {
+		return view
+	}
+
+	entries := make([]ConflictListEntry, 0, len(conflicts))
+	for _, conflict := range conflicts {
+		entries = append(entries, ConflictListEntry{
+			Path:         conflictPrimaryPath(conflict),
+			Summary:      conflictSummary(conflict, decodeConflictMetadata(conflict)),
+			ReasonCode:   optString(conflict.Reason),
+			Status:       optString(conflict.Status),
+			ArtifactPath: optString(conflict.ArtifactPath),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+
+	view.OpenCount = len(entries)
+	if limit > 0 && len(entries) > limit {
+		view.UnmergedPaths = entries[:limit]
+		view.Remaining = len(entries) - limit
+		view.Truncated = true
+		return view
+	}
+	view.UnmergedPaths = entries
+	return view
+}
+
+// BuildConflictDetailView creates an operator-focused detail view for one conflict.
+func BuildConflictDetailView(conflict *apispec.SyncConflict) *ConflictDetailView {
+	if conflict == nil {
+		return &ConflictDetailView{}
+	}
+
+	path := conflictPrimaryPath(*conflict)
+	metadata := decodeConflictMetadata(*conflict)
+	otherPaths := conflictOtherPaths(*conflict, metadata)
+	view := &ConflictDetailView{
+		ID:                  optString(conflict.ID),
+		Path:                path,
+		Summary:             conflictSummary(*conflict, metadata),
+		ReasonCode:          optString(conflict.Reason),
+		Status:              optString(conflict.Status),
+		RecordedFor:         recordedFor(*conflict),
+		CompatibilityImpact: compatibilityImpact(*conflict, metadata),
+		NormalizedPath:      optString(conflict.NormalizedPath),
+		ArtifactPath:        optString(conflict.ArtifactPath),
+		IncomingPath:        optNilString(conflict.IncomingPath),
+		IncomingOldPath:     optNilString(conflict.IncomingOldPath),
+		OtherPaths:          otherPaths,
+		ExistingSeq:         optNilInt64Ptr(conflict.ExistingSeq),
+		LatestRemoteActor:   remoteActorLabel(metadata),
+		LatestRemotePath:    metadata.LatestPath,
+		LatestRemoteEvent:   metadata.LatestEvent,
+		IssueMessage:        issueMessage(metadata),
+		Resolution:          strings.TrimSpace(metadata.Resolution),
+		Note:                strings.TrimSpace(metadata.Note),
+		ResolvedAt:          strings.TrimSpace(metadata.ResolvedAt),
+		SuggestedNextStep:   suggestedNextStep(*conflict, metadata),
+		CreatedAt:           optDateTimePtr(conflict.CreatedAt),
+		UpdatedAt:           optDateTimePtr(conflict.UpdatedAt),
+	}
+	return view
+}
+
+func conflictSummary(conflict apispec.SyncConflict, metadata conflictMetadata) string {
+	switch optString(conflict.Reason) {
+	case "concurrent_update":
+		return "modified locally, conflicted with " + remoteActorLabel(metadata)
+	case "case_only_rename_conflict":
+		return "case-only rename conflicted with " + remoteActorLabel(metadata)
+	case "casefold_collision":
+		return "casefold collision across portable replicas"
+	case "windows_reserved_name":
+		return "namespace incompatible for Windows-capable replicas"
+	case "windows_trailing_dot_space":
+		return "path ends with a dot or space and is incompatible for Windows-capable replicas"
+	case "windows_forbidden_character":
+		return "path contains a Windows-forbidden character"
+	case "windows_control_character":
+		return "path contains a Windows control character"
+	default:
+		return humanizeReason(optString(conflict.Reason))
+	}
+}
+
+func recordedFor(conflict apispec.SyncConflict) string {
+	replicaID := optNilString(conflict.ReplicaID)
+	if replicaID == "" {
+		return ""
+	}
+	return fmt.Sprintf("replica %q", replicaID)
+}
+
+func remoteActorLabel(metadata conflictMetadata) string {
+	switch strings.TrimSpace(metadata.LatestSource) {
+	case "sandbox":
+		if id := strings.TrimSpace(metadata.LatestSandboxID); id != "" {
+			return fmt.Sprintf("sandbox %q", id)
+		}
+		return "sandbox"
+	case "replica":
+		if id := strings.TrimSpace(metadata.LatestReplicaID); id != "" {
+			if platform := strings.TrimSpace(metadata.LatestPlatform); platform != "" {
+				return fmt.Sprintf("replica %q (%s)", id, platform)
+			}
+			return fmt.Sprintf("replica %q", id)
+		}
+		return "another replica"
+	default:
+		return "newer remote state"
+	}
+}
+
+func compatibilityImpact(conflict apispec.SyncConflict, metadata conflictMetadata) string {
+	switch optString(conflict.Reason) {
+	case "windows_reserved_name", "windows_trailing_dot_space", "windows_forbidden_character", "windows_control_character":
+		return "Windows-capable replicas cannot represent this path without repair."
+	case "casefold_collision":
+		return "Case-insensitive or Unicode-normalization-insensitive replicas may collapse multiple logical paths into one."
+	default:
+		if metadata.Capabilities != nil && metadata.Capabilities.WindowsCompatiblePaths {
+			return "Portable replicas may require namespace repair before this path can sync cleanly."
+		}
+		return ""
+	}
+}
+
+func conflictOtherPaths(conflict apispec.SyncConflict, metadata conflictMetadata) []string {
+	seen := map[string]struct{}{}
+	current := conflictPrimaryPath(conflict)
+	appendPath := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" || path == current {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+	}
+
+	if metadata.LatestPath != "" {
+		appendPath(metadata.LatestPath)
+	}
+	for _, issue := range metadata.Issues {
+		for _, path := range issue.Paths {
+			appendPath(path)
+		}
+	}
+
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func suggestedNextStep(conflict apispec.SyncConflict, metadata conflictMetadata) string {
+	path := conflictPrimaryPath(conflict)
+	switch optString(conflict.Status) {
+	case "resolved", "ignored":
+		return "No further conflict action is required. Continue syncing and verify the workspace state."
+	}
+
+	switch optString(conflict.Reason) {
+	case "concurrent_update", "case_only_rename_conflict":
+		if optString(conflict.ArtifactPath) != "" {
+			return fmt.Sprintf("Inspect %s, repair the canonical path locally, then run `s0 sync conflicts mark %s`.", optString(conflict.ArtifactPath), path)
+		}
+		return fmt.Sprintf("Inspect the current workspace path, repair the canonical state locally, then run `s0 sync conflicts mark %s`.", path)
+	case "casefold_collision":
+		return fmt.Sprintf("Choose one canonical path spelling, remove or rename the colliding path locally, then run `s0 sync conflicts mark %s`.", path)
+	case "windows_reserved_name", "windows_trailing_dot_space", "windows_forbidden_character", "windows_control_character":
+		return fmt.Sprintf("Rename or remove the incompatible path locally, then run `s0 sync conflicts mark %s`.", path)
+	default:
+		if metadata.Resolution != "" {
+			return "Conflict metadata already contains a recorded resolution state."
+		}
+		return fmt.Sprintf("Repair the path locally, then run `s0 sync conflicts mark %s`.", path)
+	}
+}
+
+func issueMessage(metadata conflictMetadata) string {
+	for _, issue := range metadata.Issues {
+		if strings.TrimSpace(issue.Message) != "" {
+			return strings.TrimSpace(issue.Message)
+		}
+	}
+	return ""
+}
+
+func conflictPrimaryPath(conflict apispec.SyncConflict) string {
+	for _, candidate := range []string{
+		optString(conflict.Path),
+		optNilString(conflict.IncomingPath),
+		optNilString(conflict.IncomingOldPath),
+	} {
+		if strings.TrimSpace(candidate) != "" {
+			return strings.TrimSpace(candidate)
+		}
+	}
+	return "-"
+}
+
+func decodeConflictMetadata(conflict apispec.SyncConflict) conflictMetadata {
+	value, ok := conflict.Metadata.Get()
+	if !ok || value == nil {
+		return conflictMetadata{}
+	}
+	raw := make(map[string]json.RawMessage, len(value))
+	for key, payload := range value {
+		if len(payload) == 0 {
+			continue
+		}
+		raw[key] = json.RawMessage(payload)
+	}
+	if len(raw) == 0 {
+		return conflictMetadata{}
+	}
+
+	var decoded conflictMetadata
+	if err := json.Unmarshal(mustMarshal(raw), &decoded); err != nil {
+		return conflictMetadata{}
+	}
+	return decoded
+}
+
+func mustMarshal(v any) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func humanizeReason(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return "unknown sync conflict"
+	}
+	reason = strings.ReplaceAll(reason, "_", " ")
+	return strings.ToUpper(reason[:1]) + reason[1:]
+}
+
+func optString(value apispec.OptString) string {
+	v, ok := value.Get()
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+func optNilString(value apispec.OptNilString) string {
+	v, ok := value.Get()
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+func optNilInt64Ptr(value apispec.OptNilInt64) *int64 {
+	v, ok := value.Get()
+	if !ok {
+		return nil
+	}
+	out := v
+	return &out
+}
+
+func optDateTimePtr(value apispec.OptDateTime) *time.Time {
+	v, ok := value.Get()
+	if !ok {
+		return nil
+	}
+	return &v
+}

--- a/internal/syncview/view_test.go
+++ b/internal/syncview/view_test.go
@@ -59,8 +59,36 @@ func TestBuildConflictListViewIncludesSandboxActorLabel(t *testing.T) {
 	if len(view.UnmergedPaths) != 1 {
 		t.Fatalf("len(UnmergedPaths) = %d, want 1", len(view.UnmergedPaths))
 	}
+	if got := view.UnmergedPaths[0].Path; got != "src/main.go" {
+		t.Fatalf("path = %q, want src/main.go", got)
+	}
 	if got := view.UnmergedPaths[0].Summary; got != `modified locally, conflicted with sandbox "sandbox-1"` {
 		t.Fatalf("summary = %q", got)
+	}
+}
+
+func TestBuildConflictListViewNormalizesLeadingSlashPaths(t *testing.T) {
+	attachment := &syncstate.Attachment{
+		WorkspaceRoot: "/tmp/work",
+		VolumeID:      "vol-123",
+	}
+	conflicts := []apispec.SyncConflict{
+		{
+			Path:   apispec.NewOptString("/conflict.txt"),
+			Reason: apispec.NewOptString("concurrent_update"),
+			Status: apispec.NewOptString("open"),
+			Metadata: apispec.NewOptNilSyncConflictMetadata(apispec.SyncConflictMetadata{
+				"latest_source": jx.Raw(`"sandbox"`),
+			}),
+		},
+	}
+
+	view := BuildConflictListView(attachment, conflicts, 0)
+	if len(view.UnmergedPaths) != 1 {
+		t.Fatalf("len(UnmergedPaths) = %d, want 1", len(view.UnmergedPaths))
+	}
+	if got := view.UnmergedPaths[0].Path; got != "conflict.txt" {
+		t.Fatalf("path = %q, want conflict.txt", got)
 	}
 }
 

--- a/internal/syncview/view_test.go
+++ b/internal/syncview/view_test.go
@@ -1,0 +1,135 @@
+package syncview
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-faster/jx"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func TestBuildConflictListViewSummarizesPortableConflict(t *testing.T) {
+	attachment := &syncstate.Attachment{
+		WorkspaceRoot: "/tmp/work",
+		VolumeID:      "vol-123",
+	}
+	conflicts := []apispec.SyncConflict{
+		{
+			Path:         apispec.NewOptString("docs/CON.txt"),
+			Reason:       apispec.NewOptString("windows_reserved_name"),
+			Status:       apispec.NewOptString("open"),
+			ArtifactPath: apispec.NewOptString(""),
+			Metadata: apispec.NewOptNilSyncConflictMetadata(apispec.SyncConflictMetadata{
+				"issues": jx.Raw(`[{"code":"windows_reserved_name","path":"docs/CON.txt","message":"path segment uses a Windows reserved device name"}]`),
+			}),
+		},
+	}
+
+	view := BuildConflictListView(attachment, conflicts, 0)
+	if view.OpenCount != 1 {
+		t.Fatalf("OpenCount = %d, want 1", view.OpenCount)
+	}
+	if len(view.UnmergedPaths) != 1 {
+		t.Fatalf("len(UnmergedPaths) = %d, want 1", len(view.UnmergedPaths))
+	}
+	if got := view.UnmergedPaths[0].Summary; got != "namespace incompatible for Windows-capable replicas" {
+		t.Fatalf("summary = %q, want Windows compatibility wording", got)
+	}
+}
+
+func TestBuildConflictListViewIncludesSandboxActorLabel(t *testing.T) {
+	attachment := &syncstate.Attachment{
+		WorkspaceRoot: "/tmp/work",
+		VolumeID:      "vol-123",
+	}
+	conflicts := []apispec.SyncConflict{
+		{
+			Path:   apispec.NewOptString("src/main.go"),
+			Reason: apispec.NewOptString("concurrent_update"),
+			Status: apispec.NewOptString("open"),
+			Metadata: apispec.NewOptNilSyncConflictMetadata(apispec.SyncConflictMetadata{
+				"latest_source":     jx.Raw(`"sandbox"`),
+				"latest_sandbox_id": jx.Raw(`"sandbox-1"`),
+			}),
+		},
+	}
+
+	view := BuildConflictListView(attachment, conflicts, 0)
+	if len(view.UnmergedPaths) != 1 {
+		t.Fatalf("len(UnmergedPaths) = %d, want 1", len(view.UnmergedPaths))
+	}
+	if got := view.UnmergedPaths[0].Summary; got != `modified locally, conflicted with sandbox "sandbox-1"` {
+		t.Fatalf("summary = %q", got)
+	}
+}
+
+func TestBuildConflictDetailViewIncludesLatestRemoteContext(t *testing.T) {
+	now := time.Date(2026, 3, 26, 10, 0, 0, 0, time.UTC)
+	conflict := &apispec.SyncConflict{
+		ID:             apispec.NewOptString("conflict-1"),
+		Path:           apispec.NewOptString("src/main.go"),
+		Reason:         apispec.NewOptString("concurrent_update"),
+		Status:         apispec.NewOptString("open"),
+		ReplicaID:      apispec.NewOptNilString("replica-mac"),
+		ArtifactPath:   apispec.NewOptString("src/main.sandbox0-conflict-replica-mac-seq-42.go"),
+		NormalizedPath: apispec.NewOptString("src/main.go"),
+		ExistingSeq:    apispec.NewOptNilInt64(42),
+		CreatedAt:      apispec.NewOptDateTime(now),
+		UpdatedAt:      apispec.NewOptDateTime(now.Add(time.Minute)),
+		Metadata: apispec.NewOptNilSyncConflictMetadata(apispec.SyncConflictMetadata{
+			"latest_path":       jx.Raw(`"src/main.go"`),
+			"latest_event":      jx.Raw(`"write"`),
+			"latest_source":     jx.Raw(`"sandbox"`),
+			"latest_sandbox_id": jx.Raw(`"sandbox-1"`),
+			"base_seq":          jx.Raw(`41`),
+		}),
+	}
+
+	view := BuildConflictDetailView(conflict)
+	if got := view.Summary; got != `modified locally, conflicted with sandbox "sandbox-1"` {
+		t.Fatalf("Summary = %q", got)
+	}
+	if got := view.RecordedFor; got != `replica "replica-mac"` {
+		t.Fatalf("RecordedFor = %q", got)
+	}
+	if got := view.LatestRemoteActor; got != `sandbox "sandbox-1"` {
+		t.Fatalf("LatestRemoteActor = %q", got)
+	}
+	if got := view.LatestRemoteEvent; got != "write" {
+		t.Fatalf("LatestRemoteEvent = %q, want write", got)
+	}
+	if got := view.SuggestedNextStep; got == "" || got == "-" {
+		t.Fatalf("SuggestedNextStep = %q, want non-empty", got)
+	}
+}
+
+func TestBuildStatusViewTruncatesConflictSummary(t *testing.T) {
+	attachment := &syncstate.Attachment{
+		WorkspaceRoot: "/tmp/work",
+		VolumeID:      "vol-123",
+		LastSync:      &syncstate.SyncCheckpoint{OpenConflictCount: 7},
+	}
+	conflicts := make([]apispec.SyncConflict, 0, DefaultStatusSummaryLimit+2)
+	for i := 0; i < DefaultStatusSummaryLimit+2; i++ {
+		conflicts = append(conflicts, apispec.SyncConflict{
+			Path:   apispec.NewOptString("file-" + string(rune('a'+i))),
+			Reason: apispec.NewOptString("concurrent_update"),
+			Status: apispec.NewOptString("open"),
+		})
+	}
+
+	view := BuildStatusView(attachment, conflicts, nil)
+	if view.ConflictSummary == nil {
+		t.Fatalf("ConflictSummary is nil")
+	}
+	if !view.ConflictSummary.Truncated {
+		t.Fatalf("Truncated = false, want true")
+	}
+	if got := view.ConflictSummary.Remaining; got != 2 {
+		t.Fatalf("Remaining = %d, want 2", got)
+	}
+	if got := len(view.ConflictSummary.UnmergedPaths); got != DefaultStatusSummaryLimit {
+		t.Fatalf("len(UnmergedPaths) = %d, want %d", got, DefaultStatusSummaryLimit)
+	}
+}

--- a/internal/syncworker/e2e_test.go
+++ b/internal/syncworker/e2e_test.go
@@ -1,0 +1,530 @@
+package syncworker
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-faster/jx"
+	"github.com/sandbox0-ai/s0/internal/syncapi"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	syncsdk "github.com/sandbox0-ai/sdk-go"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func TestReconcileOnceEndToEndThroughSDKHTTP(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	service := newFakeSyncService()
+	server := httptest.NewServer(service)
+	defer server.Close()
+
+	client, err := syncsdk.NewClient(
+		syncsdk.WithBaseURL(server.URL),
+		syncsdk.WithToken("test-token"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	api := syncapi.New(client)
+
+	workspace := filepath.Join(home, "work")
+	attachment, err := syncstate.NewAttachment(workspace, service.volumeID, "work", "volume")
+	if err != nil {
+		t.Fatalf("NewAttachment() error = %v", err)
+	}
+	if err := syncstate.SaveAttachment(attachment); err != nil {
+		t.Fatalf("SaveAttachment() error = %v", err)
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	ctx := context.Background()
+
+	if err := reconcileOnce(ctx, api, attachment.ID, logger, true); err != nil {
+		t.Fatalf("initial reconcileOnce() error = %v", err)
+	}
+	readmePath := filepath.Join(workspace, "README.md")
+	if got := readFile(t, readmePath); got != "hello from volume\n" {
+		t.Fatalf("README after bootstrap = %q", got)
+	}
+
+	if err := os.WriteFile(readmePath, []byte("hello from local\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(local README) error = %v", err)
+	}
+	if err := reconcileOnce(ctx, api, attachment.ID, logger, false); err != nil {
+		t.Fatalf("reconcileOnce(local upload) error = %v", err)
+	}
+	if got := service.fileContent("README.md"); got != "hello from local\n" {
+		t.Fatalf("remote README after local upload = %q", got)
+	}
+
+	service.addSandboxWrite("README.md", "hello from sandbox\n")
+	if err := reconcileOnce(ctx, api, attachment.ID, logger, false); err != nil {
+		t.Fatalf("reconcileOnce(sandbox replay) error = %v", err)
+	}
+	if got := readFile(t, readmePath); got != "hello from sandbox\n" {
+		t.Fatalf("README after sandbox replay = %q", got)
+	}
+
+	service.setConflictOnNextPath("README.md")
+	if err := os.WriteFile(readmePath, []byte("conflicted locally\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(conflicted README) error = %v", err)
+	}
+	if err := reconcileOnce(ctx, api, attachment.ID, logger, false); err != nil {
+		t.Fatalf("reconcileOnce(conflict) error = %v", err)
+	}
+
+	attachment, err = syncstate.LoadAttachmentByID(attachment.ID)
+	if err != nil {
+		t.Fatalf("LoadAttachmentByID() error = %v", err)
+	}
+	if attachment.LastSync == nil || attachment.LastSync.OpenConflictCount != 1 {
+		t.Fatalf("OpenConflictCount = %+v, want 1", attachment.LastSync)
+	}
+
+	conflicts, err := api.ListConflicts(ctx, attachment.VolumeID, "open", 256)
+	if err != nil {
+		t.Fatalf("ListConflicts() error = %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("len(conflicts) = %d, want 1", len(conflicts))
+	}
+	conflictID, ok := conflicts[0].ID.Get()
+	if !ok || conflictID == "" {
+		t.Fatalf("conflict id missing: %+v", conflicts[0])
+	}
+	resolved, err := api.ResolveConflict(ctx, attachment.VolumeID, conflictID, false)
+	if err != nil {
+		t.Fatalf("ResolveConflict() error = %v", err)
+	}
+	status, _ := resolved.Status.Get()
+	if status != "resolved" {
+		t.Fatalf("resolved.Status = %q, want resolved", status)
+	}
+	if _, err := refreshOpenConflictCount(ctx, api, attachment.ID, attachment.VolumeID); err != nil {
+		t.Fatalf("refreshOpenConflictCount() error = %v", err)
+	}
+
+	attachment, err = syncstate.LoadAttachmentByID(attachment.ID)
+	if err != nil {
+		t.Fatalf("LoadAttachmentByID() error = %v", err)
+	}
+	if attachment.LastSync.OpenConflictCount != 0 {
+		t.Fatalf("OpenConflictCount after resolve = %d, want 0", attachment.LastSync.OpenConflictCount)
+	}
+}
+
+type fakeSyncService struct {
+	mu               sync.Mutex
+	volumeID         string
+	teamID           string
+	replicas         map[string]apispec.SyncReplica
+	files            map[string]string
+	journal          []apispec.SyncJournalEntry
+	conflicts        map[string]apispec.SyncConflict
+	headSeq          int64
+	conflictNextPath string
+}
+
+func newFakeSyncService() *fakeSyncService {
+	return &fakeSyncService{
+		volumeID: "vol-test",
+		teamID:   "team-test",
+		replicas: map[string]apispec.SyncReplica{},
+		files: map[string]string{
+			"README.md": "hello from volume\n",
+		},
+		conflicts: map[string]apispec.SyncConflict{},
+	}
+}
+
+func (s *fakeSyncService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.URL.Path, "/api/v1/sandboxvolumes/"+s.volumeID+"/sync/") {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/sync/replicas/") && strings.HasSuffix(r.URL.Path, "/cursor"):
+		s.handleUpdateCursor(w, r)
+	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/sync/replicas/") && !strings.HasSuffix(r.URL.Path, "/cursor"):
+		s.handleUpsertReplica(w, r)
+	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/sync/bootstrap"):
+		s.handleBootstrap(w, r)
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/sync/bootstrap/archive"):
+		s.handleBootstrapArchive(w, r)
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/sync/changes"):
+		s.handleListChanges(w, r)
+	case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/sync/replicas/") && strings.HasSuffix(r.URL.Path, "/changes"):
+		s.handleAppendChanges(w, r)
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/sync/conflicts"):
+		s.handleListConflicts(w, r)
+	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/sync/conflicts/"):
+		s.handleResolveConflict(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *fakeSyncService) handleUpsertReplica(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	replicaID := path.Base(r.URL.Path)
+	var req apispec.UpsertSyncReplicaRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	now := time.Now().UTC()
+	replica := apispec.SyncReplica{
+		ID:             apispec.NewOptString(replicaID),
+		VolumeID:       apispec.NewOptString(s.volumeID),
+		TeamID:         apispec.NewOptString(s.teamID),
+		DisplayName:    req.DisplayName,
+		Platform:       req.Platform,
+		RootPath:       req.RootPath,
+		CaseSensitive:  req.CaseSensitive,
+		Capabilities:   req.Capabilities,
+		LastSeenAt:     apispec.NewOptDateTime(now),
+		LastAppliedSeq: apispec.NewOptInt64(0),
+		CreatedAt:      apispec.NewOptDateTime(now),
+		UpdatedAt:      apispec.NewOptDateTime(now),
+	}
+	if existing, ok := s.replicas[replicaID]; ok {
+		replica.LastAppliedSeq = existing.LastAppliedSeq
+		replica.CreatedAt = existing.CreatedAt
+	}
+	s.replicas[replicaID] = replica
+
+	writeJSON(w, http.StatusOK, apispec.SuccessVolumeSyncReplicaResponse{
+		Success: apispec.SuccessVolumeSyncReplicaResponseSuccessTrue,
+		Data: apispec.NewOptVolumeSyncReplicaEnvelope(apispec.VolumeSyncReplicaEnvelope{
+			Replica: replica,
+			HeadSeq: s.headSeq,
+		}),
+	})
+}
+
+func (s *fakeSyncService) handleBootstrap(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	writeJSON(w, http.StatusCreated, apispec.SuccessVolumeSyncBootstrapResponse{
+		Success: apispec.SuccessVolumeSyncBootstrapResponseSuccessTrue,
+		Data: apispec.NewOptVolumeSyncBootstrap(apispec.VolumeSyncBootstrap{
+			Snapshot: apispec.Snapshot{
+				ID:        "snap-1",
+				VolumeID:  s.volumeID,
+				Name:      "bootstrap",
+				SizeBytes: int64(len(s.files)),
+				CreatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+			ReplayAfterSeq:      s.headSeq,
+			ArchiveDownloadPath: "/api/v1/sandboxvolumes/" + s.volumeID + "/sync/bootstrap/archive?snapshot_id=snap-1",
+		}),
+	})
+}
+
+func (s *fakeSyncService) handleBootstrapArchive(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	archive, err := buildArchive(s.files)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/gzip")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(archive)
+}
+
+func (s *fakeSyncService) handleListChanges(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	after, _ := strconv.ParseInt(r.URL.Query().Get("after"), 10, 64)
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 {
+		limit = 256
+	}
+	changes := make([]apispec.SyncJournalEntry, 0, limit)
+	for _, entry := range s.journal {
+		seq, _ := entry.Seq.Get()
+		if seq <= after {
+			continue
+		}
+		changes = append(changes, entry)
+		if len(changes) >= limit {
+			break
+		}
+	}
+
+	writeJSON(w, http.StatusOK, apispec.SuccessVolumeSyncChangeListResponse{
+		Success: apispec.SuccessVolumeSyncChangeListResponseSuccessTrue,
+		Data: apispec.NewOptListVolumeSyncChangesResponse(apispec.ListVolumeSyncChangesResponse{
+			HeadSeq:          s.headSeq,
+			RetainedAfterSeq: 0,
+			Changes:          changes,
+		}),
+	})
+}
+
+func (s *fakeSyncService) handleAppendChanges(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	replicaID := path.Base(path.Dir(r.URL.Path))
+	var req apispec.AppendReplicaChangesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	accepted := make([]apispec.SyncJournalEntry, 0, len(req.Changes))
+	conflicts := make([]apispec.SyncConflict, 0, 1)
+	for _, change := range req.Changes {
+		changePath, _ := change.Path.Get()
+		if s.conflictNextPath != "" && changePath == s.conflictNextPath {
+			conflict := apispec.SyncConflict{
+				ID:             apispec.NewOptString("conflict-1"),
+				VolumeID:       apispec.NewOptString(s.volumeID),
+				TeamID:         apispec.NewOptString(s.teamID),
+				ReplicaID:      apispec.NewOptNilString(replicaID),
+				Path:           apispec.NewOptString(changePath),
+				NormalizedPath: apispec.NewOptString(strings.ToLower(changePath)),
+				ArtifactPath:   apispec.NewOptString(changePath + ".sandbox0-conflict-" + replicaID),
+				IncomingPath:   apispec.NewOptNilString(changePath),
+				Reason:         apispec.NewOptString("concurrent_update"),
+				Status:         apispec.NewOptString("open"),
+				ExistingSeq:    apispec.NewOptNilInt64(s.headSeq),
+				Metadata: apispec.NewOptNilSyncConflictMetadata(apispec.SyncConflictMetadata{
+					"latest_event":  jx.Raw(`"write"`),
+					"latest_path":   jx.Raw(strconv.Quote(changePath)),
+					"latest_source": jx.Raw(`"sandbox"`),
+				}),
+				CreatedAt: apispec.NewOptDateTime(time.Now().UTC()),
+				UpdatedAt: apispec.NewOptDateTime(time.Now().UTC()),
+			}
+			s.conflicts["conflict-1"] = conflict
+			s.conflictNextPath = ""
+			conflicts = append(conflicts, conflict)
+			continue
+		}
+
+		entry := s.appendJournalEntryLocked(replicaID, apispec.SyncJournalEntrySourceReplica, change)
+		accepted = append(accepted, entry)
+	}
+
+	writeJSON(w, http.StatusOK, apispec.SuccessVolumeSyncAppendResponse{
+		Success: apispec.SuccessVolumeSyncAppendResponseSuccessTrue,
+		Data: apispec.NewOptAppendReplicaChangesResponse(apispec.AppendReplicaChangesResponse{
+			HeadSeq:   s.headSeq,
+			Accepted:  accepted,
+			Conflicts: conflicts,
+		}),
+	})
+}
+
+func (s *fakeSyncService) handleUpdateCursor(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	replicaID := path.Base(path.Dir(r.URL.Path))
+	var req apispec.UpdateSyncReplicaCursorRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	replica := s.replicas[replicaID]
+	replica.LastAppliedSeq = apispec.NewOptInt64(req.LastAppliedSeq)
+	replica.LastSeenAt = apispec.NewOptDateTime(time.Now().UTC())
+	s.replicas[replicaID] = replica
+
+	writeJSON(w, http.StatusOK, apispec.SuccessVolumeSyncReplicaResponse{
+		Success: apispec.SuccessVolumeSyncReplicaResponseSuccessTrue,
+		Data: apispec.NewOptVolumeSyncReplicaEnvelope(apispec.VolumeSyncReplicaEnvelope{
+			Replica: replica,
+			HeadSeq: s.headSeq,
+		}),
+	})
+}
+
+func (s *fakeSyncService) handleListConflicts(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	statusFilter := strings.TrimSpace(r.URL.Query().Get("status"))
+	conflicts := make([]apispec.SyncConflict, 0, len(s.conflicts))
+	for _, conflict := range s.conflicts {
+		status, _ := conflict.Status.Get()
+		if statusFilter != "" && status != statusFilter {
+			continue
+		}
+		conflicts = append(conflicts, conflict)
+	}
+	writeJSON(w, http.StatusOK, apispec.SuccessVolumeSyncConflictListResponse{
+		Success: apispec.SuccessVolumeSyncConflictListResponseSuccessTrue,
+		Data: apispec.NewOptListVolumeSyncConflictsResponse(apispec.ListVolumeSyncConflictsResponse{
+			Conflicts: conflicts,
+		}),
+	})
+}
+
+func (s *fakeSyncService) handleResolveConflict(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	conflictID := path.Base(r.URL.Path)
+	conflict, ok := s.conflicts[conflictID]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req apispec.ResolveVolumeSyncConflictRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	conflict.Status = apispec.NewOptString(string(req.Status))
+	conflict.UpdatedAt = apispec.NewOptDateTime(time.Now().UTC())
+	metadata, _ := conflict.Metadata.Get()
+	if metadata == nil {
+		metadata = apispec.SyncConflictMetadata{}
+	}
+	if resolution, ok := req.Resolution.Get(); ok && strings.TrimSpace(resolution) != "" {
+		metadata["resolution"] = jx.Raw(strconv.Quote(resolution))
+	}
+	if note, ok := req.Note.Get(); ok && strings.TrimSpace(note) != "" {
+		metadata["note"] = jx.Raw(strconv.Quote(note))
+	}
+	metadata["resolved_at"] = jx.Raw(strconv.Quote(time.Now().UTC().Format(time.RFC3339)))
+	conflict.Metadata = apispec.NewOptNilSyncConflictMetadata(metadata)
+	s.conflicts[conflictID] = conflict
+
+	writeJSON(w, http.StatusOK, apispec.SuccessVolumeSyncConflictResponse{
+		Success: apispec.SuccessVolumeSyncConflictResponseSuccessTrue,
+		Data:    apispec.NewOptSyncConflict(conflict),
+	})
+}
+
+func (s *fakeSyncService) appendJournalEntryLocked(replicaID string, source apispec.SyncJournalEntrySource, change apispec.ChangeRequest) apispec.SyncJournalEntry {
+	s.headSeq++
+	eventType := change.EventType
+	changePath, _ := change.Path.Get()
+	oldPath, _ := change.OldPath.Get()
+	content, _ := change.ContentBase64.Get()
+
+	switch string(eventType) {
+	case string(apispec.SyncEventTypeCreate), string(apispec.SyncEventTypeWrite):
+		payload, _ := base64.StdEncoding.DecodeString(content)
+		s.files[changePath] = string(payload)
+	case string(apispec.SyncEventTypeRemove):
+		delete(s.files, changePath)
+	case string(apispec.SyncEventTypeRename):
+		s.files[changePath] = s.files[oldPath]
+		delete(s.files, oldPath)
+	}
+
+	entry := apispec.SyncJournalEntry{
+		Seq:            apispec.NewOptInt64(s.headSeq),
+		VolumeID:       apispec.NewOptString(s.volumeID),
+		TeamID:         apispec.NewOptString(s.teamID),
+		Source:         apispec.NewOptSyncJournalEntrySource(source),
+		ReplicaID:      apispec.NewOptNilString(replicaID),
+		EventType:      apispec.NewOptSyncEventType(eventType),
+		Path:           apispec.NewOptString(changePath),
+		NormalizedPath: apispec.NewOptString(strings.ToLower(changePath)),
+		Tombstone:      apispec.NewOptBool(eventType == apispec.SyncEventTypeRemove),
+		CreatedAt:      apispec.NewOptDateTime(time.Now().UTC()),
+	}
+	if oldPath != "" {
+		entry.OldPath = apispec.NewOptNilString(oldPath)
+		entry.NormalizedOldPath = apispec.NewOptNilString(strings.ToLower(oldPath))
+	}
+	s.journal = append(s.journal, entry)
+	return entry
+}
+
+func (s *fakeSyncService) addSandboxWrite(pathValue, content string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	change := apispec.ChangeRequest{
+		EventType:     apispec.SyncEventTypeWrite,
+		Path:          apispec.NewOptString(pathValue),
+		ContentBase64: apispec.NewOptNilString(base64.StdEncoding.EncodeToString([]byte(content))),
+	}
+	s.appendJournalEntryLocked("", apispec.SyncJournalEntrySourceSandbox, change)
+}
+
+func (s *fakeSyncService) setConflictOnNextPath(pathValue string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conflictNextPath = pathValue
+}
+
+func (s *fakeSyncService) fileContent(pathValue string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.files[pathValue]
+}
+
+func buildArchive(files map[string]string) ([]byte, error) {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	for name, content := range files {
+		payload := []byte(content)
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(payload)),
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(payload); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gzw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/syncworker/local.go
+++ b/internal/syncworker/local.go
@@ -1,0 +1,331 @@
+package syncworker
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sandbox0-ai/s0/internal/syncignore"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func scanWorkspace(root string) (*syncstate.Manifest, error) {
+	manifest := &syncstate.Manifest{Entries: map[string]syncstate.ManifestEntry{}}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+
+	err := filepath.WalkDir(root, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if current == root {
+			return nil
+		}
+
+		relative, err := filepath.Rel(root, current)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if relative == ".git" {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(relative, ".git/") {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlinks are not supported yet: %s", relative)
+		}
+
+		item := syncstate.ManifestEntry{
+			Path: relative,
+			Mode: uint32(info.Mode().Perm()),
+		}
+		switch {
+		case entry.IsDir():
+			item.Kind = "directory"
+		case info.Mode().IsRegular():
+			sum, size, err := hashFile(current)
+			if err != nil {
+				return err
+			}
+			item.Kind = "file"
+			item.Size = size
+			item.SHA256 = sum
+		default:
+			return fmt.Errorf("unsupported workspace entry: %s", relative)
+		}
+		manifest.Entries[item.Path] = item
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func buildUploadChanges(root string, previous, current *syncstate.Manifest, matcher *syncignore.Matcher) ([]apispec.ChangeRequest, error) {
+	if previous == nil {
+		previous = &syncstate.Manifest{Entries: map[string]syncstate.ManifestEntry{}}
+	}
+	if current == nil {
+		current = &syncstate.Manifest{Entries: map[string]syncstate.ManifestEntry{}}
+	}
+	if previous.Entries == nil {
+		previous.Entries = map[string]syncstate.ManifestEntry{}
+	}
+	if current.Entries == nil {
+		current.Entries = map[string]syncstate.ManifestEntry{}
+	}
+
+	creates := make([]apispec.ChangeRequest, 0)
+	writes := make([]apispec.ChangeRequest, 0)
+	removes := make([]apispec.ChangeRequest, 0)
+
+	allPaths := make([]string, 0, len(previous.Entries)+len(current.Entries))
+	seen := map[string]struct{}{}
+	for relative := range previous.Entries {
+		allPaths = append(allPaths, relative)
+		seen[relative] = struct{}{}
+	}
+	for relative := range current.Entries {
+		if _, ok := seen[relative]; ok {
+			continue
+		}
+		allPaths = append(allPaths, relative)
+	}
+	sort.Strings(allPaths)
+
+	for _, relative := range allPaths {
+		prev, hadPrev := previous.Entries[relative]
+		curr, hasCurr := current.Entries[relative]
+		isDir := hasCurr && curr.Kind == "directory"
+		if !hasCurr {
+			isDir = hadPrev && prev.Kind == "directory"
+		}
+		if matcher != nil && matcher.Match(relative, isDir) {
+			continue
+		}
+
+		switch {
+		case !hadPrev && hasCurr:
+			change, err := createChange(root, curr)
+			if err != nil {
+				return nil, err
+			}
+			creates = append(creates, change)
+		case hadPrev && !hasCurr:
+			removes = append(removes, apispec.ChangeRequest{
+				EventType: apispec.SyncEventTypeRemove,
+				Path:      apispec.NewOptString(relative),
+			})
+		case hadPrev && hasCurr:
+			if prev.Kind != curr.Kind {
+				removes = append(removes, apispec.ChangeRequest{
+					EventType: apispec.SyncEventTypeRemove,
+					Path:      apispec.NewOptString(relative),
+				})
+				change, err := createChange(root, curr)
+				if err != nil {
+					return nil, err
+				}
+				creates = append(creates, change)
+				continue
+			}
+			if curr.Kind == "file" && (prev.SHA256 != curr.SHA256 || prev.Size != curr.Size) {
+				change, err := writeChange(root, curr)
+				if err != nil {
+					return nil, err
+				}
+				writes = append(writes, change)
+			}
+		}
+	}
+
+	sort.SliceStable(creates, func(i, j int) bool {
+		left, _ := creates[i].Path.Get()
+		right, _ := creates[j].Path.Get()
+		return pathDepth(left) < pathDepth(right)
+	})
+	sort.SliceStable(removes, func(i, j int) bool {
+		left, _ := removes[i].Path.Get()
+		right, _ := removes[j].Path.Get()
+		return pathDepth(left) > pathDepth(right)
+	})
+
+	changes := make([]apispec.ChangeRequest, 0, len(creates)+len(writes)+len(removes))
+	changes = append(changes, creates...)
+	changes = append(changes, writes...)
+	changes = append(changes, removes...)
+	return changes, nil
+}
+
+func createChange(root string, entry syncstate.ManifestEntry) (apispec.ChangeRequest, error) {
+	change := apispec.ChangeRequest{
+		EventType: apispec.SyncEventTypeCreate,
+		Path:      apispec.NewOptString(entry.Path),
+		Mode:      apispec.NewOptNilInt64(int64(entry.Mode)),
+	}
+	switch entry.Kind {
+	case "directory":
+		change.EntryKind = apispec.NewOptChangeRequestEntryKind(apispec.ChangeRequestEntryKindDirectory)
+		return change, nil
+	case "file":
+		change.EntryKind = apispec.NewOptChangeRequestEntryKind(apispec.ChangeRequestEntryKindFile)
+		content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(entry.Path)))
+		if err != nil {
+			return apispec.ChangeRequest{}, err
+		}
+		change.ContentBase64 = apispec.NewOptNilString(base64.StdEncoding.EncodeToString(content))
+		change.ContentSHA256 = apispec.NewOptString(entry.SHA256)
+		change.SizeBytes = apispec.NewOptInt64(entry.Size)
+		return change, nil
+	default:
+		return apispec.ChangeRequest{}, fmt.Errorf("unsupported entry kind %q", entry.Kind)
+	}
+}
+
+func writeChange(root string, entry syncstate.ManifestEntry) (apispec.ChangeRequest, error) {
+	content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(entry.Path)))
+	if err != nil {
+		return apispec.ChangeRequest{}, err
+	}
+	return apispec.ChangeRequest{
+		EventType:     apispec.SyncEventTypeWrite,
+		Path:          apispec.NewOptString(entry.Path),
+		ContentBase64: apispec.NewOptNilString(base64.StdEncoding.EncodeToString(content)),
+		ContentSHA256: apispec.NewOptString(entry.SHA256),
+		SizeBytes:     apispec.NewOptInt64(entry.Size),
+	}, nil
+}
+
+func clearWorkspaceForBootstrap(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.MkdirAll(root, 0o755)
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Name() == ".git" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractBootstrapArchive(root string, archive []byte) error {
+	gzr, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		relative, err := sanitizeArchivePath(header.Name)
+		if err != nil {
+			return err
+		}
+		if relative == "" {
+			continue
+		}
+		target := filepath.Join(root, filepath.FromSlash(relative))
+		switch header.Typeflag {
+		case tar.TypeDir:
+			mode := os.FileMode(header.Mode) & os.ModePerm
+			if mode == 0 {
+				mode = 0o755
+			}
+			if err := os.MkdirAll(target, mode); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(header.Mode)&os.ModePerm)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(file, tr); err != nil {
+				file.Close()
+				return err
+			}
+			if err := file.Close(); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported bootstrap archive entry %q", header.Name)
+		}
+	}
+}
+
+func sanitizeArchivePath(name string) (string, error) {
+	clean := path.Clean(strings.TrimPrefix(strings.ReplaceAll(name, "\\", "/"), "/"))
+	if clean == "." || clean == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(clean, "../") || clean == ".." {
+		return "", fmt.Errorf("invalid archive entry %q", name)
+	}
+	return clean, nil
+}
+
+func hashFile(path string) (string, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	size, err := io.Copy(hasher, file)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), size, nil
+}
+
+func pathDepth(value string) int {
+	if value == "" {
+		return 0
+	}
+	return strings.Count(value, "/")
+}

--- a/internal/syncworker/local_test.go
+++ b/internal/syncworker/local_test.go
@@ -1,0 +1,129 @@
+package syncworker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sandbox0-ai/s0/internal/syncignore"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func TestBuildUploadChangesRespectsGitignore(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("build/\n"), 0o600); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "build"), 0o755); err != nil {
+		t.Fatalf("mkdir build: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "build", "artifact.txt"), []byte("ignored\n"), 0o600); err != nil {
+		t.Fatalf("write ignored file: %v", err)
+	}
+
+	matcher, err := syncignore.Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	current, err := scanWorkspace(root)
+	if err != nil {
+		t.Fatalf("scanWorkspace() error = %v", err)
+	}
+	changes, err := buildUploadChanges(root, &syncstate.Manifest{Entries: map[string]syncstate.ManifestEntry{}}, current, matcher)
+	if err != nil {
+		t.Fatalf("buildUploadChanges() error = %v", err)
+	}
+
+	if len(changes) != 3 {
+		t.Fatalf("len(changes) = %d, want 3", len(changes))
+	}
+	if got := changes[0].EventType; got != apispec.SyncEventTypeCreate {
+		t.Fatalf("changes[0].EventType = %q, want create", got)
+	}
+	if got, _ := changes[0].Path.Get(); got != ".gitignore" {
+		t.Fatalf("changes[0].Path = %q, want .gitignore", got)
+	}
+	if got, _ := changes[1].Path.Get(); got != "src" {
+		t.Fatalf("changes[1].Path = %q, want src", got)
+	}
+	if got, _ := changes[2].Path.Get(); got != "src/main.go" {
+		t.Fatalf("changes[2].Path = %q, want src/main.go", got)
+	}
+}
+
+func TestBuildUploadChangesRespectsNestedGitignore(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "apps"), 0o755); err != nil {
+		t.Fatalf("mkdir apps: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "apps", ".gitignore"), []byte("dist/\n"), 0o600); err != nil {
+		t.Fatalf("write nested .gitignore: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "apps", "dist"), 0o755); err != nil {
+		t.Fatalf("mkdir apps/dist: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "apps", "dist", "bundle.js"), []byte("ignored\n"), 0o600); err != nil {
+		t.Fatalf("write ignored bundle: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "apps", "src"), 0o755); err != nil {
+		t.Fatalf("mkdir apps/src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "apps", "src", "main.ts"), []byte("export {}\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	matcher, err := syncignore.Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	current, err := scanWorkspace(root)
+	if err != nil {
+		t.Fatalf("scanWorkspace() error = %v", err)
+	}
+	changes, err := buildUploadChanges(root, &syncstate.Manifest{Entries: map[string]syncstate.ManifestEntry{}}, current, matcher)
+	if err != nil {
+		t.Fatalf("buildUploadChanges() error = %v", err)
+	}
+
+	for _, change := range changes {
+		if got, _ := change.Path.Get(); strings.HasPrefix(got, "apps/dist") {
+			t.Fatalf("unexpected ignored path in upload changes: %q", got)
+		}
+	}
+}
+
+func TestApplyRemoteRename(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "old.txt"), []byte("hello\n"), 0o600); err != nil {
+		t.Fatalf("write old file: %v", err)
+	}
+
+	changed, err := applyRemoteChange(root, apispec.SyncJournalEntry{
+		EventType: apispec.NewOptSyncEventType(apispec.SyncEventTypeRename),
+		Path:      apispec.NewOptString("docs/new.txt"),
+		OldPath:   apispec.NewOptNilString("docs/old.txt"),
+	})
+	if err != nil {
+		t.Fatalf("applyRemoteChange() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("applyRemoteChange() changed = false, want true")
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "new.txt")); err != nil {
+		t.Fatalf("new path missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("old path still exists or unexpected error: %v", err)
+	}
+}

--- a/internal/syncworker/worker.go
+++ b/internal/syncworker/worker.go
@@ -1,0 +1,549 @@
+package syncworker
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	syncsdk "github.com/sandbox0-ai/sdk-go"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+
+	"github.com/sandbox0-ai/s0/internal/syncapi"
+	"github.com/sandbox0-ai/s0/internal/syncignore"
+	"github.com/sandbox0-ai/s0/internal/syncstate"
+)
+
+const (
+	workerHeartbeatInterval = 2 * time.Second
+	reconcileInterval       = 5 * time.Second
+	replicaRefreshInterval  = 30 * time.Second
+	changeBatchLimit        = 256
+	maxReplayBatches        = 8
+)
+
+// Run executes the phase-2 sync worker loop for one attachment.
+func Run(ctx context.Context, client *syncsdk.Client, attachmentID, mode string, out io.Writer) error {
+	attachment, err := syncstate.MarkWorkerStarted(attachmentID, mode, os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	logger := log.New(out, "", log.LstdFlags)
+	api := syncapi.New(client)
+
+	logger.Printf("Sync worker started for workspace %s (volume %s, replica %s, mode %s)", attachment.WorkspaceRoot, attachment.VolumeID, attachment.ReplicaID, mode)
+
+	heartbeatTicker := time.NewTicker(workerHeartbeatInterval)
+	defer heartbeatTicker.Stop()
+
+	reconcileTicker := time.NewTicker(reconcileInterval)
+	defer reconcileTicker.Stop()
+
+	replicaTicker := time.NewTicker(replicaRefreshInterval)
+	defer replicaTicker.Stop()
+
+	var loopErr error
+	defer func() {
+		if _, err := syncstate.MarkWorkerStopped(attachmentID, loopErr); err != nil {
+			logger.Printf("Failed to persist worker shutdown state: %v", err)
+		}
+		logger.Printf("Sync worker stopped for attachment %s", attachmentID)
+	}()
+
+	if err := reconcileOnce(ctx, api, attachmentID, logger, true); err != nil {
+		if err := recordSyncError(attachmentID, err); err != nil {
+			logger.Printf("Failed to record sync error: %v", err)
+		}
+		logger.Printf("Initial reconcile failed: %v", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-heartbeatTicker.C:
+			if _, err := syncstate.TouchWorkerHeartbeat(attachmentID, mode, os.Getpid()); err != nil {
+				loopErr = err
+				return err
+			}
+		case <-replicaTicker.C:
+			if err := refreshReplica(ctx, api, attachmentID); err != nil {
+				_ = recordSyncError(attachmentID, err)
+				logger.Printf("Replica refresh failed: %v", err)
+			}
+		case <-reconcileTicker.C:
+			if err := reconcileOnce(ctx, api, attachmentID, logger, false); err != nil {
+				_ = recordSyncError(attachmentID, err)
+				logger.Printf("Reconcile failed: %v", err)
+			}
+		}
+	}
+}
+
+func reconcileOnce(ctx context.Context, api *syncapi.Client, attachmentID string, logger *log.Logger, forceReplicaRefresh bool) error {
+	attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return err
+	}
+	if forceReplicaRefresh {
+		if _, err := upsertReplica(ctx, api, attachmentID); err != nil {
+			return err
+		}
+	}
+
+	matcher, err := syncignore.Load(attachment.WorkspaceRoot)
+	if err != nil {
+		return err
+	}
+	manifest, err := syncstate.LoadManifest(attachmentID)
+	if err != nil {
+		return err
+	}
+	if err := ensureInitialized(ctx, api, attachment, manifest, matcher, logger); err != nil {
+		return err
+	}
+
+	if _, err := refreshOpenConflictCount(ctx, api, attachmentID, attachment.VolumeID); err != nil {
+		logger.Printf("Conflict refresh failed: %v", err)
+	}
+
+	attachment, err = syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return err
+	}
+	manifest, err = syncstate.LoadManifest(attachmentID)
+	if err != nil {
+		return err
+	}
+
+	if err := uploadLocalChanges(ctx, api, attachment, manifest, matcher, logger); err != nil {
+		return err
+	}
+	if err := replayRemoteChanges(ctx, api, attachmentID, logger); err != nil {
+		return err
+	}
+
+	if _, err := refreshOpenConflictCount(ctx, api, attachmentID, attachment.VolumeID); err != nil {
+		logger.Printf("Conflict refresh failed: %v", err)
+	}
+	return markSyncSuccess(attachmentID)
+}
+
+func ensureInitialized(ctx context.Context, api *syncapi.Client, attachment *syncstate.Attachment, manifest *syncstate.Manifest, matcher *syncignore.Matcher, logger *log.Logger) error {
+	if attachment.LastSync != nil && (attachment.LastSync.LastSuccessAt != nil || attachment.LastSync.LastAppliedSeq > 0 || len(manifest.Entries) > 0) {
+		return nil
+	}
+
+	current, err := scanWorkspace(attachment.WorkspaceRoot)
+	if err != nil {
+		return err
+	}
+	useVolume := attachment.InitFrom == "volume" || (attachment.InitFrom == "auto" && len(current.Entries) == 0)
+	if useVolume {
+		logger.Printf("Bootstrapping workspace from volume %s", attachment.VolumeID)
+		return bootstrapFromVolume(ctx, api, attachment.ID, logger)
+	}
+
+	logger.Printf("Seeding volume %s from local workspace %s", attachment.VolumeID, attachment.WorkspaceRoot)
+	return seedFromLocal(ctx, api, attachment.ID, current, matcher, logger)
+}
+
+func uploadLocalChanges(ctx context.Context, api *syncapi.Client, attachment *syncstate.Attachment, manifest *syncstate.Manifest, matcher *syncignore.Matcher, logger *log.Logger) error {
+	current, err := scanWorkspace(attachment.WorkspaceRoot)
+	if err != nil {
+		return err
+	}
+
+	changes, err := buildUploadChanges(attachment.WorkspaceRoot, manifest, current, matcher)
+	if err != nil {
+		return err
+	}
+	if len(changes) == 0 {
+		return syncstate.SaveManifest(attachment.ID, current)
+	}
+	if attachment.LastSync != nil && attachment.LastSync.OpenConflictCount > 0 {
+		logger.Printf("Skipping local upload while %d sync conflicts remain open", attachment.LastSync.OpenConflictCount)
+		return nil
+	}
+
+	resp, err := api.AppendChanges(ctx, attachment, attachment.LastSync.LastAppliedSeq, newRequestID(), changes)
+	if err != nil {
+		var reseed *syncapi.ReseedRequiredError
+		if errors.As(err, &reseed) {
+			logger.Printf("Local state fell behind retained journal floor (retained_after_seq=%d head_seq=%d), bootstrapping again", reseed.RetainedAfterSeq, reseed.HeadSeq)
+			return bootstrapFromVolume(ctx, api, attachment.ID, logger)
+		}
+		return err
+	}
+
+	if err := updateCheckpoint(attachment.ID, func(checkpoint *syncstate.SyncCheckpoint) {
+		checkpoint.HeadSeq = resp.HeadSeq
+		checkpoint.OpenConflictCount = len(resp.Conflicts)
+	}); err != nil {
+		return err
+	}
+	if len(resp.Conflicts) > 0 {
+		logger.Printf("Local upload produced %d sync conflicts; waiting for manual resolution", len(resp.Conflicts))
+		return nil
+	}
+
+	if err := syncstate.SaveManifest(attachment.ID, current); err != nil {
+		return err
+	}
+	if _, err := api.UpdateCursor(ctx, attachment, resp.HeadSeq); err != nil {
+		return err
+	}
+	return updateCheckpoint(attachment.ID, func(checkpoint *syncstate.SyncCheckpoint) {
+		checkpoint.HeadSeq = resp.HeadSeq
+		checkpoint.LastAppliedSeq = resp.HeadSeq
+		checkpoint.ReseedRequired = false
+	})
+}
+
+func replayRemoteChanges(ctx context.Context, api *syncapi.Client, attachmentID string, logger *log.Logger) error {
+	for batch := 0; batch < maxReplayBatches; batch++ {
+		attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+		if err != nil {
+			return err
+		}
+		resp, err := api.ListChanges(ctx, attachment.VolumeID, attachment.LastSync.LastAppliedSeq, changeBatchLimit)
+		if err != nil {
+			var reseed *syncapi.ReseedRequiredError
+			if errors.As(err, &reseed) {
+				logger.Printf("Remote replay requires reseed (retained_after_seq=%d head_seq=%d), bootstrapping again", reseed.RetainedAfterSeq, reseed.HeadSeq)
+				return bootstrapFromVolume(ctx, api, attachmentID, logger)
+			}
+			return err
+		}
+
+		if len(resp.Changes) == 0 {
+			return updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+				checkpoint.HeadSeq = resp.HeadSeq
+			})
+		}
+
+		mutated := false
+		lastApplied := attachment.LastSync.LastAppliedSeq
+		for _, change := range resp.Changes {
+			seq, ok := change.Seq.Get()
+			if !ok {
+				return fmt.Errorf("sync journal entry missing seq")
+			}
+			if isOwnReplicaEcho(change, attachment.ReplicaID) {
+				lastApplied = seq
+				continue
+			}
+			applied, err := applyRemoteChange(attachment.WorkspaceRoot, change)
+			if err != nil {
+				if errors.Is(err, errRemoteBootstrapRequired) {
+					logger.Printf("Remote change requires bootstrap fallback (seq=%d path=%s event=%s)", seq, optString(change.Path), optEvent(change.EventType))
+					return bootstrapFromVolume(ctx, api, attachmentID, logger)
+				}
+				return err
+			}
+			if applied {
+				mutated = true
+			}
+			lastApplied = seq
+		}
+
+		if mutated {
+			current, err := scanWorkspace(attachment.WorkspaceRoot)
+			if err != nil {
+				return err
+			}
+			if err := syncstate.SaveManifest(attachmentID, current); err != nil {
+				return err
+			}
+		}
+		if _, err := api.UpdateCursor(ctx, attachment, lastApplied); err != nil {
+			var reseed *syncapi.ReseedRequiredError
+			if errors.As(err, &reseed) {
+				return bootstrapFromVolume(ctx, api, attachmentID, logger)
+			}
+			return err
+		}
+		if err := updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+			checkpoint.HeadSeq = resp.HeadSeq
+			checkpoint.LastAppliedSeq = lastApplied
+			checkpoint.ReseedRequired = false
+		}); err != nil {
+			return err
+		}
+		if lastApplied >= resp.HeadSeq {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func upsertReplica(ctx context.Context, api *syncapi.Client, attachmentID string) (*apispec.VolumeSyncReplicaEnvelope, error) {
+	attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return nil, err
+	}
+	replica, err := api.UpsertReplica(ctx, attachment)
+	if err != nil {
+		return nil, err
+	}
+	if err := updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+		now := time.Now().UTC()
+		checkpoint.HeadSeq = replica.HeadSeq
+		checkpoint.LastReplicaSyncAt = &now
+		if checkpoint.LastAppliedSeq == 0 {
+			if lastApplied, ok := replica.Replica.LastAppliedSeq.Get(); ok {
+				checkpoint.LastAppliedSeq = lastApplied
+			}
+		}
+	}); err != nil {
+		return nil, err
+	}
+	return replica, nil
+}
+
+func refreshReplica(ctx context.Context, api *syncapi.Client, attachmentID string) error {
+	_, err := upsertReplica(ctx, api, attachmentID)
+	return err
+}
+
+func bootstrapFromVolume(ctx context.Context, api *syncapi.Client, attachmentID string, logger *log.Logger) error {
+	attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return err
+	}
+	bootstrap, err := api.Bootstrap(ctx, attachment)
+	if err != nil {
+		var compatibility *syncapi.BootstrapCompatibilityError
+		if errors.As(err, &compatibility) {
+			if compatibility.Details != nil && len(compatibility.Details.Issues) > 0 {
+				logger.Printf("Bootstrap compatibility conflict: %s", compatibility.Details.Issues[0].Code)
+			}
+		}
+		return err
+	}
+	archive, err := api.DownloadBootstrapArchive(ctx, attachment.VolumeID, bootstrap.Snapshot.ID)
+	if err != nil {
+		return err
+	}
+	if err := clearWorkspaceForBootstrap(attachment.WorkspaceRoot); err != nil {
+		return err
+	}
+	if err := extractBootstrapArchive(attachment.WorkspaceRoot, archive); err != nil {
+		return err
+	}
+	current, err := scanWorkspace(attachment.WorkspaceRoot)
+	if err != nil {
+		return err
+	}
+	if err := syncstate.SaveManifest(attachmentID, current); err != nil {
+		return err
+	}
+	if _, err := api.UpdateCursor(ctx, attachment, bootstrap.ReplayAfterSeq); err != nil {
+		return err
+	}
+	if err := updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+		checkpoint.HeadSeq = bootstrap.ReplayAfterSeq
+		checkpoint.LastAppliedSeq = bootstrap.ReplayAfterSeq
+		checkpoint.ReseedRequired = false
+	}); err != nil {
+		return err
+	}
+	logger.Printf("Workspace bootstrapped from snapshot %s at replay_after_seq=%d", bootstrap.Snapshot.ID, bootstrap.ReplayAfterSeq)
+	return nil
+}
+
+func seedFromLocal(ctx context.Context, api *syncapi.Client, attachmentID string, current *syncstate.Manifest, matcher *syncignore.Matcher, logger *log.Logger) error {
+	if _, err := upsertReplica(ctx, api, attachmentID); err != nil {
+		return err
+	}
+	attachment, err := syncstate.LoadAttachmentByID(attachmentID)
+	if err != nil {
+		return err
+	}
+
+	changes, err := buildUploadChanges(attachment.WorkspaceRoot, &syncstate.Manifest{Entries: map[string]syncstate.ManifestEntry{}}, current, matcher)
+	if err != nil {
+		return err
+	}
+	if len(changes) == 0 {
+		if err := syncstate.SaveManifest(attachmentID, current); err != nil {
+			return err
+		}
+		return updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+			if checkpoint.LastAppliedSeq < checkpoint.HeadSeq {
+				checkpoint.LastAppliedSeq = checkpoint.HeadSeq
+			}
+			checkpoint.ReseedRequired = false
+		})
+	}
+
+	resp, err := api.AppendChanges(ctx, attachment, attachment.LastSync.LastAppliedSeq, newRequestID(), changes)
+	if err != nil {
+		var reseed *syncapi.ReseedRequiredError
+		if errors.As(err, &reseed) {
+			logger.Printf("Local seed rejected because the remote journal was compacted; bootstrapping instead")
+			return bootstrapFromVolume(ctx, api, attachmentID, logger)
+		}
+		return err
+	}
+	if len(resp.Conflicts) > 0 {
+		if err := updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+			checkpoint.HeadSeq = resp.HeadSeq
+			checkpoint.OpenConflictCount = len(resp.Conflicts)
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := syncstate.SaveManifest(attachmentID, current); err != nil {
+		return err
+	}
+	if _, err := api.UpdateCursor(ctx, attachment, resp.HeadSeq); err != nil {
+		return err
+	}
+	return updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+		checkpoint.HeadSeq = resp.HeadSeq
+		checkpoint.LastAppliedSeq = resp.HeadSeq
+		checkpoint.OpenConflictCount = 0
+		checkpoint.ReseedRequired = false
+	})
+}
+
+func refreshOpenConflictCount(ctx context.Context, api *syncapi.Client, attachmentID, volumeID string) (int, error) {
+	conflicts, err := api.ListConflicts(ctx, volumeID, "open", 256)
+	if err != nil {
+		return 0, err
+	}
+	if err := updateCheckpoint(attachmentID, func(checkpoint *syncstate.SyncCheckpoint) {
+		checkpoint.OpenConflictCount = len(conflicts)
+	}); err != nil {
+		return 0, err
+	}
+	return len(conflicts), nil
+}
+
+func markSyncSuccess(attachmentID string) error {
+	now := time.Now().UTC()
+	_, err := syncstate.UpdateAttachment(attachmentID, func(attachment *syncstate.Attachment) error {
+		attachment.LastError = ""
+		if attachment.LastSync == nil {
+			attachment.LastSync = &syncstate.SyncCheckpoint{}
+		}
+		attachment.LastSync.LastSuccessAt = &now
+		attachment.LastSync.ConsecutiveErrors = 0
+		attachment.LastSync.ReseedRequired = false
+		return nil
+	})
+	return err
+}
+
+func recordSyncError(attachmentID string, workerErr error) error {
+	_, err := syncstate.UpdateAttachment(attachmentID, func(attachment *syncstate.Attachment) error {
+		if workerErr == nil {
+			attachment.LastError = ""
+			return nil
+		}
+		now := time.Now().UTC()
+		attachment.LastError = workerErr.Error()
+		if attachment.LastSync == nil {
+			attachment.LastSync = &syncstate.SyncCheckpoint{}
+		}
+		var reseed *syncapi.ReseedRequiredError
+		attachment.LastSync.LastFailureAt = &now
+		attachment.LastSync.ConsecutiveErrors++
+		attachment.LastSync.ReseedRequired = errors.As(workerErr, &reseed)
+		return nil
+	})
+	return err
+}
+
+func updateCheckpoint(attachmentID string, update func(*syncstate.SyncCheckpoint)) error {
+	_, err := syncstate.UpdateAttachment(attachmentID, func(attachment *syncstate.Attachment) error {
+		if attachment.LastSync == nil {
+			attachment.LastSync = &syncstate.SyncCheckpoint{}
+		}
+		update(attachment.LastSync)
+		return nil
+	})
+	return err
+}
+
+var errRemoteBootstrapRequired = errors.New("remote change requires bootstrap")
+
+func applyRemoteChange(root string, change apispec.SyncJournalEntry) (bool, error) {
+	event := optEvent(change.EventType)
+	switch event {
+	case string(apispec.SyncEventTypeRemove):
+		target := filepath.Join(root, filepath.FromSlash(optString(change.Path)))
+		if err := os.RemoveAll(target); err != nil {
+			return false, err
+		}
+		return true, nil
+	case string(apispec.SyncEventTypeRename):
+		oldPath := optNilString(change.OldPath)
+		newPath := optString(change.Path)
+		if oldPath == "" || newPath == "" {
+			return false, errRemoteBootstrapRequired
+		}
+		source := filepath.Join(root, filepath.FromSlash(oldPath))
+		destination := filepath.Join(root, filepath.FromSlash(newPath))
+		if _, err := os.Stat(source); err != nil {
+			if os.IsNotExist(err) {
+				return false, errRemoteBootstrapRequired
+			}
+			return false, err
+		}
+		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+			return false, err
+		}
+		if _, err := os.Stat(destination); err == nil {
+			return false, errRemoteBootstrapRequired
+		}
+		if err := os.Rename(source, destination); err != nil {
+			return false, err
+		}
+		return true, nil
+	default:
+		return false, errRemoteBootstrapRequired
+	}
+}
+
+func isOwnReplicaEcho(change apispec.SyncJournalEntry, replicaID string) bool {
+	source, ok := change.Source.Get()
+	if !ok || source != apispec.SyncJournalEntrySourceReplica {
+		return false
+	}
+	remoteReplicaID, ok := change.ReplicaID.Get()
+	return ok && remoteReplicaID == replicaID
+}
+
+func newRequestID() string {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return fmt.Sprintf("req-%d", time.Now().UnixNano())
+	}
+	return "req-" + hex.EncodeToString(bytes[:])
+}
+
+func optString(value apispec.OptString) string {
+	v, _ := value.Get()
+	return v
+}
+
+func optNilString(value apispec.OptNilString) string {
+	v, _ := value.Get()
+	return v
+}
+
+func optEvent(value apispec.OptSyncEventType) string {
+	v, _ := value.Get()
+	return string(v)
+}


### PR DESCRIPTION
## Summary
- add `s0 sync` attach/detach/list/status/logs/conflicts commands for local-first workspace sync
- add local attachment state, sync worker, `.gitignore`-aware scanning, and operator-focused conflict rendering
- surface backend conflict actor metadata including sandbox-specific labels in status and conflict detail views

Refs sandbox0-ai/sandbox0#87

## Testing
- go test ./internal/syncapi ./internal/syncignore ./internal/syncworker ./internal/syncview ./internal/output ./internal/commands ./internal/syncstate
- go test ./internal/syncview ./internal/output ./internal/commands
- go build ./cmd/s0