### PR TITLE
Update shared-volume template coverage

### DIFF
--- a/.github/actions/setup-s0/action.yml
+++ b/.github/actions/setup-s0/action.yml
@@ -1,3 +1,7 @@
+# Public GitHub Actions entrypoint.
+# Keep this file path stable for consumers using:
+# sandbox0-ai/s0/.github/actions/setup-s0@<ref>
+# If the implementation moves, leave a compatibility stub at this path.
 name: Setup s0
 description: Install s0 and optionally export Sandbox0 authentication environment variables.
 

--- a/.github/workflows/template-image.yml
+++ b/.github/workflows/template-image.yml
@@ -1,3 +1,7 @@
+# Public reusable workflow entrypoint.
+# Keep this file path stable for consumers using:
+# sandbox0-ai/s0/.github/workflows/template-image.yml@<ref>
+# If the implementation moves, leave a compatibility wrapper at this path.
 name: Sandbox0 Template Image
 
 on:

--- a/README.md
+++ b/README.md
@@ -120,9 +120,16 @@ Mode resolution order:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SANDBOX0_TOKEN` | API authentication token | - |
-| `SANDBOX0_BASE_URL` | API base URL | `https://api.sandbox0.ai` |
+| `SANDBOX0_BASE_URL` | Optional API base URL override for self-hosted or private deployments | `https://api.sandbox0.ai` |
 
 ## GitHub Actions
+
+The GitHub Actions entrypoints in this repository are part of the public integration surface. Keep these paths stable for consumers:
+
+- `.github/actions/setup-s0/action.yml`
+- `.github/workflows/template-image.yml`
+
+If the implementation changes internally, keep a compatibility stub or wrapper at the same path.
 
 `s0 template image build` and `s0 template image push` shell out to Docker.
 Use a GitHub-hosted runner with Docker available, or a self-hosted runner with a working Docker daemon.
@@ -143,10 +150,11 @@ jobs:
       - uses: sandbox0-ai/s0/.github/actions/setup-s0@main
         with:
           token: ${{ secrets.SANDBOX0_TOKEN }}
-          api-url: ${{ secrets.SANDBOX0_BASE_URL }}
 
       - run: s0 template list
 ```
+
+For self-hosted or private Sandbox0 deployments, also pass `api-url: ${{ vars.SANDBOX0_BASE_URL }}`.
 
 ### Reusable Workflow
 
@@ -157,13 +165,14 @@ jobs:
   template-image:
     uses: sandbox0-ai/s0/.github/workflows/template-image.yml@main
     with:
-      api-url: ${{ vars.SANDBOX0_BASE_URL }}
       image-tag: my-app:${{ github.sha }}
       context: .
       dockerfile: Dockerfile
     secrets:
       sandbox0_token: ${{ secrets.SANDBOX0_TOKEN }}
 ```
+
+For self-hosted or private Sandbox0 deployments, also pass `api-url: ${{ vars.SANDBOX0_BASE_URL }}`.
 
 Consume the pushed template image reference from workflow outputs:
 
