### PR TITLE
Move current team selection into the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ profiles:
   default:
     api-url: https://api.sandbox0.ai
     gateway-mode: direct
+    current-team-id: team_123
     token: ${SANDBOX0_TOKEN}
 output:
   format: table
@@ -106,7 +107,7 @@ output:
 `gateway-mode` supports:
 
 - `direct`: `api-url` is the working control-plane entrypoint.
-- `global`: `api-url` is a Global Gateway entrypoint and workload commands are routed through the active team's home region.
+- `global`: `api-url` is a Global Gateway entrypoint and workload commands are routed through the locally selected current team's home region.
 
 Mode resolution order:
 
@@ -135,12 +136,13 @@ Flags:
   --token string     Override API token
 ```
 
-In `global` mode, `auth`, `user`, `team`, and `admin` commands stay on the configured entrypoint. Workload-facing commands such as `sandbox`, `template`, `volume`, `credential`, `apikey`, and registry credential flows resolve the active team and switch to the home-region gateway automatically.
+In `global` mode, `auth`, `user`, `team`, and `admin` commands stay on the configured entrypoint. Workload-facing commands such as `sandbox`, `template`, `volume`, `credential`, `apikey`, and registry credential flows use the locally selected current team and switch to the home-region gateway automatically.
 
-If a newly authenticated global-gateway user has no default team yet, finish first-team onboarding with:
+If a global-gateway profile has no current team selected yet, create one if needed and then select it locally:
 
 ```bash
-s0 team create --name <name> --home-region <region-id> --activate
+s0 team create --name <name> --home-region <region-id>
+s0 team use <team-id>
 ```
 
 ## Commands
@@ -148,7 +150,8 @@ s0 team create --name <name> --home-region <region-id> --activate
 ### Team
 
 ```bash
