### PR TITLE
Add GitHub Actions integration for s0

### DIFF
--- a/.github/actions/setup-s0/action.yml
+++ b/.github/actions/setup-s0/action.yml
@@ -1,0 +1,104 @@
+name: Setup s0
+description: Install s0 and optionally export Sandbox0 authentication environment variables.
+
+inputs:
+  version:
+    description: Release tag to install, for example v0.2.2. Defaults to the latest release.
+    required: false
+    default: ""
+  install-dir:
+    description: Directory where the s0 binary should be installed.
+    required: false
+    default: ""
+  token:
+    description: Sandbox0 API token to export as SANDBOX0_TOKEN.
+    required: false
+    default: ""
+  api-url:
+    description: Sandbox0 API URL to export as SANDBOX0_BASE_URL.
+    required: false
+    default: https://api.sandbox0.ai
+
+runs:
+  using: composite
+  steps:
+    - name: Install s0 on Unix runners
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        S0_VERSION: ${{ inputs.version }}
+        INSTALL_DIR: ${{ inputs.install-dir }}
+      run: |
+        set -euo pipefail
+
+        bash "${{ github.action_path }}/../../../scripts/install.sh"
+
+        install_dir="${INSTALL_DIR}"
+        if [ -z "${install_dir}" ]; then
+          if [ -w "/usr/local/bin" ]; then
+            install_dir="/usr/local/bin"
+          else
+            install_dir="${HOME}/.local/bin"
+          fi
+        fi
+
+        echo "${install_dir}" >> "${GITHUB_PATH}"
+
+    - name: Install s0 on Windows runners
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        S0_VERSION: ${{ inputs.version }}
+        INSTALL_DIR: ${{ inputs.install-dir }}
+      run: |
+        $scriptPath = Join-Path '${{ github.action_path }}' '..\..\..\scripts\install.ps1'
+        $scriptPath = [System.IO.Path]::GetFullPath($scriptPath)
+        & $scriptPath
+
+        $installDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $HOME '.local\bin' }
+        $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Export Sandbox0 auth on Unix runners
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        SANDBOX0_ACTION_API_URL: ${{ inputs.api-url }}
+        SANDBOX0_ACTION_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${SANDBOX0_ACTION_API_URL}" ]; then
+          echo "SANDBOX0_BASE_URL=${SANDBOX0_ACTION_API_URL}" >> "${GITHUB_ENV}"
+        fi
+
+        if [ -n "${SANDBOX0_ACTION_TOKEN}" ]; then
+          echo "SANDBOX0_TOKEN=${SANDBOX0_ACTION_TOKEN}" >> "${GITHUB_ENV}"
+        fi
+
+    - name: Export Sandbox0 auth on Windows runners
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SANDBOX0_ACTION_API_URL: ${{ inputs.api-url }}
+        SANDBOX0_ACTION_TOKEN: ${{ inputs.token }}
+      run: |
+        if ($env:SANDBOX0_ACTION_API_URL) {
+          "SANDBOX0_BASE_URL=$env:SANDBOX0_ACTION_API_URL" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        }
+
+        if ($env:SANDBOX0_ACTION_TOKEN) {
+          "SANDBOX0_TOKEN=$env:SANDBOX0_ACTION_TOKEN" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        }
+
+    - name: Verify install on Unix runners
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        s0 --help >/dev/null
+
+    - name: Verify install on Windows runners
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        s0 --help | Out-Null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,3 +146,31 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
           files: release-assets/*
+
+  update-major-tag:
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then
+            echo "skip unsupported release tag: ${RELEASE_TAG}"
+            exit 0
+          fi
+
+          major_tag="v${BASH_REMATCH[1]}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -fa "${major_tag}" -m "Update ${major_tag} to ${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}"
+          git push origin "refs/tags/${major_tag}" --force

--- a/.github/workflows/template-image.yml
+++ b/.github/workflows/template-image.yml
@@ -1,0 +1,140 @@
+name: Sandbox0 Template Image
+
+on:
+  workflow_call:
+    inputs:
+      api-url:
+        description: Sandbox0 API URL.
+        required: false
+        default: https://api.sandbox0.ai
+        type: string
+      s0-version:
+        description: Release tag to install before running s0. Defaults to the latest release.
+        required: false
+        default: ""
+        type: string
+      image-tag:
+        description: Template image tag, without the registry prefix.
+        required: true
+        type: string
+      context:
+        description: Docker build context.
+        required: false
+        default: .
+        type: string
+      dockerfile:
+        description: Dockerfile path passed to s0 template image build.
+        required: false
+        default: Dockerfile
+        type: string
+      platform:
+        description: Optional Docker build platform such as linux/amd64.
+        required: false
+        default: ""
+        type: string
+      pull:
+        description: Always attempt to pull a newer version of base images.
+        required: false
+        default: false
+        type: boolean
+      no-cache:
+        description: Disable Docker build cache.
+        required: false
+        default: false
+        type: boolean
+      checkout:
+        description: Whether to checkout the caller repository before building.
+        required: false
+        default: true
+        type: boolean
+    secrets:
+      sandbox0_token:
+        description: Sandbox0 API token.
+        required: true
+    outputs:
+      image-tag:
+        description: Canonical template image tag without the registry prefix.
+        value: ${{ jobs.build-and-push.outputs.image-tag }}
+      template-image:
+        description: Pullable template image reference for Sandbox0 templates.
+        value: ${{ jobs.build-and-push.outputs.template-image }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.image-ref.outputs.image_tag }}
+      template-image: ${{ steps.image-ref.outputs.template_image }}
+    env:
+      SANDBOX0_BASE_URL: ${{ inputs.api-url }}
+      SANDBOX0_TOKEN: ${{ secrets.sandbox0_token }}
+    steps:
+      - name: Checkout caller repository
+        if: ${{ inputs.checkout }}
+        uses: actions/checkout@v6
+
+      - name: Install s0
+        shell: bash
+        env:
+          S0_VERSION: ${{ inputs.s0-version }}
+          INSTALL_DIR: ${{ runner.temp }}/s0-bin
+        run: |
+          set -euo pipefail
+          curl -fsSL https://raw.githubusercontent.com/sandbox0-ai/s0/main/scripts/install.sh | bash
+          echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
+
+      - name: Verify Docker availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker version
+
+      - name: Build template image
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+          BUILD_CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          PLATFORM: ${{ inputs.platform }}
+          BUILD_PULL: ${{ inputs.pull }}
+          NO_CACHE: ${{ inputs.no-cache }}
+        run: |
+          set -euo pipefail
+
+          args=(template image build -f "${DOCKERFILE}" -t "${IMAGE_TAG}")
+          if [ -n "${PLATFORM}" ]; then
+            args+=(--platform "${PLATFORM}")
+          fi
+          if [ "${BUILD_PULL}" = "true" ]; then
+            args+=(--pull)
+          fi
+          if [ "${NO_CACHE}" = "true" ]; then
+            args+=(--no-cache)
+          fi
+          args+=("${BUILD_CONTEXT}")
+
+          s0 "${args[@]}"
+
+      - name: Push template image
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          set -euo pipefail
+          s0 template image push "${IMAGE_TAG}" -t "${IMAGE_TAG}"
+
+      - name: Resolve pushed template image reference
+        id: image-ref
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          set -euo pipefail
+
+          creds_json="$(s0 -o json template image credentials -t "${IMAGE_TAG}")"
+
+          echo "image_tag=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          CREDS_JSON="${creds_json}" python -c 'import json, os; creds = json.loads(os.environ["CREDS_JSON"]); image_tag = os.environ["IMAGE_TAG"]; pull_registry = creds.get("PullRegistry") or ""; template_image = f"{pull_registry}/{image_tag}" if pull_registry else image_tag; print(f"template_image={template_image}")' >> "${GITHUB_OUTPUT}"

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Pin `@main` to a release tag after the first s0 release that includes these GitH
 - uses: sandbox0-ai/s0/.github/workflows/template-image.yml@v0.2.3
 ```
 
-If you want a floating major tag later, add and maintain `v0` after the tagged release is published.
+The release workflow also updates the floating major tag automatically, so after `v0.2.3` is published, users can choose either `@v0.2.3` or `@v0`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,19 @@ jobs:
 
 Pin `@main` to a release tag after the first s0 release that includes these GitHub Actions assets.
 
+### Next Steps
+
+1. Merge the GitHub Actions changes into `main`.
+2. Publish the next `s0` release tag, for example `v0.2.3`, through the normal `s0` release flow.
+3. Replace `@main` in workflow files with that release tag:
+
+```yaml
+- uses: sandbox0-ai/s0/.github/actions/setup-s0@v0.2.3
+- uses: sandbox0-ai/s0/.github/workflows/template-image.yml@v0.2.3
+```
+
+If you want a floating major tag later, add and maintain `v0` after the tagged release is published.
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -122,6 +122,69 @@ Mode resolution order:
 | `SANDBOX0_TOKEN` | API authentication token | - |
 | `SANDBOX0_BASE_URL` | API base URL | `https://api.sandbox0.ai` |
 
+## GitHub Actions
+
+`s0 template image build` and `s0 template image push` shell out to Docker.
+Use a GitHub-hosted runner with Docker available, or a self-hosted runner with a working Docker daemon.
+
+For CI, prefer a Sandbox0 API key scoped to automation. For image pushes, the recommended team role is `builder`.
+
+### Setup Action
+
+Install `s0`, add it to `PATH`, and optionally export `SANDBOX0_TOKEN` and `SANDBOX0_BASE_URL`:
+
+```yaml
+jobs:
+  verify-s0:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: sandbox0-ai/s0/.github/actions/setup-s0@main
+        with:
+          token: ${{ secrets.SANDBOX0_TOKEN }}
+          api-url: ${{ secrets.SANDBOX0_BASE_URL }}
+
+      - run: s0 template list
+```
+
+### Reusable Workflow
+
+Build and push a template image with the official reusable workflow:
+
+```yaml
+jobs:
+  template-image:
+    uses: sandbox0-ai/s0/.github/workflows/template-image.yml@main
+    with:
+      api-url: ${{ vars.SANDBOX0_BASE_URL }}
+      image-tag: my-app:${{ github.sha }}
+      context: .
+      dockerfile: Dockerfile
+    secrets:
+      sandbox0_token: ${{ secrets.SANDBOX0_TOKEN }}
+```
+
+Consume the pushed template image reference from workflow outputs:
+
+```yaml
+jobs:
+  publish:
+    uses: sandbox0-ai/s0/.github/workflows/template-image.yml@main
+    with:
+      image-tag: my-app:${{ github.sha }}
+    secrets:
+      sandbox0_token: ${{ secrets.SANDBOX0_TOKEN }}
+
+  deploy:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ needs.publish.outputs.template-image }}"
+```
+
+Pin `@main` to a release tag after the first s0 release that includes these GitHub Actions assets.
+
 ## Usage
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.3
+	github.com/sandbox0-ai/sdk-go v0.2.4
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.3 h1:MFAq9a7r0+pQxN+hSz/DSVEKMdbs9RS94BUtVuEGZH8=
-github.com/sandbox0-ai/sdk-go v0.2.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.4 h1:UCRZLaQFajIlWCzS59O7tA4Fpbbb3b5yNU/Qj4A2zDA=
+github.com/sandbox0-ai/sdk-go v0.2.4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -259,12 +259,14 @@ var teamUseCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Error loading profile: %v\n", err)
 			os.Exit(1)
 		}
+		gatewayMode := resolveGatewayModeForProfile(cmd.Context(), profile)
 		homeRegionID, regionalGatewayURL, err := resolveCurrentTeamTarget(cmd.Context(), profile, client, data)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error validating team: %v\n", err)
 			os.Exit(1)
 		}
 
+		cfg.SetGatewayMode(profileName, gatewayMode)
 		cfg.SetCurrentTeam(profileName, teamID, homeRegionID, regionalGatewayURL)
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -161,3 +161,14 @@ func TestResolveCurrentTeamTargetGlobalModeRequiresHomeRegion(t *testing.T) {
 		t.Fatalf("expected missing home region error, got %v", err)
 	}
 }
+
+func TestResolveGatewayModeForProfileUsesConfiguredMode(t *testing.T) {
+	profile := &config.Profile{
+		APIURL:      "https://api.example.com",
+		GatewayMode: string(config.GatewayModeGlobal),
+	}
+
+	if got := resolveGatewayModeForProfile(context.Background(), profile); got != config.GatewayModeGlobal {
+		t.Fatalf("resolveGatewayModeForProfile() = %q, want %q", got, config.GatewayModeGlobal)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,19 @@ func (c *Config) SetCurrentTeam(profileName, teamID, regionID, gatewayURL string
 	c.Profiles[profileName] = p
 }
 
+// SetGatewayMode updates the configured gateway mode for a profile.
+func (c *Config) SetGatewayMode(profileName string, mode GatewayMode) {
+	if c.Profiles == nil {
+		c.Profiles = make(map[string]Profile)
+	}
+	p, ok := c.Profiles[profileName]
+	if !ok {
+		p = Profile{}
+	}
+	p.GatewayMode = strings.TrimSpace(string(mode))
+	c.Profiles[profileName] = p
+}
+
 // Save writes config to disk.
 func (c *Config) Save() error {
 	configPath := expandPath(cfgFile)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSetGatewayModePersistsToConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := tmpDir + "/config.yaml"
+
+	originalPath := *GetConfigFile()
+	t.Cleanup(func() {
+		SetConfigFile(originalPath)
+	})
+	SetConfigFile(configPath)
+
+	cfg := &Config{
+		Profiles: map[string]Profile{},
+	}
+	cfg.SetGatewayMode("test-profile", GatewayModeGlobal)
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("cfg.Save() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(raw), "gateway-mode: global") {
+		t.Fatalf("saved config missing gateway-mode: %s", string(raw))
+	}
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,6 +27,7 @@ $Arch = Resolve-Arch
 $InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $HOME ".local\bin" }
 $Archive = "s0-windows-$Arch.zip"
 $Url = "https://github.com/$Repo/releases/download/$Version/$Archive"
+$BinaryName = "s0-windows-$Arch.exe"
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("s0-" + [System.Guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $TempDir | Out-Null
@@ -38,7 +39,12 @@ try {
   Invoke-WebRequest -Uri $Url -OutFile $ZipPath
   Expand-Archive -Path $ZipPath -DestinationPath $TempDir -Force
 
-  Copy-Item -Path (Join-Path $TempDir "s0.exe") -Destination (Join-Path $InstallDir "s0.exe") -Force
+  $SourceBinary = Join-Path $TempDir $BinaryName
+  if (-not (Test-Path $SourceBinary)) {
+    $SourceBinary = Join-Path $TempDir "s0.exe"
+  }
+
+  Copy-Item -Path $SourceBinary -Destination (Join-Path $InstallDir "s0.exe") -Force
   Write-Host "installed s0 to $(Join-Path $InstallDir 's0.exe')"
 
   $currentUserPath = [Environment]::GetEnvironmentVariable("Path", "User")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,12 +76,18 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 archive="s0-${os}-${arch}.tar.gz"
 url="https://github.com/${repo}/releases/download/${version}/${archive}"
+binary="${archive%.tar.gz}"
 
 mkdir -p "${install_dir}"
 
 curl -fsSL "${url}" -o "${tmpdir}/${archive}"
 tar -xzf "${tmpdir}/${archive}" -C "${tmpdir}"
-install -m 0755 "${tmpdir}/s0" "${install_dir}/s0"
+
+if [ ! -f "${tmpdir}/${binary}" ] && [ -f "${tmpdir}/s0" ]; then
+  binary="s0"
+fi
+
+install -m 0755 "${tmpdir}/${binary}" "${install_dir}/s0"
 
 echo "installed s0 to ${install_dir}/s0"
 


### PR DESCRIPTION
## Summary
- add an official `setup-s0` composite action for GitHub Actions runners
- add an official reusable workflow for Sandbox0 template image build and push flows
- fix the install scripts so they match the current release asset naming convention and document the new GitHub Actions entrypoints in the README

## Testing
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/setup-s0/action.yml"); YAML.load_file(".github/workflows/template-image.yml"); puts :ok'`
- `tmpdir=$(mktemp -d) && INSTALL_DIR="$tmpdir" S0_VERSION=v0.2.2 bash ./scripts/install.sh && "$tmpdir/s0" --help >/dev/null && rm -rf "$tmpdir"`

Related to sandbox0-ai/sandbox0#149