@@ -183,20 +192,9 @@ jobs:
       - run: echo "${{ needs.publish.outputs.template-image }}"
 ```
 
-Pin `@main` to a release tag after the first s0 release that includes these GitHub Actions assets.
+For production workflows, pin `@main` to a published `s0` release tag such as `@v0.2.4` or `@v0`.
 
-### Next Steps
-
-1. Merge the GitHub Actions changes into `main`.
-2. Publish the next `s0` release tag, for example `v0.2.3`, through the normal `s0` release flow.
-3. Replace `@main` in workflow files with that release tag:
-
-```yaml
-- uses: sandbox0-ai/s0/.github/actions/setup-s0@v0.2.3
-- uses: sandbox0-ai/s0/.github/workflows/template-image.yml@v0.2.3
-```
-
-The release workflow also updates the floating major tag automatically, so after `v0.2.3` is published, users can choose either `@v0.2.3` or `@v0`.
+For Sandbox0 SaaS, you usually only need `SANDBOX0_TOKEN`. Set `SANDBOX0_BASE_URL` when your workflow talks to a self-hosted or private Sandbox0 deployment.
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	modernc.org/sqlite v1.47.0
 )
 
+replace github.com/sandbox0-ai/sdk-go => ../sdk-go
+
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,15 +9,13 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.4
+	github.com/sandbox0-ai/sdk-go v0.2.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.47.0
 )
-
-replace github.com/sandbox0-ai/sdk-go => ../sdk-go
 
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/sandbox0-ai/sdk-go v0.2.5 h1:p0d5R5yADE0GzxAGFCGEQi1dl43y2QLWleLwRVyK9kQ=
+github.com/sandbox0-ai/sdk-go v0.2.5/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.4 h1:UCRZLaQFajIlWCzS59O7tA4Fpbbb3b5yNU/Qj4A2zDA=
-github.com/sandbox0-ai/sdk-go v0.2.4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/template_test.go
+++ b/internal/commands/template_test.go
@@ -21,7 +21,6 @@ func TestBuildTemplateCreateRequestPreservesSidecarSpec(t *testing.T) {
       memory: 256Mi
   sharedVolumes:
     - name: workspace
-      sandboxVolumeId: vol_123
       mountPath: /workspace/shared
   sidecars:
     - name: claude-code
@@ -72,6 +71,9 @@ func TestBuildTemplateCreateRequestPreservesSidecarSpec(t *testing.T) {
 	}
 	if req.Spec.SharedVolumes[0].MountPath != "/workspace/shared" {
 		t.Fatalf("SharedVolumes[0].MountPath = %q, want /workspace/shared", req.Spec.SharedVolumes[0].MountPath)
+	}
+	if _, ok := req.Spec.SharedVolumes[0].SandboxVolumeId.Get(); ok {
+		t.Fatal("SharedVolumes[0].SandboxVolumeId should be unset for claim-bound shared volumes")
 	}
 
 	sidecar := req.Spec.Sidecars[0]

--- a/internal/commands/template_test.go
+++ b/internal/commands/template_test.go
@@ -19,12 +19,19 @@ func TestBuildTemplateCreateRequestPreservesSidecarSpec(t *testing.T) {
     resources:
       cpu: "250m"
       memory: 256Mi
+  sharedVolumes:
+    - name: workspace
+      sandboxVolumeId: vol_123
+      mountPath: /workspace/shared
   sidecars:
     - name: claude-code
       image: cc-demo:test
       resources:
         cpu: "500m"
         memory: 512Mi
+      mounts:
+        - name: workspace
+          mountPath: /shared
       env:
         - name: PORT
           value: "8081"
@@ -57,6 +64,15 @@ func TestBuildTemplateCreateRequestPreservesSidecarSpec(t *testing.T) {
 	if len(req.Spec.Sidecars) != 1 {
 		t.Fatalf("len(Spec.Sidecars) = %d, want 1", len(req.Spec.Sidecars))
 	}
+	if len(req.Spec.SharedVolumes) != 1 {
+		t.Fatalf("len(Spec.SharedVolumes) = %d, want 1", len(req.Spec.SharedVolumes))
+	}
+	if req.Spec.SharedVolumes[0].Name != "workspace" {
+		t.Fatalf("SharedVolumes[0].Name = %q, want workspace", req.Spec.SharedVolumes[0].Name)
+	}
+	if req.Spec.SharedVolumes[0].MountPath != "/workspace/shared" {
+		t.Fatalf("SharedVolumes[0].MountPath = %q, want /workspace/shared", req.Spec.SharedVolumes[0].MountPath)
+	}
 
 	sidecar := req.Spec.Sidecars[0]
 	if sidecar.Name != "claude-code" {
@@ -67,6 +83,12 @@ func TestBuildTemplateCreateRequestPreservesSidecarSpec(t *testing.T) {
 	}
 	if len(sidecar.Env) != 2 {
 		t.Fatalf("len(Sidecars[0].Env) = %d, want 2", len(sidecar.Env))
+	}
+	if len(sidecar.Mounts) != 1 {
+		t.Fatalf("len(Sidecars[0].Mounts) = %d, want 1", len(sidecar.Mounts))
+	}
+	if sidecar.Mounts[0].Name != "workspace" || sidecar.Mounts[0].MountPath != "/shared" {
+		t.Fatalf("Sidecars[0].Mounts[0] = %+v, want workspace:/shared", sidecar.Mounts[0])
 	}
 	if !sidecar.ReadinessProbe.IsSet() {
 		t.Fatal("Sidecars[0].ReadinessProbe should be set")
@@ -86,15 +108,11 @@ func TestBuildTemplateCreateRequestPreservesSidecarSpec(t *testing.T) {
 		t.Fatalf("len(Sidecars[0].ReadinessProbe.Exec.Command) = %d, want 3", len(execAction.Command))
 	}
 
-	resources, ok := sidecar.Resources.Get()
-	if !ok {
-		t.Fatal("Sidecars[0].Resources should be set")
-	}
-	cpu, ok := resources.CPU.Get()
+	cpu, ok := sidecar.Resources.CPU.Get()
 	if !ok || cpu != "500m" {
 		t.Fatalf("Sidecars[0].Resources.CPU = %q, want 500m", cpu)
 	}
-	memory, ok := resources.Memory.Get()
+	memory, ok := sidecar.Resources.Memory.Get()
 	if !ok || memory != "512Mi" {
 		t.Fatalf("Sidecars[0].Resources.Memory = %q, want 512Mi", memory)
 	}


### PR DESCRIPTION
## Summary
- extend template fixture coverage for shared volumes and sidecar mounts
- keep local development wired to the in-flight sdk-go branch with a temporary local replace directive
- clarify the public GitHub Actions entrypoints in README and workflow comments

## Testing
- go test ./...

## Note
- this PR is draft-only until sdk-go is released and the local replace can be swapped back to a published dependency version

Related to sandbox0-ai/sandbox0#148
