### PR TITLE
Add non-PTY stream exec mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,11 @@ s0 sandbox context stats <ctx-id> -s <sandbox-id>
 reusing a matching running REPL context when there is exactly one match for the
 requested alias. `s0 sandbox exec` remains the one-shot command path.
 
-Use `--stream` when you want non-TTY commands to stream stdout/stderr live:
+Use `--stream` when you want non-TTY commands to stream stdout/stderr live. The command exits when the remote process emits its terminal `done` event, and the CLI returns the remote exit code.
 
 ```bash
-s0 sandbox exec <sandbox-id> --stream -- sh -c 'echo hello && sleep 1 && echo done'
+s0 sandbox exec <sandbox-id> --stream -- sh -c 'echo hello && sleep 1 && exit 7'
+# exits locally with status 7
 ```
 
 ### Sandbox Network

--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ s0 sandbox context stats <ctx-id> -s <sandbox-id>
 reusing a matching running REPL context when there is exactly one match for the
 requested alias. `s0 sandbox exec` remains the one-shot command path.
 
+Use `--stream` when you want non-TTY commands to stream stdout/stderr live:
+
+```bash
+s0 sandbox exec <sandbox-id> --stream -- sh -c 'echo hello && sleep 1 && echo done'
+```
+
 ### Sandbox Network
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.5
+	github.com/sandbox0-ai/sdk-go v0.2.6
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.5 h1:p0d5R5yADE0GzxAGFCGEQi1dl43y2QLWleLwRVyK9kQ=
-github.com/sandbox0-ai/sdk-go v0.2.5/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.6 h1:eZul3PPz1WcY4KAWFXt08whz0Pm2G0MbEG88XSr1lnU=
+github.com/sandbox0-ai/sdk-go v0.2.6/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_exec.go
+++ b/internal/commands/sandbox_exec.go
@@ -10,7 +10,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -24,6 +23,7 @@ var (
 	execEnv         []string
 	execNoWait      bool
 	execTTL         int32
+	execStream      bool
 	execInteractive bool
 	execTTY         bool
 )
@@ -70,8 +70,8 @@ Examples:
 			os.Exit(1)
 		}
 
