### PR TITLE
Remove API key type flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.11-0.20260412200155-3e00e6fba30a
+	github.com/sandbox0-ai/sdk-go v0.2.11
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.10
+	github.com/sandbox0-ai/sdk-go v0.2.11-0.20260412200155-3e00e6fba30a
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.11-0.20260412200155-3e00e6fba30a h1:zOJ6kgoDul2Whp6bGghtBO7hXmnnAE5tS2a6ze6dd2Q=
-github.com/sandbox0-ai/sdk-go v0.2.11-0.20260412200155-3e00e6fba30a/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.11 h1:koboYSyGOaMkjzs232lRw/qqES23s4WjQNlGK7sJmbs=
+github.com/sandbox0-ai/sdk-go v0.2.11/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.10 h1:fv8tgnsOI5AIKHzoD3f2AR4p3GBJO67lRiOPSa3uUYk=
-github.com/sandbox0-ai/sdk-go v0.2.10/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.11-0.20260412200155-3e00e6fba30a h1:zOJ6kgoDul2Whp6bGghtBO7hXmnnAE5tS2a6ze6dd2Q=
+github.com/sandbox0-ai/sdk-go v0.2.11-0.20260412200155-3e00e6fba30a/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/apikey.go
+++ b/internal/commands/apikey.go
@@ -13,7 +13,6 @@ import (
 
 var (
 	apiKeyName      string
-	apiKeyType      string
 	apiKeyRoles     []string
 	apiKeyExpiresIn string
 	apiKeyRaw       bool
@@ -64,7 +63,7 @@ var apiKeyListCmd = &cobra.Command{
 var apiKeyCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create an API key",
-	Long:  `Create a new API key for user or service access.`,
+	Long:  `Create a new API key for machine access.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if strings.TrimSpace(apiKeyName) == "" {
 			fmt.Fprintln(os.Stderr, "Error: --name is required")
@@ -72,12 +71,6 @@ var apiKeyCreateCmd = &cobra.Command{
 		}
 		if len(apiKeyRoles) == 0 {
 			fmt.Fprintln(os.Stderr, "Error: at least one --role is required")
-			os.Exit(1)
-		}
-
-		keyType, err := parseAPIKeyType(apiKeyType)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -89,7 +82,6 @@ var apiKeyCreateCmd = &cobra.Command{
 
 		req := &apispec.CreateAPIKeyRequest{
 			Name:  apiKeyName,
-			Type:  keyType,
 			Roles: apiKeyRoles,
 		}
 		if strings.TrimSpace(apiKeyExpiresIn) != "" {
@@ -204,17 +196,6 @@ var apiKeyDeleteCmd = &cobra.Command{
 	},
 }
 
-func parseAPIKeyType(s string) (apispec.CreateAPIKeyRequestType, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", string(apispec.CreateAPIKeyRequestTypeUser):
-		return apispec.CreateAPIKeyRequestTypeUser, nil
-	case string(apispec.CreateAPIKeyRequestTypeService):
-		return apispec.CreateAPIKeyRequestTypeService, nil
-	default:
-		return "", fmt.Errorf("invalid --type %q, must be one of: user, service", s)
-	}
-}
-
 func printCreatedAPIKeyRaw(w io.Writer, data *apispec.CreateAPIKeyResponse) error {
 	if data == nil {
 		return fmt.Errorf("missing API key data")
@@ -236,7 +217,6 @@ func init() {
 	apiKeyCmd.AddCommand(apiKeyDeleteCmd)
 
 	apiKeyCreateCmd.Flags().StringVar(&apiKeyName, "name", "", "API key name (required)")
-	apiKeyCreateCmd.Flags().StringVar(&apiKeyType, "type", "user", "API key type (user or service)")
 	apiKeyCreateCmd.Flags().StringArrayVar(&apiKeyRoles, "role", nil, "role to grant (admin, developer, viewer; can be repeated, required)")
 	apiKeyCreateCmd.Flags().StringVar(&apiKeyExpiresIn, "expires-in", "", "key expiry (30d, 90d, 180d, 365d, or never)")
 	apiKeyCreateCmd.Flags().BoolVar(&apiKeyRaw, "raw", false, "print only the API key value (for scripts/pipes)")

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -1012,12 +1012,11 @@ func (f *TableFormatter) formatAPIKeyList(w io.Writer, keys []apispec.APIKey) er
 	}
 
 	t := newTable(w)
-	t.Header([]string{"ID", "NAME", "TYPE", "TEAM ID", "USER ID", "ROLES", "ACTIVE", "EXPIRES AT", "LAST USED"})
+	t.Header([]string{"ID", "NAME", "TEAM ID", "USER ID", "ROLES", "ACTIVE", "EXPIRES AT", "LAST USED"})
 	for _, k := range keys {
 		_ = t.Append([]string{
 			k.ID,
 			k.Name,
-			k.Type,
 			k.TeamID,
 			formatOptNilString(k.UserID),
 			formatStringSlice(k.Roles),
@@ -1033,7 +1032,6 @@ func (f *TableFormatter) formatCreatedAPIKey(w io.Writer, k *apispec.CreateAPIKe
 	t := newTable(w)
 	_ = t.Append([]string{"ID:", k.ID})
 	_ = t.Append([]string{"Name:", k.Name})
-	_ = t.Append([]string{"Type:", k.Type})
 	_ = t.Append([]string{"Team ID:", k.TeamID})
 	_ = t.Append([]string{"Roles:", formatStringSlice(k.Roles)})
 	_ = t.Append([]string{"Expires At:", formatTimestamp(k.ExpiresAt)})


### PR DESCRIPTION
## Summary
- Remove the `s0 apikey create --type` flag.
- Treat API keys as machine access credentials in CLI copy and request construction.
- Remove the API key type column from table output.
- Bump `github.com/sandbox0-ai/sdk-go` to the branch pseudo-version from sandbox0-ai/sdk-go#19.

Refs sandbox0-ai/sandbox0#179
Refs sandbox0-ai/sdk-go#19

## Testing
- `go test ./... -count=1`
- `go run ./cmd/s0 apikey create --help`