### PR TITLE
Add claim-time bootstrap mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ s0 admin region delete <region-id>
 
 ```bash
 s0 sandbox run <sandbox-id> <input> [--alias <alias>] [--context-id <ctx-id>]
-s0 sandbox create -t <template-id> [-f sandbox-config.yaml] [--ttl 3600] [--hard-ttl 7200]
+s0 sandbox create -t <template-id> [-f sandbox-config.yaml] [--ttl 3600] [--hard-ttl 7200] [--mount <volume-id>:/absolute/path] [--wait-for-mounts] [--mount-wait-timeout-ms 45000]
 s0 sandbox get <sandbox-id>
 s0 sandbox update <sandbox-id> [-f sandbox-update.yaml] [--ttl 3600] [--hard-ttl 7200] [--auto-resume true|false]
 s0 sandbox delete <sandbox-id>
@@ -179,6 +179,29 @@ s0 sandbox resume <sandbox-id>
 s0 sandbox refresh <sandbox-id>
 s0 sandbox status <sandbox-id>
 s0 sandbox list [--status <status>] [--template-id <id>] [--paused true|false] [--limit 50] [--offset 0]
+```
+
+Bootstrap mounts can be requested as part of sandbox creation:
+
+```bash
+s0 volume create
+s0 sandbox create -t default \
+  --mount <volume-id>:/workspace/data \
+  --wait-for-mounts \
+  --mount-wait-timeout-ms 45000
+
+# Or provide a full claim request file.
+cat <<'EOF' > sandbox-claim.yaml
+template: default
+mounts:
+  - sandboxvolume_id: <volume-id>
+    mount_point: /workspace/data
+wait_for_mounts: true
+mount_wait_timeout_ms: 45000
+config:
+  ttl: 3600
+EOF
+s0 sandbox create -f sandbox-claim.yaml
 ```
 
 ### Sandbox Files

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	sandbox0 "github.com/sandbox0-ai/sdk-go"
@@ -12,10 +13,13 @@ import (
 )
 
 var (
-	sandboxTemplate   string
-	sandboxTTL        int32
-	sandboxHardTTL    int32
-	sandboxConfigFile string
+	sandboxTemplate           string
+	sandboxTTL                int32
+	sandboxHardTTL            int32
+	sandboxConfigFile         string
+	sandboxMounts             []string
+	sandboxWaitForMounts      bool
+	sandboxMountWaitTimeoutMS int32
 	// list flags
 	sandboxListStatus     string
 	sandboxListTemplateID string
@@ -42,29 +46,19 @@ var sandboxCreateCmd = &cobra.Command{
 	Short: "Create (claim) a new sandbox",
 	Long:  `Create a new sandbox from a template.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if sandboxTemplate == "" {
-			fmt.Fprintln(os.Stderr, "Error: --template is required")
-			os.Exit(1)
-		}
-
 		client, err := getClientRaw(cmd)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 			os.Exit(1)
 		}
 
-		config, hasConfig, err := buildSandboxCreateConfig()
+		request, err := buildSandboxCreateRequest(cmd.Flags().Changed("wait-for-mounts"))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error building sandbox config: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error building sandbox create request: %v\n", err)
 			os.Exit(1)
 		}
 
-		var opts []sandbox0.SandboxOption
-		if hasConfig {
-			opts = append(opts, sandbox0.WithSandboxConfig(config))
-		}
-
-		sandbox, err := client.ClaimSandbox(cmd.Context(), sandboxTemplate, opts...)
+		sandbox, err := client.ClaimSandboxRequest(cmd.Context(), request)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating sandbox: %v\n", err)
 			os.Exit(1)
@@ -326,10 +320,13 @@ func init() {
 	rootCmd.AddCommand(sandboxCmd)
 
 	// Create command flags
-	sandboxCreateCmd.Flags().StringVarP(&sandboxTemplate, "template", "t", "", "template ID (required)")
-	sandboxCreateCmd.Flags().StringVarP(&sandboxConfigFile, "config-file", "f", "", "path to sandbox config YAML/JSON file, or - for stdin")
+	sandboxCreateCmd.Flags().StringVarP(&sandboxTemplate, "template", "t", "", "template ID (required unless config file includes template)")
+	sandboxCreateCmd.Flags().StringVarP(&sandboxConfigFile, "config-file", "f", "", "path to sandbox config or claim request YAML/JSON file, or - for stdin")
 	sandboxCreateCmd.Flags().Int32Var(&sandboxTTL, "ttl", 0, "soft TTL in seconds")
 	sandboxCreateCmd.Flags().Int32Var(&sandboxHardTTL, "hard-ttl", 0, "hard TTL in seconds")
+	sandboxCreateCmd.Flags().StringArrayVar(&sandboxMounts, "mount", nil, "bootstrap mount in the form <sandboxvolume-id>:/absolute/path (repeatable)")
+	sandboxCreateCmd.Flags().BoolVar(&sandboxWaitForMounts, "wait-for-mounts", false, "wait best-effort for bootstrap mounts before claim returns")
+	sandboxCreateCmd.Flags().Int32Var(&sandboxMountWaitTimeoutMS, "mount-wait-timeout-ms", 0, "best-effort bootstrap mount wait budget in milliseconds")
 
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxGetCmd)
@@ -355,19 +352,65 @@ func init() {
 	sandboxCmd.AddCommand(sandboxListCmd)
 }
 
-func buildSandboxCreateConfig() (apispec.SandboxConfig, bool, error) {
+func buildSandboxCreateRequest(waitForMountsSet bool) (apispec.ClaimRequest, error) {
+	request := apispec.ClaimRequest{}
+	if sandboxConfigFile != "" {
+		var err error
+		request, err = readSandboxCreateInputFile(sandboxConfigFile)
+		if err != nil {
+			return apispec.ClaimRequest{}, err
+		}
+	}
+	if sandboxTemplate != "" {
+		request.Template = apispec.NewOptString(sandboxTemplate)
+	}
+
+	configOverrides, hasConfigOverrides, err := buildSandboxCreateConfigOverrides()
+	if err != nil {
+		return apispec.ClaimRequest{}, err
+	}
+	if hasConfigOverrides {
+		config := apispec.SandboxConfig{}
+		if existing, ok := request.Config.Get(); ok {
+			config = existing
+		}
+		mergeSandboxCreateConfig(&config, configOverrides)
+		if err := config.Validate(); err != nil {
+			return apispec.ClaimRequest{}, fmt.Errorf("invalid sandbox config: %w", err)
+		}
+		request.Config = apispec.NewOptSandboxConfig(config)
+	}
+
+	mounts, err := parseSandboxCreateMounts(sandboxMounts)
+	if err != nil {
+		return apispec.ClaimRequest{}, err
+	}
+	if len(mounts) > 0 {
+		request.Mounts = append(request.Mounts, mounts...)
+	}
+	if waitForMountsSet {
+		request.WaitForMounts = apispec.NewOptBool(sandboxWaitForMounts)
+	}
+	if sandboxMountWaitTimeoutMS > 0 {
+		request.MountWaitTimeoutMs = apispec.NewOptInt32(sandboxMountWaitTimeoutMS)
+		if !waitForMountsSet {
+			request.WaitForMounts = apispec.NewOptBool(true)
+		}
+	}
+	if _, ok := request.Template.Get(); !ok {
+		return apispec.ClaimRequest{}, fmt.Errorf("--template is required unless provided in config file")
+	}
+	if err := request.Validate(); err != nil {
+		return apispec.ClaimRequest{}, fmt.Errorf("invalid sandbox create request: %w", err)
+	}
+	return request, nil
+}
+
+func buildSandboxCreateConfigOverrides() (apispec.SandboxConfig, bool, error) {
 	var (
 		config apispec.SandboxConfig
-		err    error
 	)
 	hasConfig := false
-	if sandboxConfigFile != "" {
-		config, err = readSandboxConfigFile(sandboxConfigFile)
-		if err != nil {
-			return apispec.SandboxConfig{}, false, err
-		}
-		hasConfig = true
-	}
 	if sandboxTTL > 0 {
 		config.TTL = apispec.NewOptInt32(sandboxTTL)
 		hasConfig = true
@@ -382,6 +425,72 @@ func buildSandboxCreateConfig() (apispec.SandboxConfig, bool, error) {
 		}
 	}
 	return config, hasConfig, nil
+}
+
+func mergeSandboxCreateConfig(dst *apispec.SandboxConfig, src apispec.SandboxConfig) {
+	if value, ok := src.TTL.Get(); ok {
+		dst.TTL = apispec.NewOptInt32(value)
+	}
+	if value, ok := src.HardTTL.Get(); ok {
+		dst.HardTTL = apispec.NewOptInt32(value)
+	}
+}
+
+func parseSandboxCreateMounts(values []string) ([]apispec.ClaimMountRequest, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]apispec.ClaimMountRequest, 0, len(values))
+	for _, raw := range values {
+		volumeID, mountPoint, ok := strings.Cut(raw, ":")
+		if !ok || volumeID == "" || mountPoint == "" {
+			return nil, fmt.Errorf("invalid --mount %q: expected <sandboxvolume-id>:/absolute/path", raw)
+		}
+		if !strings.HasPrefix(mountPoint, "/") {
+			return nil, fmt.Errorf("invalid --mount %q: mount path must be absolute", raw)
+		}
+		out = append(out, apispec.ClaimMountRequest{
+			SandboxvolumeID: volumeID,
+			MountPoint:      mountPoint,
+		})
+	}
+	return out, nil
+}
+
+func readSandboxCreateInputFile(path string) (apispec.ClaimRequest, error) {
+	data, err := readConfigFile(path)
+	if err != nil {
+		return apispec.ClaimRequest{}, err
+	}
+	claimLike, err := isSandboxCreateClaimRequest(data)
+	if err != nil {
+		return apispec.ClaimRequest{}, err
+	}
+	if claimLike {
+		var request apispec.ClaimRequest
+		if err := yaml.Unmarshal(data, &request); err != nil {
+			return apispec.ClaimRequest{}, fmt.Errorf("parse sandbox create file: %w", err)
+		}
+		return request, nil
+	}
+	config, err := readSandboxConfigFile(path)
+	if err != nil {
+		return apispec.ClaimRequest{}, err
+	}
+	return apispec.ClaimRequest{Config: apispec.NewOptSandboxConfig(config)}, nil
+}
+
+func isSandboxCreateClaimRequest(data []byte) (bool, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false, fmt.Errorf("parse sandbox create file: %w", err)
+	}
+	for _, key := range []string{"template", "config", "mounts", "wait_for_mounts", "mount_wait_timeout_ms"} {
+		if _, ok := raw[key]; ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func buildSandboxUpdateConfig() (apispec.SandboxUpdateConfig, bool, error) {

--- a/internal/commands/sandbox_test.go
+++ b/internal/commands/sandbox_test.go
@@ -11,8 +11,9 @@ import (
 func TestBuildSandboxCreateConfig(t *testing.T) {
 	resetSandboxFlagsForTest()
 
-	t.Run("reads network policy and bindings from config file", func(t *testing.T) {
+	t.Run("reads legacy sandbox config file", func(t *testing.T) {
 		resetSandboxFlagsForTest()
+		sandboxTemplate = "default"
 		sandboxConfigFile = writeTempFile(t, `
 network:
   mode: block-all
@@ -35,12 +36,17 @@ network:
               valueTemplate: "Bearer {{token}}"
 `)
 
-		config, hasConfig, err := buildSandboxCreateConfig()
+		request, err := buildSandboxCreateRequest(false)
 		if err != nil {
-			t.Fatalf("buildSandboxCreateConfig() error = %v", err)
+			t.Fatalf("buildSandboxCreateRequest() error = %v", err)
 		}
-		if !hasConfig {
-			t.Fatal("hasConfig = false, want true")
+		template, ok := request.Template.Get()
+		if !ok || template != "default" {
+			t.Fatalf("template = %q, want default", template)
+		}
+		config, ok := request.Config.Get()
+		if !ok {
+			t.Fatal("config not set")
 		}
 		network, ok := config.Network.Get()
 		if !ok {
@@ -56,18 +62,20 @@ network:
 
 	t.Run("flags override file values", func(t *testing.T) {
 		resetSandboxFlagsForTest()
+		sandboxTemplate = "default"
 		sandboxConfigFile = writeTempFile(t, `
 ttl: 60
 hard_ttl: 120
 `)
 		sandboxTTL = 300
 
-		config, hasConfig, err := buildSandboxCreateConfig()
+		request, err := buildSandboxCreateRequest(false)
 		if err != nil {
-			t.Fatalf("buildSandboxCreateConfig() error = %v", err)
+			t.Fatalf("buildSandboxCreateRequest() error = %v", err)
 		}
-		if !hasConfig {
-			t.Fatal("hasConfig = false, want true")
+		config, ok := request.Config.Get()
+		if !ok {
+			t.Fatal("config not set")
 		}
 		ttl, ok := config.TTL.Get()
 		if !ok || ttl != 300 {
@@ -76,6 +84,117 @@ hard_ttl: 120
 		hardTTL, ok := config.HardTTL.Get()
 		if !ok || hardTTL != 120 {
 			t.Fatalf("hardTTL = %d, want 120", hardTTL)
+		}
+	})
+
+	t.Run("reads full claim request file", func(t *testing.T) {
+		resetSandboxFlagsForTest()
+		sandboxConfigFile = writeTempFile(t, `
+template: from-file
+mounts:
+  - sandboxvolume_id: vol_123
+    mount_point: /workspace/data
+wait_for_mounts: true
+mount_wait_timeout_ms: 45000
+config:
+  ttl: 90
+`)
+
+		request, err := buildSandboxCreateRequest(false)
+		if err != nil {
+			t.Fatalf("buildSandboxCreateRequest() error = %v", err)
+		}
+		template, ok := request.Template.Get()
+		if !ok || template != "from-file" {
+			t.Fatalf("template = %q, want from-file", template)
+		}
+		if len(request.Mounts) != 1 {
+			t.Fatalf("mount count = %d, want 1", len(request.Mounts))
+		}
+		if request.Mounts[0].SandboxvolumeID != "vol_123" || request.Mounts[0].MountPoint != "/workspace/data" {
+			t.Fatalf("unexpected mount = %+v", request.Mounts[0])
+		}
+		waitForMounts, ok := request.WaitForMounts.Get()
+		if !ok || !waitForMounts {
+			t.Fatalf("wait_for_mounts = %v, want true", waitForMounts)
+		}
+		timeout, ok := request.MountWaitTimeoutMs.Get()
+		if !ok || timeout != 45000 {
+			t.Fatalf("mount_wait_timeout_ms = %d, want 45000", timeout)
+		}
+	})
+
+	t.Run("mount flags extend request and timeout implies wait", func(t *testing.T) {
+		resetSandboxFlagsForTest()
+		sandboxTemplate = "default"
+		sandboxMounts = []string{"vol_abc:/workspace/bootstrap-data"}
+		sandboxMountWaitTimeoutMS = 30000
+
+		request, err := buildSandboxCreateRequest(false)
+		if err != nil {
+			t.Fatalf("buildSandboxCreateRequest() error = %v", err)
+		}
+		if len(request.Mounts) != 1 {
+			t.Fatalf("mount count = %d, want 1", len(request.Mounts))
+		}
+		waitForMounts, ok := request.WaitForMounts.Get()
+		if !ok || !waitForMounts {
+			t.Fatalf("wait_for_mounts = %v, want true", waitForMounts)
+		}
+	})
+
+	t.Run("mount flags append to request file mounts and template flag overrides", func(t *testing.T) {
+		resetSandboxFlagsForTest()
+		sandboxTemplate = "flag-template"
+		sandboxConfigFile = writeTempFile(t, `
+template: from-file
+mounts:
+  - sandboxvolume_id: vol_file
+    mount_point: /workspace/from-file
+wait_for_mounts: false
+`)
+		sandboxMounts = []string{"vol_flag:/workspace/from-flag"}
+		sandboxWaitForMounts = true
+
+		request, err := buildSandboxCreateRequest(true)
+		if err != nil {
+			t.Fatalf("buildSandboxCreateRequest() error = %v", err)
+		}
+		template, ok := request.Template.Get()
+		if !ok || template != "flag-template" {
+			t.Fatalf("template = %q, want flag-template", template)
+		}
+		if len(request.Mounts) != 2 {
+			t.Fatalf("mount count = %d, want 2", len(request.Mounts))
+		}
+		if request.Mounts[0].SandboxvolumeID != "vol_file" || request.Mounts[1].SandboxvolumeID != "vol_flag" {
+			t.Fatalf("unexpected mounts = %+v", request.Mounts)
+		}
+		waitForMounts, ok := request.WaitForMounts.Get()
+		if !ok || !waitForMounts {
+			t.Fatalf("wait_for_mounts = %v, want true", waitForMounts)
+		}
+	})
+
+	t.Run("invalid mount flag fails", func(t *testing.T) {
+		resetSandboxFlagsForTest()
+		sandboxTemplate = "default"
+		sandboxMounts = []string{"missing-separator"}
+
+		_, err := buildSandboxCreateRequest(false)
+		if err == nil {
+			t.Fatal("buildSandboxCreateRequest() error = nil, want error")
+		}
+	})
+
+	t.Run("relative mount path fails", func(t *testing.T) {
+		resetSandboxFlagsForTest()
+		sandboxTemplate = "default"
+		sandboxMounts = []string{"vol_abc:workspace/relative"}
+
+		_, err := buildSandboxCreateRequest(false)
+		if err == nil {
+			t.Fatal("buildSandboxCreateRequest() error = nil, want error")
 		}
 	})
 }
@@ -152,6 +271,9 @@ func resetSandboxFlagsForTest() {
 	sandboxTTL = 0
 	sandboxHardTTL = 0
 	sandboxConfigFile = ""
+	sandboxMounts = nil
+	sandboxWaitForMounts = false
+	sandboxMountWaitTimeoutMS = 0
 	sandboxListStatus = ""
 	sandboxListTemplateID = ""
 	sandboxListPaused = ""

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -905,24 +905,37 @@ func (f *TableFormatter) formatMountStatusList(w io.Writer, mounts []apispec.Mou
 	}
 
 	t := newTable(w)
-	t.Header([]string{"VOLUME ID", "MOUNT POINT", "MOUNTED AT", "DURATION", "SESSION ID"})
+	t.Header([]string{"VOLUME ID", "MOUNT POINT", "STATE", "MOUNTED AT", "DURATION", "SESSION ID", "ERROR"})
 
 	for _, m := range mounts {
-		volumeID, _ := m.SandboxvolumeID.Get()
-		mountPoint, _ := m.MountPoint.Get()
+		volumeID := m.SandboxvolumeID
+		mountPoint := m.MountPoint
 		mountedAt, _ := m.MountedAt.Get()
 		duration := "-"
 		if d, ok := m.MountedDurationSec.Get(); ok {
 			duration = formatDuration(d)
 		}
 		sessionID, _ := m.MountSessionID.Get()
+		errorText := "-"
+		errorCode, hasErrorCode := m.ErrorCode.Get()
+		errorMessage, hasErrorMessage := m.ErrorMessage.Get()
+		switch {
+		case hasErrorCode && hasErrorMessage:
+			errorText = fmt.Sprintf("%s: %s", errorCode, errorMessage)
+		case hasErrorMessage:
+			errorText = errorMessage
+		case hasErrorCode:
+			errorText = errorCode
+		}
 
 		_ = t.Append([]string{
 			volumeID,
 			mountPoint,
+			string(m.State),
 			formatTimestampText(mountedAt),
 			duration,
 			sessionID,
+			errorText,
 		})
 	}
 	return t.Render()


### PR DESCRIPTION
## Summary
- add sandbox create flags and config-file support for claim-time bootstrap mounts
- render richer mount status output in the cli
- cover request parsing, merge rules, and mount validation in command tests

Refs sandbox0-ai/sandbox0#143

## Testing
- go test ./internal/commands/...
- go test ./...