### PR TITLE
Support device login for OIDC auth

### DIFF
--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -13,6 +13,7 @@ import (
 var (
 	authEmail    string
 	authPassword string
+	authMode     string
 )
 
 var authCmd = &cobra.Command{
@@ -49,16 +50,27 @@ var authLoginCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		provider := providers[0]
+		provider, effectiveMode, err := selectAuthProvider(providers, authMode)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error selecting auth provider: %v\n", err)
+			os.Exit(1)
+		}
+
 		var loginData *authLoginData
-		switch provider.Type {
-		case "oidc":
-			loginData, err = oidcLoginViaBrowser(cmd.Context(), baseURL, provider.ID)
+		switch effectiveMode {
+		case authLoginModeDevice:
+			loginData, err = oidcLoginViaDeviceFlow(cmd.Context(), baseURL, provider.ID)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "OIDC login failed: %v\n", err)
+				fmt.Fprintf(os.Stderr, "OIDC device login failed: %v\n", err)
 				os.Exit(1)
 			}
-		case "builtin":
+		case authLoginModeBrowser:
+			loginData, err = oidcLoginViaBrowser(cmd.Context(), baseURL, provider.ID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "OIDC browser login failed: %v\n", err)
+				os.Exit(1)
+			}
+		case authLoginModeBuiltin:
 			email, password := resolveBuiltinCredentials()
 			loginData, err = builtinLogin(cmd.Context(), baseURL, email, password)
 			if err != nil {
@@ -66,7 +78,7 @@ var authLoginCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		default:
-			fmt.Fprintf(os.Stderr, "Error: unsupported provider type %q\n", provider.Type)
+			fmt.Fprintf(os.Stderr, "Error: unsupported login mode %q\n", effectiveMode)
 			os.Exit(1)
 		}
 
@@ -83,7 +95,7 @@ var authLoginCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("Login successful via provider %q (profile: %s)\n", provider.ID, profileName)
+		fmt.Printf("Login successful via provider %q using %s mode (profile: %s)\n", provider.ID, effectiveMode, profileName)
 		if shouldShowFirstTeamOnboardingHint(cmd.Context(), baseURL, loginData) {
 			fmt.Println("No active team is configured yet. Create and activate your first team with:")
 			fmt.Println("  s0 team create --name <name> --home-region <region-id> --activate")
@@ -167,5 +179,6 @@ func init() {
 
 	authLoginCmd.Flags().StringVar(&authEmail, "email", "", "email for built-in provider login")
 	authLoginCmd.Flags().StringVar(&authPassword, "password", "", "password for built-in provider login")
+	authLoginCmd.Flags().StringVar(&authMode, "mode", string(authLoginModeAuto), "login mode: auto, device, browser, builtin")
 	authLoginCmd.MarkFlagsRequiredTogether("email", "password")
 }

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -20,9 +20,11 @@ import (
 )
 
 type authProvider struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	Type                string `json:"type"`
+	BrowserLoginEnabled bool   `json:"browser_login_enabled"`
+	DeviceLoginEnabled  bool   `json:"device_login_enabled"`
 }
 
 type authLoginData struct {
@@ -45,6 +47,15 @@ type authEnvelope struct {
 		Message string `json:"message"`
 	} `json:"error,omitempty"`
 }