-		if execNoWait && (execInteractive || execTTY) {
-			fmt.Fprintln(os.Stderr, "Error: --no-wait cannot be used with interactive or TTY exec")
+		if execNoWait && (execStream || execInteractive || execTTY) {
+			fmt.Fprintln(os.Stderr, "Error: --no-wait cannot be used with streaming, interactive, or TTY exec")
 			os.Exit(1)
 		}
 
@@ -148,7 +148,7 @@ func shouldUseStreamingExec(command []string) bool {
 	if execNoWait {
 		return false
 	}
-	if execInteractive || execTTY {
+	if execStream || execInteractive || execTTY {
 		return true
 	}
 	return shouldAutoInteractiveExec(command)
@@ -174,6 +174,8 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	allocateTTY := execTTY || execInteractive || shouldAutoInteractiveExec(command)
+
 	req := apispec.CreateContextRequest{
 		Type:          apispec.NewOptProcessType(apispec.ProcessTypeCmd),
 		Cmd:           apispec.NewOptCreateCMDContextRequest(apispec.CreateCMDContextRequest{Command: command}),
@@ -189,7 +191,6 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 		req.TTLSec = apispec.NewOptInt32(execTTL)
 	}
 
-	allocateTTY := execTTY || execInteractive || shouldAutoInteractiveExec(command)
 	if allocateTTY {
 		rows, cols := currentTerminalSize()
 		req.PtySize = apispec.NewOptPTYSize(apispec.PTYSize{
@@ -201,6 +202,9 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 	contextResp, err := client.Sandbox(sandboxID).CreateContext(ctx, req)
 	if err != nil {
 		return err
+	}
+	if contextResp == nil {
+		return fmt.Errorf("create context returned nil response")
 	}
 
 	conn, _, err := client.Sandbox(sandboxID).ConnectWSContext(ctx, contextResp.ID)
@@ -217,15 +221,8 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 	}
 	defer restoreTerminal()
 
-	var writeMu sync.Mutex
-	writeJSON := func(msg execWSMessage) error {
-		writeMu.Lock()
-		defer writeMu.Unlock()
-		return conn.WriteJSON(msg)
-	}
+	writeJSON := func(msg execWSMessage) error { return conn.WriteJSON(msg) }
 	writeControl := func(messageType int, data []byte) error {
-		writeMu.Lock()
-		defer writeMu.Unlock()
 		return conn.WriteControl(messageType, data, time.Now().Add(time.Second))
 	}
 
@@ -238,11 +235,15 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 
 	for {
 		var msg execWSMessage
-		if err := conn.ReadJSON(&msg); err != nil {
+		err := conn.ReadJSON(&msg)
+		if err != nil {
 			if isNormalWSClose(err) || ctx.Err() != nil {
 				return nil
 			}
 			return err
+		}
+		if msg.Type != "" && msg.Type != "output" {
+			continue
 		}
 		switch msg.Source {
 		case "stderr":
@@ -430,6 +431,7 @@ func init() {
 	sandboxExecCmd.Flags().StringArrayVar(&execEnv, "env", nil, "environment variables (KEY=VALUE, can be repeated)")
 	sandboxExecCmd.Flags().BoolVar(&execNoWait, "no-wait", false, "don't wait for command completion")
 	sandboxExecCmd.Flags().Int32Var(&execTTL, "ttl", 0, "context TTL in seconds")
+	sandboxExecCmd.Flags().BoolVar(&execStream, "stream", false, "stream stdout/stderr without allocating a TTY")
 	sandboxExecCmd.Flags().BoolVarP(&execInteractive, "interactive", "i", false, "keep stdin attached and stream exec I/O (implies TTY)")
 	sandboxExecCmd.Flags().BoolVarP(&execTTY, "tty", "t", false, "allocate a TTY and stream exec I/O")
 

--- a/internal/commands/sandbox_exec.go
+++ b/internal/commands/sandbox_exec.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -29,12 +30,23 @@ var (
 )
 
 type execWSMessage struct {
-	Type   string `json:"type,omitempty"`
-	Source string `json:"source,omitempty"`
-	Data   string `json:"data,omitempty"`
-	Rows   int    `json:"rows,omitempty"`
-	Cols   int    `json:"cols,omitempty"`
-	Signal string `json:"signal,omitempty"`
+	Type      string `json:"type,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Data      string `json:"data,omitempty"`
+	Rows      int    `json:"rows,omitempty"`
+	Cols      int    `json:"cols,omitempty"`
+	Signal    string `json:"signal,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
+	ExitCode  *int   `json:"exit_code,omitempty"`
+	State     string `json:"state,omitempty"`
+}
+
+type execExitCodeError struct {
+	code int
+}
+
+func (e *execExitCodeError) Error() string {
+	return fmt.Sprintf("remote command exited with code %d", e.code)
 }
 
 // sandboxExecCmd executes a command in a sandbox.
@@ -77,6 +89,10 @@ Examples:
 
 		if shouldUseStreamingExec(command) {
 			if err := runStreamingExec(cmd.Context(), client, sandboxID, command, envMap); err != nil {
+				var exitErr *execExitCodeError
+				if errors.As(err, &exitErr) {
+					os.Exit(exitErr.code)
+				}
 				fmt.Fprintf(os.Stderr, "Error executing command: %v\n", err)
 				os.Exit(1)
 			}
@@ -242,6 +258,12 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 			}
 			return err
 		}
+		if isTerminalDoneExecMessage(msg) {
+			if msg.ExitCode != nil && *msg.ExitCode != 0 {
+				return &execExitCodeError{code: *msg.ExitCode}
+			}
+			return nil
+		}
 		if msg.Type != "" && msg.Type != "output" {
 			continue
 		}
@@ -256,6 +278,13 @@ func runStreamingExec(ctx context.Context, client *sandbox0.Client, sandboxID st
 			}
 		}
 	}
+}
+
+func isTerminalDoneExecMessage(msg execWSMessage) bool {
+	if msg.Type != "done" {
+		return false
+	}
+	return msg.RequestID == "" || msg.ExitCode != nil || msg.State != ""
 }
 
 func prepareTerminalForStreaming(allocateTTY bool) (func(), error) {

--- a/internal/commands/sandbox_exec_test.go
+++ b/internal/commands/sandbox_exec_test.go
@@ -114,3 +114,15 @@ func TestShouldUseStreamingExec(t *testing.T) {
 		t.Fatal("shouldUseStreamingExec() = true, want false when --no-wait is enabled")
 	}
 }
+
+func TestIsTerminalDoneExecMessage(t *testing.T) {
+	t.Parallel()
+
+	code := 0
+	if isTerminalDoneExecMessage(execWSMessage{Type: "done", RequestID: "req-1"}) {
+		t.Fatal("request-scoped done should not terminate exec stream")
+	}
+	if !isTerminalDoneExecMessage(execWSMessage{Type: "done", ExitCode: &code, State: "stopped"}) {
+		t.Fatal("process done should terminate exec stream")
+	}
+}

--- a/internal/commands/sandbox_exec_test.go
+++ b/internal/commands/sandbox_exec_test.go
@@ -86,3 +86,31 @@ func TestIsInteractiveCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldUseStreamingExec(t *testing.T) {
+	t.Parallel()
+
+	prevNoWait := execNoWait
+	prevStream := execStream
+	prevInteractive := execInteractive
+	prevTTY := execTTY
+	t.Cleanup(func() {
+		execNoWait = prevNoWait
+		execStream = prevStream
+		execInteractive = prevInteractive
+		execTTY = prevTTY
+	})
+
+	execNoWait = false
+	execStream = true
+	execInteractive = false
+	execTTY = false
+	if !shouldUseStreamingExec([]string{"python", "-c", "print(1)"}) {
+		t.Fatal("shouldUseStreamingExec() = false, want true when --stream is enabled")
+	}
+
+	execNoWait = true
+	if shouldUseStreamingExec([]string{"python", "-c", "print(1)"}) {
+		t.Fatal("shouldUseStreamingExec() = true, want false when --no-wait is enabled")
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit `--stream` support for non-PTY `s0 sandbox exec`
- keep interactive and TTY exec on the existing streaming path
- document the new CLI flow and add focused command tests

Refs sandbox0-ai/sandbox0#154

## Testing
- go test ./...