### PR TITLE
Pass target image when requesting registry credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,15 +9,13 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.2
+	github.com/sandbox0-ai/sdk-go v0.2.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.47.0
 )
-
-replace github.com/sandbox0-ai/sdk-go => ../sdk-go
 
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	modernc.org/sqlite v1.47.0
 )
 
+replace github.com/sandbox0-ai/sdk-go => ../sdk-go
+
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.2 h1:HJjNXn8hvtyI7+mpU2FmA6F6ztpNZ3IJ0XxVOz2L2J4=
-github.com/sandbox0-ai/sdk-go v0.2.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/sandbox0-ai/sdk-go v0.2.3 h1:MFAq9a7r0+pQxN+hSz/DSVEKMdbs9RS94BUtVuEGZH8=
+github.com/sandbox0-ai/sdk-go v0.2.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strings"
 
 	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
@@ -32,8 +33,13 @@ type RegistryCredentials struct {
 }
 
 // GetRegistryCredentials retrieves temporary registry credentials for image push.
-func (c *Client) GetRegistryCredentials(ctx context.Context) (*RegistryCredentials, error) {
-	resp, err := c.API().APIV1RegistryCredentialsPost(ctx)
+func (c *Client) GetRegistryCredentials(ctx context.Context, targetImage string) (*RegistryCredentials, error) {
+	req := apispec.OptRegistryCredentialsRequest{}
+	if strings.TrimSpace(targetImage) != "" {
+		req.SetTo(apispec.RegistryCredentialsRequest{TargetImage: apispec.NewOptString(targetImage)})
+	}
+
+	resp, err := c.API().APIV1RegistryCredentialsPost(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/image.go
+++ b/internal/commands/image.go
@@ -92,7 +92,7 @@ var imagePushCmd = &cobra.Command{
 		}
 
 		// Get registry credentials
-		creds, err := client.GetRegistryCredentials(cmd.Context())
+		creds, err := client.GetRegistryCredentials(cmd.Context(), imageTag)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting registry credentials: %v\n", err)
 			os.Exit(1)
@@ -147,7 +147,7 @@ var imageCredentialsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		creds, err := client.GetRegistryCredentials(cmd.Context())
+		creds, err := client.GetRegistryCredentials(cmd.Context(), imageTag)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting registry credentials: %v\n", err)
 			os.Exit(1)
@@ -173,6 +173,7 @@ func init() {
 
 	// Push command flags
 	imagePushCmd.Flags().StringVarP(&imageTag, "tag", "t", "", "target image name:tag (required)")
+	imageCredentialsCmd.Flags().StringVarP(&imageTag, "tag", "t", "", "target image name:tag (optional, enables repository provisioning checks)")
 	imageCredentialsCmd.Flags().BoolVar(&imageShowSecret, "show-secret", false, "show full password in output")
 
 	imageCmd.AddCommand(imageBuildCmd)


### PR DESCRIPTION
## Summary
- send targetImage when requesting registry credentials so the backend can scope AWS ECR access and ensure repositories
- add a temporary local sdk-go replace until the generated SDK release is available

Refs sandbox0-ai/sandbox0#140

## Testing
- go test ./internal/client ./internal/commands