### PR TITLE
Fix stale team selection after login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.6
+	github.com/sandbox0-ai/sdk-go v0.2.7
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.6 h1:eZul3PPz1WcY4KAWFXt08whz0Pm2G0MbEG88XSr1lnU=
-github.com/sandbox0-ai/sdk-go v0.2.6/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.7 h1:bfnQUyTFfthmAHCQPNQit7sjUtxFvkiF3yAeN4f0Af8=
+github.com/sandbox0-ai/sdk-go v0.2.7/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -338,12 +338,10 @@ func maybeAutoSelectCurrentTeam(ctx context.Context, cfg *config.Config, profile
 	if err != nil {
 		return nil, false, err
 	}
-	if strings.TrimSpace(profile.GetCurrentTeamID()) != "" {
-		return nil, false, nil
-	}
 	if strings.TrimSpace(profile.GetToken()) == "" {
 		return nil, false, nil
 	}
+	currentTeamID := strings.TrimSpace(profile.GetCurrentTeamID())
 
 	client, err := newSDKClientForBaseURL(profile.GetAPIURL(), profile.GetToken())
 	if err != nil {
@@ -362,7 +360,17 @@ func maybeAutoSelectCurrentTeam(ctx context.Context, cfg *config.Config, profile
 	if !ok {
 		return nil, false, fmt.Errorf("list teams: missing response data")
 	}
+
+	for _, team := range data.Teams {
+		if strings.TrimSpace(team.ID) == currentTeamID && currentTeamID != "" {
+			return nil, false, nil
+		}
+	}
+
 	if len(data.Teams) != 1 {
+		if currentTeamID != "" {
+			cfg.ClearCurrentTeam(profileName)
+		}
 		return nil, false, nil
 	}
 

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -133,6 +133,122 @@ func TestMaybeAutoSelectCurrentTeamDoesNotSelectWhenMultipleTeamsExist(t *testin
 	}
 }
 
+func TestMaybeAutoSelectCurrentTeamReplacesStaleTeamWhenOnlyOneTeamExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/teams":
+			writeAuthJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"teams": []map[string]any{{
+						"id":         "team-2",
+						"name":       "New Team",
+						"slug":       "new-team",
+						"created_at": "2026-01-01T00:00:00Z",
+						"updated_at": "2026-01-01T00:00:00Z",
+					}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		CurrentProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				APIURL:        server.URL,
+				Token:         "user-token",
+				CurrentTeamID: "team-1",
+			},
+		},
+	}
+
+	team, ok, err := maybeAutoSelectCurrentTeam(context.Background(), cfg, "default")
+	if err != nil {
+		t.Fatalf("maybeAutoSelectCurrentTeam() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("maybeAutoSelectCurrentTeam() did not replace stale team")
+	}
+	if team == nil || team.ID != "team-2" {
+		t.Fatalf("team = %+v, want team-2", team)
+	}
+
+	profile, err := cfg.GetProfile("default")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if got := profile.GetCurrentTeamID(); got != "team-2" {
+		t.Fatalf("CurrentTeamID = %q, want team-2", got)
+	}
+}
+
+func TestMaybeAutoSelectCurrentTeamClearsStaleTeamWhenMultipleTeamsExist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/teams":
+			writeAuthJSON(t, w, http.StatusOK, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"teams": []map[string]any{
+						{
+							"id":         "team-2",
+							"name":       "Two",
+							"slug":       "two",
+							"created_at": "2026-01-01T00:00:00Z",
+							"updated_at": "2026-01-01T00:00:00Z",
+						},
+						{
+							"id":         "team-3",
+							"name":       "Three",
+							"slug":       "three",
+							"created_at": "2026-01-01T00:00:00Z",
+							"updated_at": "2026-01-01T00:00:00Z",
+						},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		CurrentProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				APIURL:              server.URL,
+				Token:               "user-token",
+				CurrentTeamID:       "team-1",
+				CurrentTeamRegionID: "aws-us-east-1",
+			},
+		},
+	}
+
+	team, ok, err := maybeAutoSelectCurrentTeam(context.Background(), cfg, "default")
+	if err != nil {
+		t.Fatalf("maybeAutoSelectCurrentTeam() error = %v", err)
+	}
+	if ok || team != nil {
+		t.Fatalf("maybeAutoSelectCurrentTeam() = (%+v, %v), want no auto-selection", team, ok)
+	}
+
+	profile, err := cfg.GetProfile("default")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if got := profile.GetCurrentTeamID(); got != "" {
+		t.Fatalf("CurrentTeamID = %q, want empty", got)
+	}
+	if _, ok := profile.GetCurrentTeamTarget(); ok {
+		t.Fatal("CurrentTeamTarget should be cleared when current team is stale")
+	}
+}
+
 func writeAuthJSON(t *testing.T, w http.ResponseWriter, status int, payload any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -145,7 +145,7 @@ var sandboxPauseCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("Sandbox %s paused successfully\n", sandboxID)
+		fmt.Printf("Pause requested for sandbox %s\n", sandboxID)
 	},
 }
 
@@ -170,7 +170,7 @@ var sandboxResumeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("Sandbox %s resumed successfully\n", sandboxID)
+		fmt.Printf("Resume requested for sandbox %s\n", sandboxID)
 	},
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,21 @@ func (c *Config) SetCurrentTeam(profileName, teamID, regionID, gatewayURL string
 	c.Profiles[profileName] = p
 }
 
+// ClearCurrentTeam removes the locally selected current team and cached region target.
+func (c *Config) ClearCurrentTeam(profileName string) {
+	if c.Profiles == nil {
+		return
+	}
+	p, ok := c.Profiles[profileName]
+	if !ok {
+		return
+	}
+	p.CurrentTeamID = ""
+	p.CurrentTeamRegionID = ""
+	p.CurrentTeamGatewayURL = ""
+	c.Profiles[profileName] = p
+}
+
 // SetGatewayMode updates the configured gateway mode for a profile.
 func (c *Config) SetGatewayMode(profileName string, mode GatewayMode) {
 	if c.Profiles == nil {


### PR DESCRIPTION
## Summary
- refresh stale current team selection after login so workload commands do not keep using an invalid team
- clear the local team target when the previous selection is no longer valid and multiple teams now exist
- update sandbox pause/resume CLI output to match async power-state semantics

## Testing
- go test ./internal/commands ./internal/config -count=1
- remote kind smoke: `s0 sandbox list`, `create`, `get`, `pause`, `resume`, `delete`
- remote kind smoke after rebuilding `sdk-js` dist confirmed `powerState` is populated as expected