### PR TITLE
Bump sdk-go to v0.1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.1.14
+	github.com/sandbox0-ai/sdk-go v0.1.15
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.1.14 h1:BUTVbjiBVlIxGiZ0pjfgTHlNVGcu5D3Tbit+5hCZLJE=
 github.com/sandbox0-ai/sdk-go v0.1.14/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.1.15 h1:1A7NHypNdtxyCBBKAn5qENusu6ZwBLq6NWjL0Z+DbxQ=
+github.com/sandbox0-ai/sdk-go v0.1.15/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -487,7 +487,7 @@ func buildActivateTeamRequest(teamID string) *apispec.UpdateUserRequest {
 }
 
 func activateCreatedTeam(ctx context.Context, client *sandbox0.Client, teamID string) error {
-	res, err := client.API().TenantActivePut(ctx, buildActivateTeamRequest(teamID))
+	res, err := client.API().UsersMePut(ctx, buildActivateTeamRequest(teamID))
 	if err != nil {
 		return err
 	}

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -96,7 +96,7 @@ var userUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		res, err := client.API().TenantActivePut(cmd.Context(), req)
+		res, err := client.API().UsersMePut(cmd.Context(), req)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error updating user profile: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- bump `github.com/sandbox0-ai/sdk-go` from `v0.1.14` to `v0.1.15`
- switch `s0` user and team activation calls from `TenantActivePut` to `UsersMePut`
- refresh module sums for the upgraded sdk-go dependency

## Testing
- `go test ./...`