+
+type authLoginMode string
+
+const (
+	authLoginModeAuto    authLoginMode = "auto"
+	authLoginModeDevice  authLoginMode = "device"
+	authLoginModeBrowser authLoginMode = "browser"
+	authLoginModeBuiltin authLoginMode = "builtin"
+)
 
 func authRequest(ctx context.Context, method, endpoint, token string, requestBody any, responseData any) error {
 	var body io.Reader
@@ -108,6 +119,56 @@ func fetchAuthProviders(ctx context.Context, baseURL string) ([]authProvider, er
 		return nil, err
 	}
 	return data.Providers, nil
+}
+
+func selectAuthProvider(providers []authProvider, requestedMode string) (*authProvider, authLoginMode, error) {
+	mode := authLoginMode(strings.TrimSpace(strings.ToLower(requestedMode)))
+	if mode == "" {
+		mode = authLoginModeAuto
+	}
+
+	switch mode {
+	case authLoginModeAuto:
+		for i := range providers {
+			provider := &providers[i]
+			if provider.Type == "oidc" && provider.DeviceLoginEnabled {
+				return provider, authLoginModeDevice, nil
+			}
+			if provider.Type == "oidc" && provider.BrowserLoginEnabled {
+				return provider, authLoginModeBrowser, nil
+			}
+			if provider.Type == "builtin" {
+				return provider, authLoginModeBuiltin, nil
+			}
+		}
+		return nil, "", fmt.Errorf("no supported auth provider found")
+	case authLoginModeDevice:
+		for i := range providers {
+			provider := &providers[i]
+			if provider.Type == "oidc" && provider.DeviceLoginEnabled {
+				return provider, authLoginModeDevice, nil
+			}
+		}
+		return nil, "", fmt.Errorf("no OIDC provider with device login is enabled on server")
+	case authLoginModeBrowser:
+		for i := range providers {
+			provider := &providers[i]
+			if provider.Type == "oidc" && provider.BrowserLoginEnabled {
+				return provider, authLoginModeBrowser, nil
+			}
+		}
+		return nil, "", fmt.Errorf("no OIDC provider with browser login is enabled on server")
+	case authLoginModeBuiltin:
+		for i := range providers {
+			provider := &providers[i]
+			if provider.Type == "builtin" {
+				return provider, authLoginModeBuiltin, nil
+			}
+		}
+		return nil, "", fmt.Errorf("built-in auth is not enabled on server")
+	default:
+		return nil, "", fmt.Errorf("unsupported auth mode %q", requestedMode)
+	}
 }
 
 func fetchGatewayMode(ctx context.Context, baseURL string) (config.GatewayMode, bool) {
@@ -307,6 +368,91 @@ func oidcLoginViaBrowser(ctx context.Context, baseURL, providerID string) (*auth
 	case <-time.After(3 * time.Minute):
 		_ = server.Shutdown(context.Background())
 		return nil, fmt.Errorf("oidc login timed out")
+	}
+}
+
+func oidcLoginViaDeviceFlow(ctx context.Context, baseURL, providerID string) (*authLoginData, error) {
+	type startResponse struct {
+		DeviceLoginID           string `json:"device_login_id"`
+		UserCode                string `json:"user_code"`
+		VerificationURI         string `json:"verification_uri"`
+		VerificationURIComplete string `json:"verification_uri_complete"`
+		ExpiresAt               int64  `json:"expires_at"`
+		IntervalSeconds         int    `json:"interval_seconds"`
+	}
+	var start startResponse
+	if err := authRequest(
+		ctx,
+		http.MethodPost,
+		strings.TrimRight(baseURL, "/")+"/auth/oidc/"+url.PathEscape(providerID)+"/device/start",
+		"",
+		nil,
+		&start,
+	); err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Open %s and enter code %s to continue login.\n", start.VerificationURI, start.UserCode)
+	if start.VerificationURIComplete != "" {
+		if err := openBrowser(start.VerificationURIComplete); err != nil {
+			fmt.Printf("Open browser failed, please open manually:\n%s\n", start.VerificationURIComplete)
+		}
+	}
+
+	type pollResponse struct {
+		Status          string         `json:"status"`
+		IntervalSeconds int            `json:"interval_seconds"`
+		ExpiresAt       int64          `json:"expires_at"`
+		Login           *authLoginData `json:"login"`
+	}
+
+	interval := start.IntervalSeconds
+	if interval <= 0 {
+		interval = 5
+	}
+
+	for {
+		if start.ExpiresAt > 0 && time.Now().Unix() >= start.ExpiresAt {
+			return nil, fmt.Errorf("device login expired before completion")
+		}
+
+		var poll pollResponse
+		if err := authRequest(
+			ctx,
+			http.MethodPost,
+			strings.TrimRight(baseURL, "/")+"/auth/oidc/"+url.PathEscape(providerID)+"/device/poll",
+			"",
+			map[string]string{"device_login_id": start.DeviceLoginID},
+			&poll,
+		); err != nil {
+			return nil, err
+		}
+
+		switch poll.Status {
+		case "completed":
+			if poll.Login == nil {
+				return nil, fmt.Errorf("device login completed without login data")
+			}
+			return poll.Login, nil
+		case "slow_down":
+			if poll.IntervalSeconds > interval {
+				interval = poll.IntervalSeconds
+			} else {
+				interval += 5
+			}
+		case "pending":
+			if poll.IntervalSeconds > 0 {
+				interval = poll.IntervalSeconds
+			}
+		default:
+			return nil, fmt.Errorf("unexpected device login status %q", poll.Status)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Duration(interval) * time.Second):
+		}
 	}
 }
 

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -70,3 +70,28 @@ func TestAuthLoginCommandDoesNotExposeHomeRegionFlag(t *testing.T) {
 		t.Fatalf("home-region flag should be removed, got %v", flag)
 	}
 }
+
+func TestSelectAuthProviderAutoPrefersDeviceOIDC(t *testing.T) {
+	provider, mode, err := selectAuthProvider([]authProvider{
+		{ID: "auth0", Type: "oidc", BrowserLoginEnabled: true, DeviceLoginEnabled: true},
+		{ID: "builtin", Type: "builtin"},
+	}, "auto")
+	if err != nil {
+		t.Fatalf("selectAuthProvider() error = %v", err)
+	}
+	if provider.ID != "auth0" {
+		t.Fatalf("provider = %q, want auth0", provider.ID)
+	}
+	if mode != authLoginModeDevice {
+		t.Fatalf("mode = %q, want %q", mode, authLoginModeDevice)
+	}
+}
+
+func TestSelectAuthProviderBuiltinModeRequiresBuiltinProvider(t *testing.T) {
+	_, _, err := selectAuthProvider([]authProvider{
+		{ID: "auth0", Type: "oidc", BrowserLoginEnabled: true, DeviceLoginEnabled: true},
+	}, "builtin")
+	if err == nil {
+		t.Fatal("expected error when builtin provider is absent")
+	}
+}


### PR DESCRIPTION
## Summary
- add auth mode selection for auto, device, browser, and builtin login
- prefer OIDC device flow in auto mode when the provider advertises support
- keep builtin email and password login for self-hosted and dev workflows

Refs sandbox0-ai/sandbox0-cloud#28

## Testing
- go test ./internal/commands