### PR TITLE
Fix current team handling for direct login flows

### DIFF
--- a/internal/client/routing.go
+++ b/internal/client/routing.go
@@ -72,9 +72,6 @@ func ResolveTarget(ctx context.Context, opts ResolveTargetOptions) (*ResolvedTar
 			GatewayMode: mode,
 		}, nil
 	}
-	if tokenUsesImplicitTeamSelection(opts.Token) && strings.TrimSpace(opts.CurrentTeamID) == "" {
-		return nil, ErrCurrentTeamRequired
-	}
 	if mode != config.GatewayModeGlobal {
 		return target, nil
 	}

--- a/internal/client/routing_test.go
+++ b/internal/client/routing_test.go
@@ -35,18 +35,24 @@ func TestResolveTargetDefaultsToDirectWhenMetadataIsMissing(t *testing.T) {
 	}
 }
 
-func TestResolveTargetRequiresCurrentTeamForDirectHomeRegionRoutingWithUserToken(t *testing.T) {
+func TestResolveTargetAllowsDirectHomeRegionRoutingWithUserTokenWithoutCurrentTeam(t *testing.T) {
 	server := httptest.NewServer(http.NotFoundHandler())
 	defer server.Close()
 
-	_, err := ResolveTarget(context.Background(), ResolveTargetOptions{
+	target, err := ResolveTarget(context.Background(), ResolveTargetOptions{
 		BaseURL:   server.URL,
 		Token:     "user-token",
 		Scope:     RouteScopeHomeRegion,
 		UserAgent: "s0/test",
 	})
-	if err != ErrCurrentTeamRequired {
-		t.Fatalf("ResolveTarget() error = %v, want %v", err, ErrCurrentTeamRequired)
+	if err != nil {
+		t.Fatalf("ResolveTarget() error = %v", err)
+	}
+	if target.BaseURL != server.URL {
+		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, server.URL)
+	}
+	if target.Token != "user-token" {
+		t.Fatalf("Token = %q, want user-token", target.Token)
 	}
 }
 

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -83,13 +83,25 @@ var authLoginCmd = &cobra.Command{
 			loginData.RefreshToken,
 			loginData.ExpiresAt,
 		)
+		autoSelectedTeam, autoSelected, autoSelectErr := maybeAutoSelectCurrentTeam(cmd.Context(), cfg, profileName)
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving credentials: %v\n", err)
 			os.Exit(1)
 		}
 
 		fmt.Printf("Login successful via provider %q using %s mode (profile: %s)\n", provider.ID, effectiveMode, profileName)
-		if shouldShowCurrentTeamSelectionHint(cmd.Context(), baseURL, p.GetCurrentTeamID()) {
+		if autoSelectErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not auto-select current team: %v\n", autoSelectErr)
+		}
+		if autoSelected {
+			fmt.Printf("Auto-selected current team %s (%s)\n", autoSelectedTeam.ID, autoSelectedTeam.Name)
+		}
+		updatedProfile, err := cfg.GetProfile(profileName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading updated profile: %v\n", err)
+			os.Exit(1)
+		}
+		if shouldShowCurrentTeamSelectionHint(resolveGatewayModeForProfile(cmd.Context(), updatedProfile), updatedProfile.GetCurrentTeamID()) {
 			fmt.Println("Global routing requires a locally selected current team for workload commands.")
 			fmt.Println("Set it with: s0 team use <team-id>")
 			fmt.Println("If you do not have a team yet, create one with: s0 team create --name <name> --home-region <region-id>")

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/s0/internal/config"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
 type authProvider struct {
@@ -328,9 +329,56 @@ func oidcLoginViaDeviceFlow(ctx context.Context, baseURL, providerID string) (*a
 	}
 }
 
-func shouldShowCurrentTeamSelectionHint(ctx context.Context, baseURL, currentTeamID string) bool {
-	_ = ctx
-	_ = baseURL
+func maybeAutoSelectCurrentTeam(ctx context.Context, cfg *config.Config, profileName string) (*apispec.Team, bool, error) {
+	if cfg == nil {
+		return nil, false, nil
+	}
+
+	profile, err := cfg.GetProfile(profileName)
+	if err != nil {
+		return nil, false, err
+	}
+	if strings.TrimSpace(profile.GetCurrentTeamID()) != "" {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(profile.GetToken()) == "" {
+		return nil, false, nil
+	}
+
+	client, err := newSDKClientForBaseURL(profile.GetAPIURL(), profile.GetToken())
+	if err != nil {
+		return nil, false, err
+	}
+
+	res, err := client.API().TeamsGet(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("list teams: %w", err)
+	}
+	successRes, ok := res.(*apispec.SuccessTeamListResponse)
+	if !ok {
+		return nil, false, fmt.Errorf("list teams: unexpected response type %T", res)
+	}
+	data, ok := successRes.Data.Get()
+	if !ok {
+		return nil, false, fmt.Errorf("list teams: missing response data")
+	}
+	if len(data.Teams) != 1 {
+		return nil, false, nil
+	}
+
+	team := data.Teams[0]
+	homeRegionID, regionalGatewayURL, err := resolveCurrentTeamTarget(ctx, profile, client, team)
+	if err != nil {
+		return nil, false, err
+	}
+	cfg.SetCurrentTeam(profileName, team.ID, homeRegionID, regionalGatewayURL)
+	return &team, true, nil
+}
+
+func shouldShowCurrentTeamSelectionHint(mode config.GatewayMode, currentTeamID string) bool {
+	if mode != config.GatewayModeGlobal {
+		return false
+	}
 	if strings.TrimSpace(currentTeamID) != "" {
 		return false
 	}

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -2,18 +2,143 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/sandbox0-ai/s0/internal/config"
 )
 
 func TestShouldShowCurrentTeamSelectionHint(t *testing.T) {
-	if !shouldShowCurrentTeamSelectionHint(context.Background(), "http://127.0.0.1:0", "") {
+	if !shouldShowCurrentTeamSelectionHint(config.GatewayModeGlobal, "") {
 		t.Fatal("shouldShowCurrentTeamSelectionHint() = false, want true")
 	}
 }
 
 func TestShouldShowCurrentTeamSelectionHintSkipsWhenCurrentTeamExists(t *testing.T) {
-	if shouldShowCurrentTeamSelectionHint(context.Background(), "http://127.0.0.1:0", "team-1") {
+	if shouldShowCurrentTeamSelectionHint(config.GatewayModeGlobal, "team-1") {
 		t.Fatal("shouldShowCurrentTeamSelectionHint() = true, want false")
+	}
+}
+
+func TestShouldShowCurrentTeamSelectionHintSkipsInDirectMode(t *testing.T) {
+	if shouldShowCurrentTeamSelectionHint(config.GatewayModeDirect, "") {
+		t.Fatal("shouldShowCurrentTeamSelectionHint() = true, want false")
+	}
+}
+
+func TestMaybeAutoSelectCurrentTeamSelectsOnlyTeamInDirectMode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/teams":
+			writeAuthJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"teams": []map[string]any{{
+						"id":         "team-1",
+						"name":       "Personal Team",
+						"slug":       "personal-team",
+						"created_at": "2026-01-01T00:00:00Z",
+						"updated_at": "2026-01-01T00:00:00Z",
+					}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		CurrentProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				APIURL: server.URL,
+				Token:  "user-token",
+			},
+		},
+	}
+
+	team, ok, err := maybeAutoSelectCurrentTeam(context.Background(), cfg, "default")
+	if err != nil {
+		t.Fatalf("maybeAutoSelectCurrentTeam() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("maybeAutoSelectCurrentTeam() did not auto-select team")
+	}
+	if team.ID != "team-1" {
+		t.Fatalf("team.ID = %q, want team-1", team.ID)
+	}
+
+	profile, err := cfg.GetProfile("default")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if got := profile.GetCurrentTeamID(); got != "team-1" {
+		t.Fatalf("CurrentTeamID = %q, want team-1", got)
+	}
+	if target, ok := profile.GetCurrentTeamTarget(); ok {
+		t.Fatalf("CurrentTeamTarget should be unset in direct mode, got %+v", target)
+	}
+}
+
+func TestMaybeAutoSelectCurrentTeamDoesNotSelectWhenMultipleTeamsExist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/teams":
+			writeAuthJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"teams": []map[string]any{
+						{
+							"id": "team-1", "name": "One", "slug": "one", "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+						},
+						{
+							"id": "team-2", "name": "Two", "slug": "two", "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+						},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		CurrentProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				APIURL: server.URL,
+				Token:  "user-token",
+			},
+		},
+	}
+
+	team, ok, err := maybeAutoSelectCurrentTeam(context.Background(), cfg, "default")
+	if err != nil {
+		t.Fatalf("maybeAutoSelectCurrentTeam() error = %v", err)
+	}
+	if ok {
+		t.Fatalf("maybeAutoSelectCurrentTeam() selected unexpected team %+v", team)
+	}
+
+	profile, err := cfg.GetProfile("default")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if got := profile.GetCurrentTeamID(); got != "" {
+		t.Fatalf("CurrentTeamID = %q, want empty", got)
+	}
+}
+
+func writeAuthJSON(t *testing.T, w http.ResponseWriter, status int, payload any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode response: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop requiring `s0 team use` for direct or single-cluster workload commands
- auto-select the current team after `s0 auth login` when the user only has one team
- only show the current-team hint for global routing, and add tests for the new behavior

## Testing
- `go test ./internal/client ./internal/commands`
- remote kind: `s0 auth login --mode builtin` followed by `s0 credential create/get/delete` without running `s0 team use`