### PR TITLE
Redact image credentials output by default

### DIFF
--- a/internal/commands/image.go
+++ b/internal/commands/image.go
@@ -139,7 +139,7 @@ var imagePushCmd = &cobra.Command{
 var imageCredentialsCmd = &cobra.Command{
 	Use:   "credentials",
 	Short: "Show temporary registry credentials",
-	Long:  `Show temporary registry credentials used by s0 template image push.`,
+	Long:  `Show temporary registry credentials used by s0 template image push. Secrets are redacted by default; use --show-secret to print the full password.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := getClient(cmd)
 		if err != nil {

--- a/internal/output/secrets.go
+++ b/internal/output/secrets.go
@@ -10,6 +10,7 @@ const (
 	visibleSecretPrefix = 3
 	visibleSecretSuffix = 3
 	minSecretMaskLength = 8
+	fixedSecretMaskBody = "********"
 )
 
 func redactSensitiveData(data any, showSecrets bool) any {
@@ -37,9 +38,5 @@ func maskSecret(raw string) string {
 
 	prefix := raw[:visibleSecretPrefix]
 	suffix := raw[len(raw)-visibleSecretSuffix:]
-	maskedLen := len(raw) - visibleSecretPrefix - visibleSecretSuffix
-	if maskedLen < 1 {
-		maskedLen = 1
-	}
-	return prefix + strings.Repeat("*", maskedLen) + suffix
+	return prefix + fixedSecretMaskBody + suffix
 }


### PR DESCRIPTION
## Summary
- shorten the default secret mask for `s0 template image credentials` so long registry tokens do not flood terminal output
- clarify in CLI help that `--show-secret` is required to print the full password

## Testing
- go test ./internal/output ./internal/commands ./internal/client