### PR TITLE
Route SSH key commands to home region

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -165,7 +165,7 @@ func buildUserAgent() string {
 func commandRouteScope(cmd *cobra.Command) client.RouteScope {
 	for current := cmd; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "sandbox", "template", "volume", "sync", "credential", "apikey", "image":
+		case "sandbox", "template", "volume", "sync", "credential", "apikey", "image", "ssh-key":
 			return client.RouteScopeHomeRegion
 		case "auth", "team", "user":
 			return client.RouteScopeEntrypoint

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/s0/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func TestCommandRouteScopeRoutesUserSSHKeysToHomeRegion(t *testing.T) {
+	user := &cobra.Command{Use: "user"}
+	sshKey := &cobra.Command{Use: "ssh-key"}
+	add := &cobra.Command{Use: "add"}
+	user.AddCommand(sshKey)
+	sshKey.AddCommand(add)
+
+	if got := commandRouteScope(add); got != client.RouteScopeHomeRegion {
+		t.Fatalf("commandRouteScope(user ssh-key add) = %q, want %q", got, client.RouteScopeHomeRegion)
+	}
+}
+
+func TestCommandRouteScopeKeepsUserProfileOnEntrypoint(t *testing.T) {
+	user := &cobra.Command{Use: "user"}
+	get := &cobra.Command{Use: "get"}
+	user.AddCommand(get)
+
+	if got := commandRouteScope(get); got != client.RouteScopeEntrypoint {
+		t.Fatalf("commandRouteScope(user get) = %q, want %q", got, client.RouteScopeEntrypoint)
+	}
+}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -173,7 +173,7 @@ func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 		AutoResume: true,
 		PodName:    "sb-123-pod",
 		SSH: apispec.NewOptSandboxSSHConnection(apispec.SandboxSSHConnection{
-			Host:     "ssh.aws-us-east-1.sandbox0.app",
+			Host:     "aws-us-east-1.ssh.sandbox0.app",
 			Port:     30222,
 			Username: "sb_123",
 		}),
@@ -190,7 +190,7 @@ func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 	output := buf.String()
 	for _, want := range []string{
 		"SSH Host:",
-		"ssh.aws-us-east-1.sandbox0.app",
+		"aws-us-east-1.ssh.sandbox0.app",
 		"SSH Port:",
 		"30222",
 		"SSH Username:",


### PR DESCRIPTION
## Summary
- route `s0 user ssh-key ...` commands to the home region instead of the global entrypoint
- keep user profile commands on the global entrypoint
- update command routing and SSH host output tests

## Testing
- go test ./... -count=1