-s0 team create --name <name> [--slug <slug>] [--home-region <region-id>] [--activate]
+s0 team create --name <name> [--slug <slug>] [--home-region <region-id>]
+s0 team use <team-id>
 ```
 
 ### Admin Region

--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -28,10 +29,13 @@ type ResolveTargetOptions struct {
 	BaseURL               string
 	Token                 string
 	ConfiguredGatewayMode config.GatewayMode
+	CurrentTeamID         string
 	RegionalSession       *config.RegionalSession
 	Scope                 RouteScope
 	UserAgent             string
 }
+
+var ErrCurrentTeamRequired = errors.New("current team is not set; run `s0 team use <team-id>`")
 
 // ResolveTarget resolves the correct API target for the current command scope.
 func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTarget, error) {
@@ -52,6 +56,9 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 	if opts.Scope != RouteScopeHomeRegion || mode != config.GatewayModeGlobal {
 		return target, nil
 	}
+	if strings.TrimSpace(opts.CurrentTeamID) == "" {
+		return nil, ErrCurrentTeamRequired
+	}
 
 	if regionalTarget, ok := resolveStoredRegionalTarget(opts.RegionalSession, mode); ok {
 		return regionalTarget, nil
@@ -62,23 +69,8 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 		return nil, err
 	}
 
-	activeTeamRes, err := globalClient.API().TenantActiveGet(ctx, apispec.TenantActiveGetParams{})
-	if err != nil {
-		return nil, fmt.Errorf("resolve active team: %w", err)
-	}
-
-	activeTeamSuccess, ok := activeTeamRes.(*apispec.SuccessActiveTeamResponse)
-	if !ok {
-		return nil, fmt.Errorf("resolve active team: unexpected response type %T", activeTeamRes)
-	}
-
-	activeTeam, ok := activeTeamSuccess.Data.Get()
-	if !ok {
-		return nil, fmt.Errorf("resolve active team: missing response data")
-	}
-
 	regionTokenRes, err := globalClient.API().AuthRegionTokenPost(ctx, apispec.NewOptIssueRegionTokenRequest(apispec.IssueRegionTokenRequest{
-		TeamID: apispec.NewOptString(activeTeam.TeamID),
+		TeamID: apispec.NewOptString(strings.TrimSpace(opts.CurrentTeamID)),
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("issue region token: %w", err)

--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -35,6 +35,10 @@ type ResolveTargetOptions struct {
 var ErrCurrentTeamRequired = errors.New("current team is not set; run `s0 team use <team-id>`")
 var ErrCurrentTeamTargetRequired = errors.New("current team region endpoint is not set; run `s0 team use <team-id>`")
 
+func tokenUsesImplicitTeamSelection(token string) bool {
+	return !strings.HasPrefix(strings.TrimSpace(token), "s0_")
+}
+
 // ResolveTarget resolves the correct API target for the current command scope.
 func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTarget, error) {
 	mode := opts.ConfiguredGatewayMode
@@ -51,7 +55,13 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 		Token:       opts.Token,
 		GatewayMode: mode,
 	}
-	if opts.Scope != RouteScopeHomeRegion || mode != config.GatewayModeGlobal {
+	if opts.Scope != RouteScopeHomeRegion {
+		return target, nil
+	}
+	if tokenUsesImplicitTeamSelection(opts.Token) && strings.TrimSpace(opts.CurrentTeamID) == "" {
+		return nil, ErrCurrentTeamRequired
+	}
+	if mode != config.GatewayModeGlobal {
 		return target, nil
 	}
 	if strings.TrimSpace(opts.CurrentTeamID) == "" {

--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -3,13 +3,10 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
-	"time"
 
 	"github.com/sandbox0-ai/s0/internal/config"
 	sandbox0 "github.com/sandbox0-ai/sdk-go"
-	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
 type RouteScope string
@@ -30,12 +27,13 @@ type ResolveTargetOptions struct {
 	Token                 string
 	ConfiguredGatewayMode config.GatewayMode
 	CurrentTeamID         string
-	RegionalSession       *config.RegionalSession
+	CurrentTeamTarget     *config.CurrentTeamTarget
 	Scope                 RouteScope
 	UserAgent             string
 }
 
 var ErrCurrentTeamRequired = errors.New("current team is not set; run `s0 team use <team-id>`")
+var ErrCurrentTeamTargetRequired = errors.New("current team region endpoint is not set; run `s0 team use <team-id>`")
 
 // ResolveTarget resolves the correct API target for the current command scope.
 func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTarget, error) {
@@ -59,60 +57,15 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 	if strings.TrimSpace(opts.CurrentTeamID) == "" {
 		return nil, ErrCurrentTeamRequired
 	}
-
-	if regionalTarget, ok := resolveStoredRegionalTarget(opts.RegionalSession, mode); ok {
-		return regionalTarget, nil
-	}
-
-	globalClient, err := newSDKClient(opts.BaseURL, opts.Token, opts.UserAgent)
-	if err != nil {
-		return nil, err
-	}
-
-	regionTokenRes, err := globalClient.API().AuthRegionTokenPost(ctx, apispec.NewOptIssueRegionTokenRequest(apispec.IssueRegionTokenRequest{
-		TeamID: apispec.NewOptString(strings.TrimSpace(opts.CurrentTeamID)),
-	}))
-	if err != nil {
-		return nil, fmt.Errorf("issue region token: %w", err)
-	}
-
-	regionTokenSuccess, ok := regionTokenRes.(*apispec.SuccessIssueRegionTokenResponse)
-	if !ok {
-		return nil, fmt.Errorf("issue region token: unexpected response type %T", regionTokenRes)
-	}
-
-	regionToken, ok := regionTokenSuccess.Data.Get()
-	if !ok {
-		return nil, fmt.Errorf("issue region token: missing response data")
-	}
-
-	regionalGatewayURL, ok := regionToken.RegionalGatewayURL.Get()
-	if !ok || strings.TrimSpace(regionalGatewayURL) == "" {
-		return nil, fmt.Errorf("issue region token: missing regional gateway URL")
+	if opts.CurrentTeamTarget == nil || strings.TrimSpace(opts.CurrentTeamTarget.GatewayURL) == "" {
+		return nil, ErrCurrentTeamTargetRequired
 	}
 
 	return &ResolvedTarget{
-		BaseURL:     regionalGatewayURL,
-		Token:       regionToken.Token,
+		BaseURL:     opts.CurrentTeamTarget.GatewayURL,
+		Token:       opts.Token,
 		GatewayMode: mode,
 	}, nil
-}
-
-func resolveStoredRegionalTarget(session *config.RegionalSession, mode config.GatewayMode) (*ResolvedTarget, bool) {
-	if session == nil {
-		return nil, false
-	}
-	if strings.TrimSpace(session.Token) == "" || strings.TrimSpace(session.GatewayURL) == "" {
-		return nil, false
-	}
-	if session.ExpiresAt != 0 && time.Now().Unix() >= session.ExpiresAt-30 {
-		return nil, false
-	}
-	return &ResolvedTarget{
-		BaseURL:     session.GatewayURL,
-		Token:       session.Token,
-		GatewayMode: mode,
-	}, true
 }
 
 func discoverGatewayMode(ctx context.Context, baseURL, userAgent string) (config.GatewayMode, bool) {

--- a/internal/client/routing_test.go
+++ b/internal/client/routing_test.go
@@ -16,7 +16,7 @@ func TestResolveTargetDefaultsToDirectWhenMetadataIsMissing(t *testing.T) {
 
 	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
 		BaseURL:   server.URL,
-		Token:     "token-1",
+		Token:     "s0_api_key_1",
 		Scope:     RouteScopeHomeRegion,
 		UserAgent: "s0/test",
 	})
@@ -27,11 +27,44 @@ func TestResolveTargetDefaultsToDirectWhenMetadataIsMissing(t *testing.T) {
 	if target.BaseURL != server.URL {
 		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, server.URL)
 	}
-	if target.Token != "token-1" {
-		t.Fatalf("Token = %q, want token-1", target.Token)
+	if target.Token != "s0_api_key_1" {
+		t.Fatalf("Token = %q, want s0_api_key_1", target.Token)
 	}
 	if target.GatewayMode != config.GatewayModeDirect {
 		t.Fatalf("GatewayMode = %q, want %q", target.GatewayMode, config.GatewayModeDirect)
+	}
+}
+
+func TestResolveTargetRequiresCurrentTeamForDirectHomeRegionRoutingWithUserToken(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:   server.URL,
+		Token:     "user-token",
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
+	})
+	if err != ErrCurrentTeamRequired {
+		t.Fatalf("ResolveTarget() error = %v, want %v", err, ErrCurrentTeamRequired)
+	}
+}
+
+func TestResolveTargetAllowsDirectHomeRegionRoutingWithAPIKeyWithoutCurrentTeam(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:   server.URL,
+		Token:     "s0_api_key_1",
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+	if target.BaseURL != server.URL {
+		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, server.URL)
 	}
 }
 

--- a/internal/client/routing_test.go
+++ b/internal/client/routing_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,8 +36,35 @@ func TestResolveTargetDefaultsToDirectWhenMetadataIsMissing(t *testing.T) {
 	}
 }
 
+func TestResolveTargetRequiresCurrentTeamForGlobalHomeRegionRouting(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metadata" {
+			http.NotFound(w, r)
+			return
+		}
+
+		writeJSON(t, w, http.StatusOK, map[string]any{
+			"success": true,
+			"data": map[string]any{
+				"gateway_mode": "global",
+				"service":      "global-gateway",
+			},
+		})
+	}))
+	defer server.Close()
+
+	_, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:   server.URL,
+		Token:     "global-token",
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
+	})
+	if err != ErrCurrentTeamRequired {
+		t.Fatalf("ResolveTarget() error = %v, want %v", err, ErrCurrentTeamRequired)
+	}
+}
+
 func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
-	var tenantActiveCalls int
 	var regionTokenCalls int
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,21 +77,21 @@ func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
 					"service":      "global-gateway",
 				},
 			})
-		case "/tenant/active":
-			tenantActiveCalls++
-			writeJSON(t, w, http.StatusOK, map[string]any{
-				"success": true,
-				"data": map[string]any{
-					"user_id":              "user-1",
-					"team_id":              "team-1",
-					"team_role":            "admin",
-					"home_region_id":       "aws/us-east-1",
-					"default_team":         true,
-					"regional_gateway_url": "https://regional.example.com",
-				},
-			})
 		case "/auth/region-token":
 			regionTokenCalls++
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			var request struct {
+				TeamID string `json:"team_id"`
+			}
+			if err := json.Unmarshal(body, &request); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if request.TeamID != "team-1" {
+				t.Fatalf("team_id = %q, want team-1", request.TeamID)
+			}
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"success": true,
 				"data": map[string]any{
@@ -80,10 +108,11 @@ func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
 	defer server.Close()
 
 	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
-		BaseURL:   server.URL,
-		Token:     "global-token",
-		Scope:     RouteScopeHomeRegion,
-		UserAgent: "s0/test",
+		BaseURL:       server.URL,
+		Token:         "global-token",
+		CurrentTeamID: "team-1",
+		Scope:         RouteScopeHomeRegion,
+		UserAgent:     "s0/test",
 	})
 	if err != nil {
 		t.Fatalf("ResolveTarget() error = %v", err)
@@ -95,16 +124,12 @@ func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
 	if target.Token != "region-token" {
 		t.Fatalf("Token = %q, want region-token", target.Token)
 	}
-	if tenantActiveCalls != 1 {
-		t.Fatalf("tenant/active calls = %d, want 1", tenantActiveCalls)
-	}
 	if regionTokenCalls != 1 {
 		t.Fatalf("auth/region-token calls = %d, want 1", regionTokenCalls)
 	}
 }
 
 func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T) {
-	var tenantActiveCalls int
 	var regionTokenCalls int
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -117,9 +142,6 @@ func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T
 					"service":      "global-gateway",
 				},
 			})
-		case "/tenant/active":
-			tenantActiveCalls++
-			http.Error(w, "unexpected", http.StatusInternalServerError)
 		case "/auth/region-token":
 			regionTokenCalls++
 			http.Error(w, "unexpected", http.StatusInternalServerError)
@@ -130,9 +152,11 @@ func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T
 	defer server.Close()
 
 	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
-		BaseURL: server.URL,
-		Token:   "global-token",
+		BaseURL:       server.URL,
+		Token:         "global-token",
+		CurrentTeamID: "team-1",
 		RegionalSession: &config.RegionalSession{
+			TeamID:     "team-1",
 			Token:      "regional-token",
 			GatewayURL: "https://regional.example.com",
 			RegionID:   "aws/us-east-1",
@@ -151,16 +175,12 @@ func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T
 	if target.Token != "regional-token" {
 		t.Fatalf("Token = %q, want regional-token", target.Token)
 	}
-	if tenantActiveCalls != 0 {
-		t.Fatalf("tenant/active calls = %d, want 0", tenantActiveCalls)
-	}
 	if regionTokenCalls != 0 {
 		t.Fatalf("auth/region-token calls = %d, want 0", regionTokenCalls)
 	}
 }
 
 func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
-	var tenantActiveCalls int
 	var regionTokenCalls int
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -173,9 +193,6 @@ func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
 					"service":      "global-gateway",
 				},
 			})
-		case "/tenant/active":
-			tenantActiveCalls++
-			http.Error(w, "unexpected", http.StatusInternalServerError)
 		case "/auth/region-token":
 			regionTokenCalls++
 			http.Error(w, "unexpected", http.StatusInternalServerError)
@@ -201,9 +218,6 @@ func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
 	if target.Token != "global-token" {
 		t.Fatalf("Token = %q, want global-token", target.Token)
 	}
-	if tenantActiveCalls != 0 {
-		t.Fatalf("tenant/active calls = %d, want 0", tenantActiveCalls)
-	}
 	if regionTokenCalls != 0 {
 		t.Fatalf("auth/region-token calls = %d, want 0", regionTokenCalls)
 	}
@@ -214,18 +228,6 @@ func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *te
 		switch r.URL.Path {
 		case "/metadata":
 			http.NotFound(w, r)
-		case "/tenant/active":
-			writeJSON(t, w, http.StatusOK, map[string]any{
-				"success": true,
-				"data": map[string]any{
-					"user_id":              "user-1",
-					"team_id":              "team-1",
-					"team_role":            "admin",
-					"home_region_id":       "aws/us-east-1",
-					"default_team":         true,
-					"regional_gateway_url": "https://regional.example.com",
-				},
-			})
 		case "/auth/region-token":
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"success": true,
@@ -246,6 +248,7 @@ func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *te
 		BaseURL:               server.URL,
 		Token:                 "global-token",
 		ConfiguredGatewayMode: config.GatewayModeGlobal,
+		CurrentTeamID:         "team-1",
 		Scope:                 RouteScopeHomeRegion,
 		UserAgent:             "s0/test",
 	})

--- a/internal/client/routing_test.go
+++ b/internal/client/routing_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,9 +63,7 @@ func TestResolveTargetRequiresCurrentTeamForGlobalHomeRegionRouting(t *testing.T
 	}
 }
 
-func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
-	var regionTokenCalls int
-
+func TestResolveTargetUsesCachedCurrentTeamGatewayForGlobalHomeRegionRouting(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/metadata":
@@ -75,30 +72,6 @@ func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
 				"data": map[string]any{
 					"gateway_mode": "global",
 					"service":      "global-gateway",
-				},
-			})
-		case "/auth/region-token":
-			regionTokenCalls++
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatalf("read request body: %v", err)
-			}
-			var request struct {
-				TeamID string `json:"team_id"`
-			}
-			if err := json.Unmarshal(body, &request); err != nil {
-				t.Fatalf("decode request body: %v", err)
-			}
-			if request.TeamID != "team-1" {
-				t.Fatalf("team_id = %q, want team-1", request.TeamID)
-			}
-			writeJSON(t, w, http.StatusOK, map[string]any{
-				"success": true,
-				"data": map[string]any{
-					"region_id":            "aws/us-east-1",
-					"regional_gateway_url": "https://regional.example.com",
-					"token":                "region-token",
-					"expires_at":           int64(1893456000),
 				},
 			})
 		default:
@@ -111,56 +84,10 @@ func TestResolveTargetUsesGlobalHomeRegionRouting(t *testing.T) {
 		BaseURL:       server.URL,
 		Token:         "global-token",
 		CurrentTeamID: "team-1",
-		Scope:         RouteScopeHomeRegion,
-		UserAgent:     "s0/test",
-	})
-	if err != nil {
-		t.Fatalf("ResolveTarget() error = %v", err)
-	}
-
-	if target.BaseURL != "https://regional.example.com" {
-		t.Fatalf("BaseURL = %q, want regional gateway URL", target.BaseURL)
-	}
-	if target.Token != "region-token" {
-		t.Fatalf("Token = %q, want region-token", target.Token)
-	}
-	if regionTokenCalls != 1 {
-		t.Fatalf("auth/region-token calls = %d, want 1", regionTokenCalls)
-	}
-}
-
-func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T) {
-	var regionTokenCalls int
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/metadata":
-			writeJSON(t, w, http.StatusOK, map[string]any{
-				"success": true,
-				"data": map[string]any{
-					"gateway_mode": "global",
-					"service":      "global-gateway",
-				},
-			})
-		case "/auth/region-token":
-			regionTokenCalls++
-			http.Error(w, "unexpected", http.StatusInternalServerError)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
-		BaseURL:       server.URL,
-		Token:         "global-token",
-		CurrentTeamID: "team-1",
-		RegionalSession: &config.RegionalSession{
+		CurrentTeamTarget: &config.CurrentTeamTarget{
 			TeamID:     "team-1",
-			Token:      "regional-token",
 			GatewayURL: "https://regional.example.com",
 			RegionID:   "aws/us-east-1",
-			ExpiresAt:  1893456000,
 		},
 		Scope:     RouteScopeHomeRegion,
 		UserAgent: "s0/test",
@@ -172,17 +99,12 @@ func TestResolveTargetUsesStoredRegionalSessionBeforeGlobalExchange(t *testing.T
 	if target.BaseURL != "https://regional.example.com" {
 		t.Fatalf("BaseURL = %q, want regional gateway URL", target.BaseURL)
 	}
-	if target.Token != "regional-token" {
-		t.Fatalf("Token = %q, want regional-token", target.Token)
-	}
-	if regionTokenCalls != 0 {
-		t.Fatalf("auth/region-token calls = %d, want 0", regionTokenCalls)
+	if target.Token != "global-token" {
+		t.Fatalf("Token = %q, want global-token", target.Token)
 	}
 }
 
-func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
-	var regionTokenCalls int
-
+func TestResolveTargetRequiresCurrentTeamTargetForGlobalHomeRegionRouting(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/metadata":
@@ -193,9 +115,35 @@ func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
 					"service":      "global-gateway",
 				},
 			})
-		case "/auth/region-token":
-			regionTokenCalls++
-			http.Error(w, "unexpected", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	_, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+		BaseURL:       server.URL,
+		Token:         "global-token",
+		CurrentTeamID: "team-1",
+		Scope:         RouteScopeHomeRegion,
+		UserAgent:     "s0/test",
+	})
+	if err != ErrCurrentTeamTargetRequired {
+		t.Fatalf("ResolveTarget() error = %v, want %v", err, ErrCurrentTeamTargetRequired)
+	}
+}
+
+func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metadata":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"gateway_mode": "global",
+					"service":      "global-gateway",
+				},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -218,9 +166,6 @@ func TestResolveTargetKeepsEntrypointCommandsOnGlobalGateway(t *testing.T) {
 	if target.Token != "global-token" {
 		t.Fatalf("Token = %q, want global-token", target.Token)
 	}
-	if regionTokenCalls != 0 {
-		t.Fatalf("auth/region-token calls = %d, want 0", regionTokenCalls)
-	}
 }
 
 func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *testing.T) {
@@ -228,16 +173,6 @@ func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *te
 		switch r.URL.Path {
 		case "/metadata":
 			http.NotFound(w, r)
-		case "/auth/region-token":
-			writeJSON(t, w, http.StatusOK, map[string]any{
-				"success": true,
-				"data": map[string]any{
-					"region_id":            "aws/us-east-1",
-					"regional_gateway_url": "https://regional.example.com",
-					"token":                "region-token",
-					"expires_at":           int64(1893456000),
-				},
-			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -249,8 +184,13 @@ func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *te
 		Token:                 "global-token",
 		ConfiguredGatewayMode: config.GatewayModeGlobal,
 		CurrentTeamID:         "team-1",
-		Scope:                 RouteScopeHomeRegion,
-		UserAgent:             "s0/test",
+		CurrentTeamTarget: &config.CurrentTeamTarget{
+			TeamID:     "team-1",
+			GatewayURL: "https://regional.example.com",
+			RegionID:   "aws/us-east-1",
+		},
+		Scope:     RouteScopeHomeRegion,
+		UserAgent: "s0/test",
 	})
 	if err != nil {
 		t.Fatalf("ResolveTarget() error = %v", err)
@@ -259,8 +199,8 @@ func TestResolveTargetHonorsConfiguredGatewayModeWhenMetadataIsUnavailable(t *te
 	if target.BaseURL != "https://regional.example.com" {
 		t.Fatalf("BaseURL = %q, want regional gateway URL", target.BaseURL)
 	}
-	if target.Token != "region-token" {
-		t.Fatalf("Token = %q, want region-token", target.Token)
+	if target.Token != "global-token" {
+		t.Fatalf("Token = %q, want global-token", target.Token)
 	}
 }
 

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -90,9 +90,10 @@ var authLoginCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Login successful via provider %q using %s mode (profile: %s)\n", provider.ID, effectiveMode, profileName)
-		if shouldShowFirstTeamOnboardingHint(cmd.Context(), baseURL, loginData) {
-			fmt.Println("No active team is configured yet. Create and activate your first team with:")
-			fmt.Println("  s0 team create --name <name> --home-region <region-id> --activate")
+		if shouldShowCurrentTeamSelectionHint(cmd.Context(), baseURL, p.GetCurrentTeamID()) {
+			fmt.Println("Global routing requires a locally selected current team for workload commands.")
+			fmt.Println("Set it with: s0 team use <team-id>")
+			fmt.Println("If you do not have a team yet, create one with: s0 team create --name <name> --home-region <region-id>")
 		}
 	},
 }

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -82,7 +82,6 @@ var authLoginCmd = &cobra.Command{
 			loginData.AccessToken,
 			loginData.RefreshToken,
 			loginData.ExpiresAt,
-			toRegionalSessionConfig(loginData),
 		)
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving credentials: %v\n", err)

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -232,7 +232,6 @@ func getProfileWithFreshToken() (*config.Profile, error) {
 		refreshed.AccessToken,
 		refreshed.RefreshToken,
 		refreshed.ExpiresAt,
-		nil,
 	)
 	if err := cfg.Save(); err != nil {
 		return nil, fmt.Errorf("save refreshed credentials: %w", err)
@@ -336,10 +335,6 @@ func shouldShowCurrentTeamSelectionHint(ctx context.Context, baseURL, currentTea
 
 	mode, ok := fetchGatewayMode(ctx, baseURL)
 	return ok && mode == config.GatewayModeGlobal
-}
-
-func toRegionalSessionConfig(data *authLoginData) *config.RegionalSession {
-	return nil
 }
 
 func openBrowser(targetURL string) error {

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -26,15 +26,9 @@ type authProvider struct {
 }
 
 type authLoginData struct {
-	AccessToken     string `json:"access_token"`
-	RefreshToken    string `json:"refresh_token"`
-	ExpiresAt       int64  `json:"expires_at"`
-	RegionalSession *struct {
-		RegionID           string `json:"region_id"`
-		RegionalGatewayURL string `json:"regional_gateway_url"`
-		Token              string `json:"token"`
-		ExpiresAt          int64  `json:"expires_at"`
-	} `json:"regional_session,omitempty"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at"`
 }
 
 type authEnvelope struct {
@@ -238,7 +232,7 @@ func getProfileWithFreshToken() (*config.Profile, error) {
 		refreshed.AccessToken,
 		refreshed.RefreshToken,
 		refreshed.ExpiresAt,
-		toRegionalSessionConfig(refreshed),
+		nil,
 	)
 	if err := cfg.Save(); err != nil {
 		return nil, fmt.Errorf("save refreshed credentials: %w", err)
@@ -335,8 +329,8 @@ func oidcLoginViaDeviceFlow(ctx context.Context, baseURL, providerID string) (*a
 	}
 }
 
-func shouldShowFirstTeamOnboardingHint(ctx context.Context, baseURL string, data *authLoginData) bool {
-	if data == nil || data.RegionalSession != nil {
+func shouldShowCurrentTeamSelectionHint(ctx context.Context, baseURL, currentTeamID string) bool {
+	if strings.TrimSpace(currentTeamID) != "" {
 		return false
 	}
 
@@ -345,21 +339,7 @@ func shouldShowFirstTeamOnboardingHint(ctx context.Context, baseURL string, data
 }
 
 func toRegionalSessionConfig(data *authLoginData) *config.RegionalSession {
-	if data == nil || data.RegionalSession == nil {
-		return nil
-	}
-	if data.RegionalSession.Token == "" ||
-		data.RegionalSession.RegionalGatewayURL == "" ||
-		data.RegionalSession.RegionID == "" ||
-		data.RegionalSession.ExpiresAt == 0 {
-		return nil
-	}
-	return &config.RegionalSession{
-		Token:      data.RegionalSession.Token,
-		GatewayURL: data.RegionalSession.RegionalGatewayURL,
-		RegionID:   data.RegionalSession.RegionID,
-		ExpiresAt:  data.RegionalSession.ExpiresAt,
-	}
+	return nil
 }
 
 func openBrowser(targetURL string) error {

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -329,12 +329,12 @@ func oidcLoginViaDeviceFlow(ctx context.Context, baseURL, providerID string) (*a
 }
 
 func shouldShowCurrentTeamSelectionHint(ctx context.Context, baseURL, currentTeamID string) bool {
+	_ = ctx
+	_ = baseURL
 	if strings.TrimSpace(currentTeamID) != "" {
 		return false
 	}
-
-	mode, ok := fetchGatewayMode(ctx, baseURL)
-	return ok && mode == config.GatewayModeGlobal
+	return true
 }
 
 func openBrowser(targetURL string) error {

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -2,41 +2,17 @@ package commands
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
 func TestShouldShowCurrentTeamSelectionHint(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/metadata" {
-			http.NotFound(w, r)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"success":true,"data":{"gateway_mode":"global","service":"global-gateway"}}`))
-	}))
-	defer server.Close()
-
-	if !shouldShowCurrentTeamSelectionHint(context.Background(), server.URL, "") {
+	if !shouldShowCurrentTeamSelectionHint(context.Background(), "http://127.0.0.1:0", "") {
 		t.Fatal("shouldShowCurrentTeamSelectionHint() = false, want true")
 	}
 }
 
 func TestShouldShowCurrentTeamSelectionHintSkipsWhenCurrentTeamExists(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/metadata" {
-			http.NotFound(w, r)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"success":true,"data":{"gateway_mode":"global","service":"global-gateway"}}`))
-	}))
-	defer server.Close()
-
-	if shouldShowCurrentTeamSelectionHint(context.Background(), server.URL, "team-1") {
+	if shouldShowCurrentTeamSelectionHint(context.Background(), "http://127.0.0.1:0", "team-1") {
 		t.Fatal("shouldShowCurrentTeamSelectionHint() = true, want false")
 	}
 }

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestShouldShowFirstTeamOnboardingHint(t *testing.T) {
+func TestShouldShowCurrentTeamSelectionHint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/metadata" {
 			http.NotFound(w, r)
@@ -19,29 +19,25 @@ func TestShouldShowFirstTeamOnboardingHint(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if !shouldShowFirstTeamOnboardingHint(context.Background(), server.URL, &authLoginData{}) {
-		t.Fatal("shouldShowFirstTeamOnboardingHint() = false, want true")
+	if !shouldShowCurrentTeamSelectionHint(context.Background(), server.URL, "") {
+		t.Fatal("shouldShowCurrentTeamSelectionHint() = false, want true")
 	}
 }
 
-func TestShouldShowFirstTeamOnboardingHintSkipsWhenRegionalSessionExists(t *testing.T) {
-	server := httptest.NewServer(http.NotFoundHandler())
+func TestShouldShowCurrentTeamSelectionHintSkipsWhenCurrentTeamExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metadata" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"gateway_mode":"global","service":"global-gateway"}}`))
+	}))
 	defer server.Close()
 
-	if shouldShowFirstTeamOnboardingHint(context.Background(), server.URL, &authLoginData{
-		RegionalSession: &struct {
-			RegionID           string `json:"region_id"`
-			RegionalGatewayURL string `json:"regional_gateway_url"`
-			Token              string `json:"token"`
-			ExpiresAt          int64  `json:"expires_at"`
-		}{
-			RegionID:           "aws/us-east-1",
-			RegionalGatewayURL: "https://regional.example.com",
-			Token:              "region-token",
-			ExpiresAt:          1893456000,
-		},
-	}) {
-		t.Fatal("shouldShowFirstTeamOnboardingHint() = true, want false")
+	if shouldShowCurrentTeamSelectionHint(context.Background(), server.URL, "team-1") {
+		t.Fatal("shouldShowCurrentTeamSelectionHint() = true, want false")
 	}
 }
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -122,8 +122,9 @@ func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, er
 			BaseURL:               p.GetAPIURL(),
 			Token:                 token,
 			ConfiguredGatewayMode: configuredMode,
+			CurrentTeamID:         p.GetCurrentTeamID(),
 			RegionalSession: func() *config.RegionalSession {
-				if session, ok := p.GetRegionalSession(); ok {
+				if session, ok := p.GetRegionalSession(p.GetCurrentTeamID()); ok {
 					return session
 				}
 				return nil

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 
@@ -66,7 +68,7 @@ func getConfig() (*config.Config, error) {
 
 // getClient creates a new wrapped SDK client from the configuration.
 func getClient(cmd *cobra.Command) (*client.Client, error) {
-	resolved, userAgent, err := resolveClientTarget(cmd)
+	resolved, userAgent, currentTeamID, scope, err := resolveClientTarget(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +80,14 @@ func getClient(cmd *cobra.Command) (*client.Client, error) {
 	if userAgent != "" {
 		opts = append(opts, sandbox0.WithUserAgent(userAgent))
 	}
+	appendCurrentTeamHeader(&opts, currentTeamID, scope)
 
 	return client.NewClient(opts...)
 }
 
 // getClientRaw creates a raw SDK client for operations that don't need the wrapper.
 func getClientRaw(cmd *cobra.Command) (*sandbox0.Client, error) {
-	resolved, userAgent, err := resolveClientTarget(cmd)
+	resolved, userAgent, currentTeamID, scope, err := resolveClientTarget(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -96,19 +99,20 @@ func getClientRaw(cmd *cobra.Command) (*sandbox0.Client, error) {
 	if userAgent != "" {
 		opts = append(opts, sandbox0.WithUserAgent(userAgent))
 	}
+	appendCurrentTeamHeader(&opts, currentTeamID, scope)
 
 	return sandbox0.NewClient(opts...)
 }
 
-func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, error) {
+func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, string, client.RouteScope, error) {
 	p, err := getProfileWithFreshToken()
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", "", err
 	}
 
 	token := p.GetToken()
 	if token == "" {
-		return nil, "", ErrNoToken
+		return nil, "", "", "", ErrNoToken
 	}
 
 	var configuredMode config.GatewayMode
@@ -116,6 +120,7 @@ func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, er
 		configuredMode = mode
 	}
 
+	scope := commandRouteScope(cmd)
 	resolved, err := client.ResolveTarget(
 		cmd.Context(),
 		client.ResolveTargetOptions{
@@ -123,21 +128,31 @@ func resolveClientTarget(cmd *cobra.Command) (*client.ResolvedTarget, string, er
 			Token:                 token,
 			ConfiguredGatewayMode: configuredMode,
 			CurrentTeamID:         p.GetCurrentTeamID(),
-			RegionalSession: func() *config.RegionalSession {
-				if session, ok := p.GetRegionalSession(p.GetCurrentTeamID()); ok {
-					return session
+			CurrentTeamTarget: func() *config.CurrentTeamTarget {
+				if target, ok := p.GetCurrentTeamTarget(); ok {
+					return target
 				}
 				return nil
 			}(),
-			Scope:     commandRouteScope(cmd),
+			Scope:     scope,
 			UserAgent: buildUserAgent(),
 		},
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", "", err
 	}
 
-	return resolved, buildUserAgent(), nil
+	return resolved, buildUserAgent(), p.GetCurrentTeamID(), scope, nil
+}
+
+func appendCurrentTeamHeader(opts *[]sandbox0.Option, currentTeamID string, scope client.RouteScope) {
+	if scope != client.RouteScopeHomeRegion || currentTeamID == "" {
+		return
+	}
+	*opts = append(*opts, sandbox0.WithRequestEditor(func(_ context.Context, req *http.Request) error {
+		req.Header.Set("X-Team-ID", currentTeamID)
+		return nil
+	}))
 }
 
 func buildUserAgent() string {

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -246,17 +246,6 @@ var teamUseCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Error validating team: missing response data")
 			os.Exit(1)
 		}
-		homeRegionID, ok := data.HomeRegionID.Get()
-		if !ok || strings.TrimSpace(homeRegionID) == "" {
-			fmt.Fprintln(os.Stderr, "Error validating team: team has no home region")
-			os.Exit(1)
-		}
-
-		regionalGatewayURL, err := resolveRegionalGatewayURL(cmd.Context(), client, homeRegionID)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error resolving team region endpoint: %v\n", err)
-			os.Exit(1)
-		}
 
 		cfg, err := getConfig()
 		if err != nil {
@@ -265,6 +254,17 @@ var teamUseCmd = &cobra.Command{
 		}
 
 		profileName := cfg.GetActiveProfile()
+		profile, err := cfg.GetProfile(profileName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading profile: %v\n", err)
+			os.Exit(1)
+		}
+		homeRegionID, regionalGatewayURL, err := resolveCurrentTeamTarget(cmd.Context(), profile, client, data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error validating team: %v\n", err)
+			os.Exit(1)
+		}
+
 		cfg.SetCurrentTeam(profileName, teamID, homeRegionID, regionalGatewayURL)
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
@@ -273,6 +273,21 @@ var teamUseCmd = &cobra.Command{
 
 		fmt.Printf("Current team for profile %q set to %s (%s)\n", profileName, data.ID, data.Name)
 	},
+}
+
+func resolveCurrentTeamTarget(ctx context.Context, profile *config.Profile, client *sandbox0.Client, team apispec.Team) (string, string, error) {
+	if resolveGatewayModeForProfile(ctx, profile) == config.GatewayModeDirect {
+		return "", "", nil
+	}
+	homeRegionID, ok := team.HomeRegionID.Get()
+	if !ok || strings.TrimSpace(homeRegionID) == "" {
+		return "", "", fmt.Errorf("team has no home region")
+	}
+	regionalGatewayURL, err := resolveRegionalGatewayURL(ctx, client, homeRegionID)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving team region endpoint: %w", err)
+	}
+	return homeRegionID, regionalGatewayURL, nil
 }
 
 func resolveRegionalGatewayURL(ctx context.Context, client *sandbox0.Client, regionID string) (string, error) {

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -1,12 +1,10 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +13,6 @@ var (
 	teamName       string
 	teamSlug       string
 	teamHomeRegion string
-	teamActivate   bool
 
 	teamMemberTeamID string
 	teamMemberEmail  string
@@ -139,21 +136,60 @@ var teamCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if teamActivate {
-			if err := activateCreatedTeam(cmd.Context(), client, data.ID); err != nil {
-				fmt.Fprintf(os.Stderr, "Error activating team: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
 		if err := getFormatter().Format(os.Stdout, data); err != nil {
 			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 			os.Exit(1)
 		}
+	},
+}
 
-		if teamActivate {
-			fmt.Fprintf(os.Stderr, "Activated team %s as the default team\n", data.ID)
+var teamUseCmd = &cobra.Command{
+	Use:   "use <team-id>",
+	Short: "Set the current team locally",
+	Long:  `Set the current team in local CLI config.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		teamID := strings.TrimSpace(args[0])
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
 		}
+
+		res, err := client.API().TeamsIDGet(cmd.Context(), apispec.TeamsIDGetParams{
+			ID: teamID,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error validating team: %v\n", err)
+			os.Exit(1)
+		}
+
+		successRes, ok := res.(*apispec.SuccessTeamResponse)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Error validating team: unexpected response type")
+			os.Exit(1)
+		}
+
+		data, ok := successRes.Data.Get()
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Error validating team: missing response data")
+			os.Exit(1)
+		}
+
+		cfg, err := getConfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+			os.Exit(1)
+		}
+
+		profileName := cfg.GetActiveProfile()
+		cfg.SetCurrentTeam(profileName, teamID)
+		if err := cfg.Save(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Current team for profile %q set to %s (%s)\n", profileName, data.ID, data.Name)
 	},
 }
 
@@ -480,36 +516,13 @@ func buildCreateTeamRequest(name, slug, homeRegion string) *apispec.CreateTeamRe
 	return req
 }
 
-func buildActivateTeamRequest(teamID string) *apispec.UpdateUserRequest {
-	req := &apispec.UpdateUserRequest{}
-	req.DefaultTeamID = apispec.NewOptNilString(strings.TrimSpace(teamID))
-	return req
-}
-
-func activateCreatedTeam(ctx context.Context, client *sandbox0.Client, teamID string) error {
-	res, err := client.API().UsersMePut(ctx, buildActivateTeamRequest(teamID))
-	if err != nil {
-		return err
-	}
-
-	successRes, ok := res.(*apispec.SuccessUserResponse)
-	if !ok {
-		return fmt.Errorf("unexpected response type %T", res)
-	}
-
-	if _, ok := successRes.Data.Get(); !ok {
-		return fmt.Errorf("missing response data")
-	}
-
-	return nil
-}
-
 func init() {
 	rootCmd.AddCommand(teamCmd)
 
 	teamCmd.AddCommand(teamListCmd)
 	teamCmd.AddCommand(teamGetCmd)
 	teamCmd.AddCommand(teamCreateCmd)
+	teamCmd.AddCommand(teamUseCmd)
 	teamCmd.AddCommand(teamUpdateCmd)
 	teamCmd.AddCommand(teamDeleteCmd)
 	teamCmd.AddCommand(teamMemberCmd)
@@ -524,7 +537,6 @@ func init() {
 	teamCreateCmd.Flags().StringVar(&teamName, "name", "", "team name (required)")
 	teamCreateCmd.Flags().StringVar(&teamSlug, "slug", "", "team slug")
 	teamCreateCmd.Flags().StringVar(&teamHomeRegion, "home-region", "", "team home region ID")
-	teamCreateCmd.Flags().BoolVar(&teamActivate, "activate", false, "set the created team as the default active team")
 
 	teamUpdateCmd.Flags().StringVar(&teamName, "name", "", "new team name")
 	teamUpdateCmd.Flags().StringVar(&teamSlug, "slug", "", "new team slug")

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/sandbox0-ai/s0/internal/config"
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 	"github.com/spf13/cobra"
 )
@@ -110,7 +113,7 @@ var teamCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		client, err := getClientRaw(cmd)
+		client, err := getTeamCreateClient(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
@@ -141,6 +144,74 @@ var teamCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+func resolveGatewayModeForProfile(ctx context.Context, p *config.Profile) config.GatewayMode {
+	if mode, ok := p.GetConfiguredGatewayMode(); ok {
+		return mode
+	}
+	if detected, detectedOK := fetchGatewayMode(ctx, p.GetAPIURL()); detectedOK {
+		return detected
+	}
+	return config.GatewayModeDirect
+}
+
+func getTeamCreateClient(cmd *cobra.Command) (*sandbox0.Client, error) {
+	p, err := getProfileWithFreshToken()
+	if err != nil {
+		return nil, err
+	}
+	token := p.GetToken()
+	if token == "" {
+		return nil, ErrNoToken
+	}
+	baseURL := p.GetAPIURL()
+	mode := resolveGatewayModeForProfile(cmd.Context(), p)
+	if mode == config.GatewayModeGlobal {
+		if strings.TrimSpace(teamHomeRegion) == "" {
+			return nil, fmt.Errorf("--home-region is required in global mode")
+		}
+	}
+	return newSDKClientForBaseURL(baseURL, token)
+}
+
+func resolveTeamGatewayURL(ctx context.Context, client *sandbox0.Client, teamID string) (string, error) {
+	homeRegionID, err := resolveTeamHomeRegionID(ctx, client, teamID)
+	if err != nil {
+		return "", err
+	}
+	return resolveRegionalGatewayURL(ctx, client, homeRegionID)
+}
+
+func resolveTeamHomeRegionID(ctx context.Context, client *sandbox0.Client, teamID string) (string, error) {
+	res, err := client.API().TeamsIDGet(ctx, apispec.TeamsIDGetParams{ID: teamID})
+	if err != nil {
+		return "", fmt.Errorf("get team %s: %w", teamID, err)
+	}
+	successRes, ok := res.(*apispec.SuccessTeamResponse)
+	if !ok {
+		return "", fmt.Errorf("get team %s: unexpected response type %T", teamID, res)
+	}
+	data, ok := successRes.Data.Get()
+	if !ok {
+		return "", fmt.Errorf("get team %s: missing response data", teamID)
+	}
+	homeRegionID, ok := data.HomeRegionID.Get()
+	if !ok || strings.TrimSpace(homeRegionID) == "" {
+		return "", fmt.Errorf("team %s has no home region", teamID)
+	}
+	return homeRegionID, nil
+}
+
+func newSDKClientForBaseURL(baseURL, token string) (*sandbox0.Client, error) {
+	opts := []sandbox0.Option{
+		sandbox0.WithBaseURL(baseURL),
+		sandbox0.WithToken(token),
+	}
+	if userAgent := buildUserAgent(); userAgent != "" {
+		opts = append(opts, sandbox0.WithUserAgent(userAgent))
+	}
+	return sandbox0.NewClient(opts...)
 }
 
 var teamUseCmd = &cobra.Command{
@@ -175,6 +246,17 @@ var teamUseCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Error validating team: missing response data")
 			os.Exit(1)
 		}
+		homeRegionID, ok := data.HomeRegionID.Get()
+		if !ok || strings.TrimSpace(homeRegionID) == "" {
+			fmt.Fprintln(os.Stderr, "Error validating team: team has no home region")
+			os.Exit(1)
+		}
+
+		regionalGatewayURL, err := resolveRegionalGatewayURL(cmd.Context(), client, homeRegionID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving team region endpoint: %v\n", err)
+			os.Exit(1)
+		}
 
 		cfg, err := getConfig()
 		if err != nil {
@@ -183,7 +265,7 @@ var teamUseCmd = &cobra.Command{
 		}
 
 		profileName := cfg.GetActiveProfile()
-		cfg.SetCurrentTeam(profileName, teamID)
+		cfg.SetCurrentTeam(profileName, teamID, homeRegionID, regionalGatewayURL)
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
 			os.Exit(1)
@@ -191,6 +273,34 @@ var teamUseCmd = &cobra.Command{
 
 		fmt.Printf("Current team for profile %q set to %s (%s)\n", profileName, data.ID, data.Name)
 	},
+}
+
+func resolveRegionalGatewayURL(ctx context.Context, client *sandbox0.Client, regionID string) (string, error) {
+	res, err := client.API().RegionsGet(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list regions: %w", err)
+	}
+	successRes, ok := res.(*apispec.SuccessRegionListResponse)
+	if !ok {
+		return "", fmt.Errorf("list regions: unexpected response type %T", res)
+	}
+	data, ok := successRes.Data.Get()
+	if !ok {
+		return "", fmt.Errorf("list regions: missing response data")
+	}
+	for _, region := range data.Regions {
+		if strings.TrimSpace(region.ID) != strings.TrimSpace(regionID) {
+			continue
+		}
+		if !region.Enabled {
+			return "", fmt.Errorf("region %s is disabled", regionID)
+		}
+		if strings.TrimSpace(region.RegionalGatewayURL) == "" {
+			return "", fmt.Errorf("region %s has no regional gateway URL", regionID)
+		}
+		return region.RegionalGatewayURL, nil
+	}
+	return "", fmt.Errorf("region %s not found", regionID)
 }
 
 var teamUpdateCmd = &cobra.Command{

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -31,11 +31,8 @@ func TestBuildCreateTeamRequestOmitsOptionalFieldsWhenBlank(t *testing.T) {
 	}
 }
 
-func TestBuildActivateTeamRequest(t *testing.T) {
-	req := buildActivateTeamRequest(" team-1 ")
-
-	defaultTeamID, ok := req.DefaultTeamID.Get()
-	if !ok || defaultTeamID != "team-1" {
-		t.Fatalf("DefaultTeamID = %q, want team-1", defaultTeamID)
+func TestTeamCreateCommandDoesNotExposeActivateFlag(t *testing.T) {
+	if flag := teamCreateCmd.Flags().Lookup("activate"); flag != nil {
+		t.Fatalf("activate flag should be removed, got %v", flag)
 	}
 }

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -1,6 +1,12 @@
 package commands
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestBuildCreateTeamRequest(t *testing.T) {
 	req := buildCreateTeamRequest("Team One", " team-one ", " aws/us-east-1 ")
@@ -34,5 +40,84 @@ func TestBuildCreateTeamRequestOmitsOptionalFieldsWhenBlank(t *testing.T) {
 func TestTeamCreateCommandDoesNotExposeActivateFlag(t *testing.T) {
 	if flag := teamCreateCmd.Flags().Lookup("activate"); flag != nil {
 		t.Fatalf("activate flag should be removed, got %v", flag)
+	}
+}
+
+func TestResolveTeamHomeRegionID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/teams/team-1" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token-1" {
+			t.Fatalf("Authorization = %q, want Bearer token-1", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"team-1","name":"Team One","slug":"team-one","home_region_id":"aws/us-east-1","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer server.Close()
+
+	client, err := newSDKClientForBaseURL(server.URL, "token-1")
+	if err != nil {
+		t.Fatalf("newSDKClientForBaseURL() error = %v", err)
+	}
+
+	homeRegionID, err := resolveTeamHomeRegionID(context.Background(), client, "team-1")
+	if err != nil {
+		t.Fatalf("resolveTeamHomeRegionID() error = %v", err)
+	}
+	if homeRegionID != "aws/us-east-1" {
+		t.Fatalf("resolveTeamHomeRegionID() = %q, want aws/us-east-1", homeRegionID)
+	}
+}
+
+func TestResolveTeamHomeRegionIDRequiresConfiguredHomeRegion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/teams/team-1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"team-1","name":"Team One","slug":"team-one","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer server.Close()
+
+	client, err := newSDKClientForBaseURL(server.URL, "token-1")
+	if err != nil {
+		t.Fatalf("newSDKClientForBaseURL() error = %v", err)
+	}
+
+	_, err = resolveTeamHomeRegionID(context.Background(), client, "team-1")
+	if err == nil || !strings.Contains(err.Error(), "team team-1 has no home region") {
+		t.Fatalf("expected missing home region error, got %v", err)
+	}
+}
+
+func TestResolveTeamGatewayURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/teams/team-1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"id":"team-1","name":"Team One","slug":"team-one","home_region_id":"aws/us-east-1","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+		case "/regions":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"regions":[{"id":"aws/us-east-1","display_name":"US East 1","regional_gateway_url":"https://use1.example.com","metering_export_url":"https://metering.use1.example.com","enabled":true}]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newSDKClientForBaseURL(server.URL, "token-1")
+	if err != nil {
+		t.Fatalf("newSDKClientForBaseURL() error = %v", err)
+	}
+
+	regionalGatewayURL, err := resolveTeamGatewayURL(context.Background(), client, "team-1")
+	if err != nil {
+		t.Fatalf("resolveTeamGatewayURL() error = %v", err)
+	}
+	if regionalGatewayURL != "https://use1.example.com" {
+		t.Fatalf("resolveTeamGatewayURL() = %q, want https://use1.example.com", regionalGatewayURL)
 	}
 }

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/sandbox0-ai/s0/internal/config"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
 func TestBuildCreateTeamRequest(t *testing.T) {
@@ -119,5 +122,42 @@ func TestResolveTeamGatewayURL(t *testing.T) {
 	}
 	if regionalGatewayURL != "https://use1.example.com" {
 		t.Fatalf("resolveTeamGatewayURL() = %q, want https://use1.example.com", regionalGatewayURL)
+	}
+}
+
+func TestResolveCurrentTeamTargetDirectModeAllowsTeamWithoutHomeRegion(t *testing.T) {
+	client, err := newSDKClientForBaseURL("https://api.example.com", "token-1")
+	if err != nil {
+		t.Fatalf("newSDKClientForBaseURL() error = %v", err)
+	}
+
+	homeRegionID, regionalGatewayURL, err := resolveCurrentTeamTarget(
+		context.Background(),
+		&config.Profile{GatewayMode: string(config.GatewayModeDirect)},
+		client,
+		apispec.Team{ID: "team-1", Name: "Team One"},
+	)
+	if err != nil {
+		t.Fatalf("resolveCurrentTeamTarget() error = %v", err)
+	}
+	if homeRegionID != "" || regionalGatewayURL != "" {
+		t.Fatalf("resolveCurrentTeamTarget() = (%q, %q), want empty target for direct mode", homeRegionID, regionalGatewayURL)
+	}
+}
+
+func TestResolveCurrentTeamTargetGlobalModeRequiresHomeRegion(t *testing.T) {
+	client, err := newSDKClientForBaseURL("https://api.example.com", "token-1")
+	if err != nil {
+		t.Fatalf("newSDKClientForBaseURL() error = %v", err)
+	}
+
+	_, _, err = resolveCurrentTeamTarget(
+		context.Background(),
+		&config.Profile{GatewayMode: string(config.GatewayModeGlobal)},
+		client,
+		apispec.Team{ID: "team-1", Name: "Team One"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "team has no home region") {
+		t.Fatalf("expected missing home region error, got %v", err)
 	}
 }

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -10,10 +10,8 @@ import (
 )
 
 var (
-	userName               string
-	userAvatarURL          string
-	userDefaultTeamID      string
-	userClearDefaultTeamID bool
+	userName      string
+	userAvatarURL string
 )
 
 var userCmd = &cobra.Command{
@@ -76,17 +74,9 @@ var userUpdateCmd = &cobra.Command{
 			hasChange = true
 		}
 
-		if userClearDefaultTeamID {
-			req.DefaultTeamID.SetToNull()
-			hasChange = true
-		} else if strings.TrimSpace(userDefaultTeamID) != "" {
-			req.DefaultTeamID = apispec.NewOptNilString(userDefaultTeamID)
-			hasChange = true
-		}
-
 		if !hasChange {
 			fmt.Fprintln(os.Stderr, "Error: at least one field must be set for update")
-			fmt.Fprintln(os.Stderr, "Use --name, --avatar-url, --default-team-id, or --clear-default-team-id")
+			fmt.Fprintln(os.Stderr, "Use --name and/or --avatar-url")
 			os.Exit(1)
 		}
 
@@ -129,6 +119,4 @@ func init() {
 
 	userUpdateCmd.Flags().StringVar(&userName, "name", "", "new display name")
 	userUpdateCmd.Flags().StringVar(&userAvatarURL, "avatar-url", "", "new avatar URL")
-	userUpdateCmd.Flags().StringVar(&userDefaultTeamID, "default-team-id", "", "new default team ID")
-	userUpdateCmd.Flags().BoolVar(&userClearDefaultTeamID, "clear-default-team-id", false, "clear default team ID")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,25 +18,20 @@ type Config struct {
 
 // Profile represents a named configuration profile.
 type Profile struct {
-	APIURL             string `yaml:"api-url" mapstructure:"api-url"`
-	GatewayMode        string `yaml:"gateway-mode" mapstructure:"gateway-mode"`
-	CurrentTeamID      string `yaml:"current-team-id" mapstructure:"current-team-id"`
-	Token              string `yaml:"token" mapstructure:"token"`
-	RefreshToken       string `yaml:"refresh-token" mapstructure:"refresh-token"`
-	ExpiresAt          int64  `yaml:"expires-at" mapstructure:"expires-at"`
-	RegionalTeamID     string `yaml:"regional-team-id" mapstructure:"regional-team-id"`
-	RegionalToken      string `yaml:"regional-token" mapstructure:"regional-token"`
-	RegionalGatewayURL string `yaml:"regional-gateway-url" mapstructure:"regional-gateway-url"`
-	RegionalRegionID   string `yaml:"regional-region-id" mapstructure:"regional-region-id"`
-	RegionalExpiresAt  int64  `yaml:"regional-expires-at" mapstructure:"regional-expires-at"`
+	APIURL                string `yaml:"api-url" mapstructure:"api-url"`
+	GatewayMode           string `yaml:"gateway-mode" mapstructure:"gateway-mode"`
+	CurrentTeamID         string `yaml:"current-team-id" mapstructure:"current-team-id"`
+	CurrentTeamRegionID   string `yaml:"current-team-region-id" mapstructure:"current-team-region-id"`
+	CurrentTeamGatewayURL string `yaml:"current-team-gateway-url" mapstructure:"current-team-gateway-url"`
+	Token                 string `yaml:"token" mapstructure:"token"`
+	RefreshToken          string `yaml:"refresh-token" mapstructure:"refresh-token"`
+	ExpiresAt             int64  `yaml:"expires-at" mapstructure:"expires-at"`
 }
 
-type RegionalSession struct {
+type CurrentTeamTarget struct {
 	TeamID     string
-	Token      string
 	GatewayURL string
 	RegionID   string
-	ExpiresAt  int64
 }
 
 // OutputConfig represents output formatting configuration.
@@ -217,24 +212,18 @@ func (p *Profile) GetCurrentTeamID() string {
 	return strings.TrimSpace(expandEnvVars(p.CurrentTeamID))
 }
 
-// GetRegionalSession returns the stored regional session when all required fields are present.
-func (p *Profile) GetRegionalSession(currentTeamID string) (*RegionalSession, bool) {
-	token := expandEnvVars(p.RegionalToken)
-	gatewayURL := expandEnvVars(p.RegionalGatewayURL)
-	regionID := expandEnvVars(p.RegionalRegionID)
-	teamID := strings.TrimSpace(expandEnvVars(p.RegionalTeamID))
-	if token == "" || gatewayURL == "" || regionID == "" || teamID == "" || p.RegionalExpiresAt == 0 {
+// GetCurrentTeamTarget returns the cached region endpoint for the selected current team.
+func (p *Profile) GetCurrentTeamTarget() (*CurrentTeamTarget, bool) {
+	teamID := strings.TrimSpace(expandEnvVars(p.CurrentTeamID))
+	regionID := strings.TrimSpace(expandEnvVars(p.CurrentTeamRegionID))
+	gatewayURL := strings.TrimSpace(expandEnvVars(p.CurrentTeamGatewayURL))
+	if teamID == "" || regionID == "" || gatewayURL == "" {
 		return nil, false
 	}
-	if strings.TrimSpace(currentTeamID) == "" || teamID != strings.TrimSpace(currentTeamID) {
-		return nil, false
-	}
-	return &RegionalSession{
+	return &CurrentTeamTarget{
 		TeamID:     teamID,
-		Token:      token,
-		GatewayURL: gatewayURL,
 		RegionID:   regionID,
-		ExpiresAt:  p.RegionalExpiresAt,
+		GatewayURL: gatewayURL,
 	}, true
 }
 
@@ -259,7 +248,6 @@ func (c *Config) SetCredentials(
 	accessToken,
 	refreshToken string,
 	expiresAt int64,
-	regionalSession *RegionalSession,
 ) {
 	if c.Profiles == nil {
 		c.Profiles = make(map[string]Profile)
@@ -274,19 +262,6 @@ func (c *Config) SetCredentials(
 	p.Token = accessToken
 	p.RefreshToken = refreshToken
 	p.ExpiresAt = expiresAt
-	if regionalSession != nil {
-		p.RegionalTeamID = regionalSession.TeamID
-		p.RegionalToken = regionalSession.Token
-		p.RegionalGatewayURL = regionalSession.GatewayURL
-		p.RegionalRegionID = regionalSession.RegionID
-		p.RegionalExpiresAt = regionalSession.ExpiresAt
-	} else {
-		p.RegionalTeamID = ""
-		p.RegionalToken = ""
-		p.RegionalGatewayURL = ""
-		p.RegionalRegionID = ""
-		p.RegionalExpiresAt = 0
-	}
 	c.Profiles[profileName] = p
 	c.CurrentProfile = profileName
 }
@@ -303,16 +278,11 @@ func (c *Config) ClearCredentials(profileName string) {
 	p.Token = ""
 	p.RefreshToken = ""
 	p.ExpiresAt = 0
-	p.RegionalTeamID = ""
-	p.RegionalToken = ""
-	p.RegionalGatewayURL = ""
-	p.RegionalRegionID = ""
-	p.RegionalExpiresAt = 0
 	c.Profiles[profileName] = p
 }
 
-// SetCurrentTeam updates the locally selected current team and clears any cached regional session.
-func (c *Config) SetCurrentTeam(profileName, teamID string) {
+// SetCurrentTeam updates the locally selected current team and its cached region endpoint.
+func (c *Config) SetCurrentTeam(profileName, teamID, regionID, gatewayURL string) {
 	if c.Profiles == nil {
 		c.Profiles = make(map[string]Profile)
 	}
@@ -321,11 +291,8 @@ func (c *Config) SetCurrentTeam(profileName, teamID string) {
 		p = Profile{}
 	}
 	p.CurrentTeamID = strings.TrimSpace(teamID)
-	p.RegionalTeamID = ""
-	p.RegionalToken = ""
-	p.RegionalGatewayURL = ""
-	p.RegionalRegionID = ""
-	p.RegionalExpiresAt = 0
+	p.CurrentTeamRegionID = strings.TrimSpace(regionID)
+	p.CurrentTeamGatewayURL = strings.TrimSpace(gatewayURL)
 	c.Profiles[profileName] = p
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,9 +20,11 @@ type Config struct {
 type Profile struct {
 	APIURL             string `yaml:"api-url" mapstructure:"api-url"`
 	GatewayMode        string `yaml:"gateway-mode" mapstructure:"gateway-mode"`
+	CurrentTeamID      string `yaml:"current-team-id" mapstructure:"current-team-id"`
 	Token              string `yaml:"token" mapstructure:"token"`
 	RefreshToken       string `yaml:"refresh-token" mapstructure:"refresh-token"`
 	ExpiresAt          int64  `yaml:"expires-at" mapstructure:"expires-at"`
+	RegionalTeamID     string `yaml:"regional-team-id" mapstructure:"regional-team-id"`
 	RegionalToken      string `yaml:"regional-token" mapstructure:"regional-token"`
 	RegionalGatewayURL string `yaml:"regional-gateway-url" mapstructure:"regional-gateway-url"`
 	RegionalRegionID   string `yaml:"regional-region-id" mapstructure:"regional-region-id"`
@@ -30,6 +32,7 @@ type Profile struct {
 }
 
 type RegionalSession struct {
+	TeamID     string
 	Token      string
 	GatewayURL string
 	RegionID   string
@@ -209,15 +212,25 @@ func (p *Profile) GetRefreshToken() string {
 	return expandEnvVars(p.RefreshToken)
 }
 
+// GetCurrentTeamID returns the locally selected current team ID.
+func (p *Profile) GetCurrentTeamID() string {
+	return strings.TrimSpace(expandEnvVars(p.CurrentTeamID))
+}
+
 // GetRegionalSession returns the stored regional session when all required fields are present.
-func (p *Profile) GetRegionalSession() (*RegionalSession, bool) {
+func (p *Profile) GetRegionalSession(currentTeamID string) (*RegionalSession, bool) {
 	token := expandEnvVars(p.RegionalToken)
 	gatewayURL := expandEnvVars(p.RegionalGatewayURL)
 	regionID := expandEnvVars(p.RegionalRegionID)
-	if token == "" || gatewayURL == "" || regionID == "" || p.RegionalExpiresAt == 0 {
+	teamID := strings.TrimSpace(expandEnvVars(p.RegionalTeamID))
+	if token == "" || gatewayURL == "" || regionID == "" || teamID == "" || p.RegionalExpiresAt == 0 {
+		return nil, false
+	}
+	if strings.TrimSpace(currentTeamID) == "" || teamID != strings.TrimSpace(currentTeamID) {
 		return nil, false
 	}
 	return &RegionalSession{
+		TeamID:     teamID,
 		Token:      token,
 		GatewayURL: gatewayURL,
 		RegionID:   regionID,
@@ -262,11 +275,13 @@ func (c *Config) SetCredentials(
 	p.RefreshToken = refreshToken
 	p.ExpiresAt = expiresAt
 	if regionalSession != nil {
+		p.RegionalTeamID = regionalSession.TeamID
 		p.RegionalToken = regionalSession.Token
 		p.RegionalGatewayURL = regionalSession.GatewayURL
 		p.RegionalRegionID = regionalSession.RegionID
 		p.RegionalExpiresAt = regionalSession.ExpiresAt
 	} else {
+		p.RegionalTeamID = ""
 		p.RegionalToken = ""
 		p.RegionalGatewayURL = ""
 		p.RegionalRegionID = ""
@@ -288,6 +303,25 @@ func (c *Config) ClearCredentials(profileName string) {
 	p.Token = ""
 	p.RefreshToken = ""
 	p.ExpiresAt = 0
+	p.RegionalTeamID = ""
+	p.RegionalToken = ""
+	p.RegionalGatewayURL = ""
+	p.RegionalRegionID = ""
+	p.RegionalExpiresAt = 0
+	c.Profiles[profileName] = p
+}
+
+// SetCurrentTeam updates the locally selected current team and clears any cached regional session.
+func (c *Config) SetCurrentTeam(profileName, teamID string) {
+	if c.Profiles == nil {
+		c.Profiles = make(map[string]Profile)
+	}
+	p, ok := c.Profiles[profileName]
+	if !ok {
+		p = Profile{}
+	}
+	p.CurrentTeamID = strings.TrimSpace(teamID)
+	p.RegionalTeamID = ""
 	p.RegionalToken = ""
 	p.RegionalGatewayURL = ""
 	p.RegionalRegionID = ""


### PR DESCRIPTION
## Summary
- store `current_team_id` in local config and use it for global workload routing
- remove CLI flows that mutated server-side default or active team state
- add `s0 team use <team-id>` and update docs for the new routing model

## Testing
- go test ./...