### PR TITLE
Show sandbox SSH connection info

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ s0 sandbox list [--status <status>] [--template-id <id>] [--paused true|false] [
 
 `s0 sandbox get <sandbox-id>` prints the SSH connection fields returned by sandbox detail when they are available, including `SSH Host`, `SSH Port`, and `SSH Username`.
 
+Manage the current user's SSH public keys with:
+
+```bash
+s0 user ssh-key list
+s0 user ssh-key add --public-key-file ~/.ssh/id_ed25519.pub
+s0 user ssh-key delete <ssh-key-id>
+```
+
 Bootstrap mounts can be requested as part of sandbox creation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ s0 sandbox status <sandbox-id>
 s0 sandbox list [--status <status>] [--template-id <id>] [--paused true|false] [--limit 50] [--offset 0]
 ```
 
+`s0 sandbox get <sandbox-id>` prints the SSH connection fields returned by sandbox detail when they are available, including `SSH Host`, `SSH Port`, and `SSH Username`.
+
 Bootstrap mounts can be requested as part of sandbox creation:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.8-0.20260409164027-221be11eb151
+	github.com/sandbox0-ai/sdk-go v0.2.9-0.20260409165024-34b47e3fc815
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.9-0.20260409165024-34b47e3fc815
+	github.com/sandbox0-ai/sdk-go v0.2.9
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.7
+	github.com/sandbox0-ai/sdk-go v0.2.8-0.20260409164027-221be11eb151
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.8-0.20260409164027-221be11eb151 h1:E8z1sbjmLrBqI8QaQTpK9r/bhItJiGcSeCU7OucKjA8=
-github.com/sandbox0-ai/sdk-go v0.2.8-0.20260409164027-221be11eb151/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.9-0.20260409165024-34b47e3fc815 h1:O3znmccQ/mJr1aP+GEf4Pwexrxv6eABeZnMxpgxmNvk=
+github.com/sandbox0-ai/sdk-go v0.2.9-0.20260409165024-34b47e3fc815/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.7 h1:bfnQUyTFfthmAHCQPNQit7sjUtxFvkiF3yAeN4f0Af8=
-github.com/sandbox0-ai/sdk-go v0.2.7/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.8-0.20260409164027-221be11eb151 h1:E8z1sbjmLrBqI8QaQTpK9r/bhItJiGcSeCU7OucKjA8=
+github.com/sandbox0-ai/sdk-go v0.2.8-0.20260409164027-221be11eb151/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.9-0.20260409165024-34b47e3fc815 h1:O3znmccQ/mJr1aP+GEf4Pwexrxv6eABeZnMxpgxmNvk=
-github.com/sandbox0-ai/sdk-go v0.2.9-0.20260409165024-34b47e3fc815/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.9 h1:llZUDGjNQpgZDA5fE1usnVhAAp38qm3CMkpbPOxLo5U=
+github.com/sandbox0-ai/sdk-go v0.2.9/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
@@ -12,6 +13,9 @@ import (
 var (
 	userName      string
 	userAvatarURL string
+	sshKeyName    string
+	sshPublicKey  string
+	sshKeyFile    string
 )
 
 var userCmd = &cobra.Command{
@@ -111,12 +115,139 @@ var userUpdateCmd = &cobra.Command{
 	},
 }
 
+var userSSHKeyCmd = &cobra.Command{
+	Use:   "ssh-key",
+	Short: "Manage SSH public keys",
+	Long:  `List, add, and delete SSH public keys for the current user.`,
+}
+
+var userSSHKeyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List SSH public keys",
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		keys, err := client.ListUserSSHPublicKeys(cmd.Context())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing SSH public keys: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, keys); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var userSSHKeyAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add an SSH public key",
+	Run: func(cmd *cobra.Command, args []string) {
+		req, err := buildCreateSSHPublicKeyRequest()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		key, err := client.CreateUserSSHPublicKey(cmd.Context(), *req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error adding SSH public key: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, key); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var userSSHKeyDeleteCmd = &cobra.Command{
+	Use:   "delete <ssh-key-id>",
+	Short: "Delete an SSH public key",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		resp, err := client.DeleteUserSSHPublicKey(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting SSH public key: %v\n", err)
+			os.Exit(1)
+		}
+
+		if data, ok := resp.Data.Get(); ok {
+			if message, ok := data.Message.Get(); ok && strings.TrimSpace(message) != "" {
+				fmt.Println(message)
+				return
+			}
+		}
+		fmt.Printf("SSH public key %s deleted successfully\n", args[0])
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(userCmd)
 
 	userCmd.AddCommand(userGetCmd)
 	userCmd.AddCommand(userUpdateCmd)
+	userCmd.AddCommand(userSSHKeyCmd)
+	userSSHKeyCmd.AddCommand(userSSHKeyListCmd)
+	userSSHKeyCmd.AddCommand(userSSHKeyAddCmd)
+	userSSHKeyCmd.AddCommand(userSSHKeyDeleteCmd)
 
 	userUpdateCmd.Flags().StringVar(&userName, "name", "", "new display name")
 	userUpdateCmd.Flags().StringVar(&userAvatarURL, "avatar-url", "", "new avatar URL")
+	userSSHKeyAddCmd.Flags().StringVar(&sshKeyName, "name", "", "SSH key name (defaults to the public key file name)")
+	userSSHKeyAddCmd.Flags().StringVar(&sshPublicKey, "public-key", "", "SSH public key content")
+	userSSHKeyAddCmd.Flags().StringVar(&sshKeyFile, "public-key-file", "", "path to an SSH public key file")
+}
+
+func buildCreateSSHPublicKeyRequest() (*apispec.CreateSSHPublicKeyRequest, error) {
+	inlineKey := strings.TrimSpace(sshPublicKey)
+	keyFile := strings.TrimSpace(sshKeyFile)
+	switch {
+	case inlineKey == "" && keyFile == "":
+		return nil, fmt.Errorf("either --public-key or --public-key-file is required")
+	case inlineKey != "" && keyFile != "":
+		return nil, fmt.Errorf("use only one of --public-key or --public-key-file")
+	}
+
+	keyName := strings.TrimSpace(sshKeyName)
+	if keyFile != "" {
+		data, err := os.ReadFile(keyFile)
+		if err != nil {
+			return nil, err
+		}
+		inlineKey = strings.TrimSpace(string(data))
+		if keyName == "" {
+			keyName = strings.TrimSuffix(filepath.Base(keyFile), filepath.Ext(keyFile))
+		}
+	}
+
+	if inlineKey == "" {
+		return nil, fmt.Errorf("SSH public key content is empty")
+	}
+	if keyName == "" {
+		return nil, fmt.Errorf("--name is required when using --public-key")
+	}
+
+	return &apispec.CreateSSHPublicKeyRequest{
+		Name:      keyName,
+		PublicKey: inlineKey,
+	}, nil
 }

--- a/internal/commands/user_ssh_key_test.go
+++ b/internal/commands/user_ssh_key_test.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildCreateSSHPublicKeyRequest(t *testing.T) {
+	reset := func() {
+		sshKeyName = ""
+		sshPublicKey = ""
+		sshKeyFile = ""
+	}
+	t.Cleanup(reset)
+
+	t.Run("inline key requires name", func(t *testing.T) {
+		reset()
+		sshPublicKey = "ssh-ed25519 AAAA test@example"
+
+		_, err := buildCreateSSHPublicKeyRequest()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("inline key with name", func(t *testing.T) {
+		reset()
+		sshKeyName = "macbook"
+		sshPublicKey = "ssh-ed25519 AAAA test@example"
+
+		req, err := buildCreateSSHPublicKeyRequest()
+		if err != nil {
+			t.Fatalf("buildCreateSSHPublicKeyRequest() error = %v", err)
+		}
+		if req.Name != "macbook" {
+			t.Fatalf("name = %q, want macbook", req.Name)
+		}
+	})
+
+	t.Run("file derives name", func(t *testing.T) {
+		reset()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "id_ed25519.pub")
+		if err := os.WriteFile(path, []byte("ssh-ed25519 AAAA file@example\n"), 0o644); err != nil {
+			t.Fatalf("write public key: %v", err)
+		}
+		sshKeyFile = path
+
+		req, err := buildCreateSSHPublicKeyRequest()
+		if err != nil {
+			t.Fatalf("buildCreateSSHPublicKeyRequest() error = %v", err)
+		}
+		if req.Name != "id_ed25519" {
+			t.Fatalf("name = %q, want id_ed25519", req.Name)
+		}
+		if req.PublicKey != "ssh-ed25519 AAAA file@example" {
+			t.Fatalf("public key = %q", req.PublicKey)
+		}
+	})
+
+	t.Run("rejects both inline and file", func(t *testing.T) {
+		reset()
+		sshKeyName = "macbook"
+		sshPublicKey = "ssh-ed25519 AAAA inline@example"
+		sshKeyFile = "/tmp/id_ed25519.pub"
+
+		_, err := buildCreateSSHPublicKeyRequest()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -107,6 +107,12 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatUser(w, &v)
 	case *apispec.User:
 		return f.formatUser(w, v)
+	case []apispec.SSHPublicKey:
+		return f.formatSSHPublicKeyList(w, v)
+	case apispec.SSHPublicKey:
+		return f.formatSSHPublicKey(w, &v)
+	case *apispec.SSHPublicKey:
+		return f.formatSSHPublicKey(w, v)
 	case []syncstate.Attachment:
 		return f.formatSyncAttachments(w, v)
 	case *syncstate.Attachment:
@@ -497,6 +503,39 @@ func (f *TableFormatter) formatSandbox(w io.Writer, s *apispec.Sandbox) error {
 		_ = t.Append([]string{"SSH Port:", intOrDash(ssh.Port)})
 		_ = t.Append([]string{"SSH Username:", valueOrDash(ssh.Username)})
 	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSSHPublicKeyList(w io.Writer, keys []apispec.SSHPublicKey) error {
+	if len(keys) == 0 {
+		_, _ = fmt.Fprintln(w, "No SSH public keys found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"ID", "NAME", "KEY TYPE", "FINGERPRINT", "CREATED AT"})
+	for _, key := range keys {
+		_ = t.Append([]string{
+			key.ID,
+			key.Name,
+			key.KeyType,
+			key.FingerprintSHA256,
+			key.CreatedAt.Format(timeLayout),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSSHPublicKey(w io.Writer, key *apispec.SSHPublicKey) error {
+	t := newTable(w)
+	_ = t.Append([]string{"ID:", key.ID})
+	_ = t.Append([]string{"Name:", key.Name})
+	_ = t.Append([]string{"Key Type:", key.KeyType})
+	_ = t.Append([]string{"Fingerprint:", key.FingerprintSHA256})
+	_ = t.Append([]string{"Comment:", formatOptString(key.Comment)})
+	_ = t.Append([]string{"Public Key:", key.PublicKey})
+	_ = t.Append([]string{"Created At:", key.CreatedAt.Format(timeLayout)})
+	_ = t.Append([]string{"Updated At:", key.UpdatedAt.Format(timeLayout)})
 	return t.Render()
 }
 

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -492,6 +492,11 @@ func (f *TableFormatter) formatSandbox(w io.Writer, s *apispec.Sandbox) error {
 	_ = t.Append([]string{"Claimed At:", s.ClaimedAt.Format(timeLayout)})
 	_ = t.Append([]string{"Soft Expires At:", formatTimestamp(s.ExpiresAt)})
 	_ = t.Append([]string{"Hard Expires At:", formatTimestamp(s.HardExpiresAt)})
+	if ssh, ok := s.SSH.Get(); ok {
+		_ = t.Append([]string{"SSH Host:", valueOrDash(ssh.Host)})
+		_ = t.Append([]string{"SSH Port:", intOrDash(ssh.Port)})
+		_ = t.Append([]string{"SSH Username:", valueOrDash(ssh.Username)})
+	}
 	return t.Render()
 }
 

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -161,6 +161,47 @@ func TestTableFormatterFormatRegion(t *testing.T) {
 	}
 }
 
+func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
+	formatter := &TableFormatter{}
+	sandbox := &apispec.Sandbox{
+		ID:         "sb_123",
+		TemplateID: "default",
+		TeamID:     "team_123",
+		Status:     "running",
+		Paused:     false,
+		PowerState: apispec.SandboxPowerState{},
+		AutoResume: true,
+		PodName:    "sb-123-pod",
+		SSH: apispec.NewOptSandboxSSHConnection(apispec.SandboxSSHConnection{
+			Host:     "ssh.aws-us-east-1.sandbox0.app",
+			Port:     30222,
+			Username: "sb_123",
+		}),
+		ClaimedAt:     time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		ExpiresAt:     time.Date(2026, 4, 10, 13, 0, 0, 0, time.UTC),
+		HardExpiresAt: time.Date(2026, 4, 10, 14, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, sandbox); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"SSH Host:",
+		"ssh.aws-us-east-1.sandbox0.app",
+		"SSH Port:",
+		"30222",
+		"SSH Username:",
+		"sb_123",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestTableFormatterFormatSyncStatusView(t *testing.T) {
 	formatter := &TableFormatter{}
 	view := &syncview.StatusView{

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -202,6 +202,74 @@ func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 	}
 }
 
+func TestTableFormatterFormatSSHPublicKeyList(t *testing.T) {
+	formatter := &TableFormatter{}
+	keys := []apispec.SSHPublicKey{
+		{
+			ID:                "key_123",
+			Name:              "macbook",
+			PublicKey:         "ssh-ed25519 AAAA test@example",
+			KeyType:           "ssh-ed25519",
+			FingerprintSHA256: "SHA256:abc",
+			CreatedAt:         time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:         time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, keys); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ID",
+		"NAME",
+		"KEY TYPE",
+		"FINGERPRINT",
+		"macbook",
+		"ssh-ed25519",
+		"SHA256:abc",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatSSHPublicKey(t *testing.T) {
+	formatter := &TableFormatter{}
+	key := &apispec.SSHPublicKey{
+		ID:                "key_123",
+		Name:              "macbook",
+		PublicKey:         "ssh-ed25519 AAAA test@example",
+		KeyType:           "ssh-ed25519",
+		FingerprintSHA256: "SHA256:abc",
+		Comment:           apispec.NewOptString("test@example"),
+		CreatedAt:         time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:         time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, key); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Name:",
+		"macbook",
+		"Fingerprint:",
+		"SHA256:abc",
+		"Public Key:",
+		"ssh-ed25519 AAAA test@example",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestTableFormatterFormatSyncStatusView(t *testing.T) {
 	formatter := &TableFormatter{}
 	view := &syncview.StatusView{


### PR DESCRIPTION
## Summary
- show `SSH Host`, `SSH Port`, and `SSH Username` in `s0 sandbox get` table output when sandbox detail provides them
- add `s0 user ssh-key list|add|delete` so users can manage SSH public keys without calling the API directly
- update the README and bump `sdk-go` to the branch commit that includes both sandbox SSH detail fields and SSH key helpers

Depends on sandbox0-ai/sdk-go#16.

## Testing
- go test ./internal/output ./internal/commands