### PR TITLE
Refresh team grants after team create/use

### DIFF
--- a/internal/commands/apikey.go
+++ b/internal/commands/apikey.go
@@ -37,7 +37,7 @@ var apiKeyListCmd = &cobra.Command{
 
 		res, err := client.API().APIKeysGet(cmd.Context())
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error listing API keys: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error listing API keys: %v\n", withSelectedTeamAuthHint(err))
 			os.Exit(1)
 		}
 
@@ -90,7 +90,7 @@ var apiKeyCreateCmd = &cobra.Command{
 
 		res, err := client.API().APIKeysPost(cmd.Context(), req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating API key: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error creating API key: %v\n", withSelectedTeamAuthHint(err))
 			os.Exit(1)
 		}
 
@@ -140,7 +140,7 @@ var apiKeyDeactivateCmd = &cobra.Command{
 			ID: args[0],
 		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deactivating API key: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error deactivating API key: %v\n", withSelectedTeamAuthHint(err))
 			os.Exit(1)
 		}
 
@@ -176,7 +176,7 @@ var apiKeyDeleteCmd = &cobra.Command{
 			ID: args[0],
 		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting API key: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error deleting API key: %v\n", withSelectedTeamAuthHint(err))
 			os.Exit(1)
 		}
 

--- a/internal/commands/auth_helpers.go
+++ b/internal/commands/auth_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/s0/internal/config"
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
@@ -47,6 +49,8 @@ const (
 	authLoginModeAuto    authLoginMode = "auto"
 	authLoginModeDevice  authLoginMode = "device"
 	authLoginModeBuiltin authLoginMode = "builtin"
+
+	staleSelectedTeamGrantHint = "token stale, run `s0 auth login` or refresh token, then run `s0 team use <team-id>` and retry"
 )
 
 func authRequest(ctx context.Context, method, endpoint, token string, requestBody any, responseData any) error {
@@ -189,6 +193,72 @@ func refreshAccessToken(ctx context.Context, baseURL, refreshToken string) (*aut
 		return nil, err
 	}
 	return &data, nil
+}
+
+func refreshProfileTeamGrants(ctx context.Context, cfg *config.Config, profileName string) (bool, error) {
+	if cfg == nil {
+		return false, nil
+	}
+	profile, err := cfg.GetProfile(profileName)
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(*config.GetTokenVar()) != "" || strings.TrimSpace(os.Getenv(config.EnvToken)) != "" {
+		return false, nil
+	}
+	refreshToken := strings.TrimSpace(profile.GetRefreshToken())
+	if refreshToken == "" {
+		return false, nil
+	}
+
+	refreshed, err := refreshAccessToken(ctx, profile.GetAPIURL(), refreshToken)
+	if err != nil {
+		return false, err
+	}
+	cfg.SetCredentials(
+		profileName,
+		profile.GetAPIURL(),
+		refreshed.AccessToken,
+		refreshed.RefreshToken,
+		refreshed.ExpiresAt,
+	)
+	return true, nil
+}
+
+func printTeamGrantRefreshWarning(action string, refreshed bool, err error) {
+	if err == nil && refreshed {
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not refresh access token team grants after %s: %v\n", action, err)
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: access token team grants were not refreshed after %s.\n", action)
+	}
+	fmt.Fprintf(os.Stderr, "Hint: %s.\n", staleSelectedTeamGrantHint)
+}
+
+func withSelectedTeamAuthHint(err error) error {
+	if err == nil || !isSelectedTeamAuthError(err) {
+		return err
+	}
+	return fmt.Errorf("%w\nHint: %s", err, staleSelectedTeamGrantHint)
+}
+
+func isSelectedTeamAuthError(err error) bool {
+	var apiErr *sandbox0.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode != http.StatusUnauthorized {
+			return false
+		}
+		return containsSelectedTeamAuthMessage(apiErr.Message) ||
+			containsSelectedTeamAuthMessage(string(apiErr.Body)) ||
+			containsSelectedTeamAuthMessage(err.Error())
+	}
+	return containsSelectedTeamAuthMessage(err.Error())
+}
+
+func containsSelectedTeamAuthMessage(value string) bool {
+	return strings.Contains(strings.ToLower(value), "not a member of selected team")
 }
 
 func logoutToken(ctx context.Context, baseURL, accessToken string) error {

--- a/internal/commands/auth_helpers_test.go
+++ b/internal/commands/auth_helpers_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/sandbox0-ai/s0/internal/config"
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 )
 
 func TestShouldShowCurrentTeamSelectionHint(t *testing.T) {
@@ -246,6 +248,120 @@ func TestMaybeAutoSelectCurrentTeamClearsStaleTeamWhenMultipleTeamsExist(t *test
 	}
 	if _, ok := profile.GetCurrentTeamTarget(); ok {
 		t.Fatal("CurrentTeamTarget should be cleared when current team is stale")
+	}
+}
+
+func TestRefreshProfileTeamGrantsRefreshesToken(t *testing.T) {
+	oldToken := *config.GetTokenVar()
+	*config.GetTokenVar() = ""
+	t.Cleanup(func() { *config.GetTokenVar() = oldToken })
+	t.Setenv(config.EnvToken, "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/refresh" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		writeAuthJSON(t, w, http.StatusOK, map[string]any{
+			"success": true,
+			"data": map[string]any{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"expires_at":    int64(1893456000),
+			},
+		})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		CurrentProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				APIURL:       server.URL,
+				Token:        "old-access-token",
+				RefreshToken: "old-refresh-token",
+				ExpiresAt:    100,
+			},
+		},
+	}
+
+	refreshed, err := refreshProfileTeamGrants(context.Background(), cfg, "default")
+	if err != nil {
+		t.Fatalf("refreshProfileTeamGrants() error = %v", err)
+	}
+	if !refreshed {
+		t.Fatal("refreshProfileTeamGrants() did not refresh")
+	}
+	profile, err := cfg.GetProfile("default")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if profile.Token != "new-access-token" {
+		t.Fatalf("Token = %q, want new-access-token", profile.Token)
+	}
+	if profile.RefreshToken != "new-refresh-token" {
+		t.Fatalf("RefreshToken = %q, want new-refresh-token", profile.RefreshToken)
+	}
+	if profile.ExpiresAt != 1893456000 {
+		t.Fatalf("ExpiresAt = %d, want 1893456000", profile.ExpiresAt)
+	}
+}
+
+func TestRefreshProfileTeamGrantsSkipsWithoutRefreshToken(t *testing.T) {
+	oldToken := *config.GetTokenVar()
+	*config.GetTokenVar() = ""
+	t.Cleanup(func() { *config.GetTokenVar() = oldToken })
+	t.Setenv(config.EnvToken, "")
+
+	cfg := &config.Config{
+		CurrentProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				APIURL: "https://api.example.test",
+				Token:  "access-token",
+			},
+		},
+	}
+
+	refreshed, err := refreshProfileTeamGrants(context.Background(), cfg, "default")
+	if err != nil {
+		t.Fatalf("refreshProfileTeamGrants() error = %v", err)
+	}
+	if refreshed {
+		t.Fatal("refreshProfileTeamGrants() refreshed without a refresh token")
+	}
+}
+
+func TestWithSelectedTeamAuthHintAddsTokenStaleHint(t *testing.T) {
+	err := withSelectedTeamAuthHint(&sandbox0.APIError{
+		StatusCode: http.StatusUnauthorized,
+		Message:    "not a member of selected team",
+	})
+	if err == nil {
+		t.Fatal("withSelectedTeamAuthHint() returned nil")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "not a member of selected team") {
+		t.Fatalf("error = %q, want original message", got)
+	}
+	if !strings.Contains(got, "token stale, run `s0 auth login` or refresh token") {
+		t.Fatalf("error = %q, want stale token hint", got)
+	}
+}
+
+func TestWithSelectedTeamAuthHintHandlesCompactJSONError(t *testing.T) {
+	err := withSelectedTeamAuthHint(&sandbox0.APIError{
+		StatusCode: http.StatusUnauthorized,
+		Message:    `{"error":"not a member of selected team"}`,
+	})
+	if err == nil {
+		t.Fatal("withSelectedTeamAuthHint() returned nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "token stale, run `s0 auth login` or refresh token") {
+		t.Fatalf("error = %q, want stale token hint", got)
 	}
 }
 

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -143,7 +143,33 @@ var teamCreateCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 			os.Exit(1)
 		}
+		refreshCurrentProfileTeamGrantsAfter(cmd.Context(), "creating team")
 	},
+}
+
+func refreshCurrentProfileTeamGrantsAfter(ctx context.Context, action string) {
+	cfg, err := getConfig()
+	if err != nil {
+		printTeamGrantRefreshWarning(action, false, err)
+		return
+	}
+	profileName := cfg.GetActiveProfile()
+	profile, err := cfg.GetProfile(profileName)
+	if err != nil {
+		printTeamGrantRefreshWarning(action, false, err)
+		return
+	}
+	if resolveGatewayModeForProfile(ctx, profile) != config.GatewayModeGlobal {
+		return
+	}
+	refreshed, err := refreshProfileTeamGrants(ctx, cfg, profileName)
+	if err != nil || !refreshed {
+		printTeamGrantRefreshWarning(action, refreshed, err)
+		return
+	}
+	if err := cfg.Save(); err != nil {
+		printTeamGrantRefreshWarning(action, false, fmt.Errorf("save refreshed credentials: %w", err))
+	}
 }
 
 func resolveGatewayModeForProfile(ctx context.Context, p *config.Profile) config.GatewayMode {
@@ -268,6 +294,12 @@ var teamUseCmd = &cobra.Command{
 
 		cfg.SetGatewayMode(profileName, gatewayMode)
 		cfg.SetCurrentTeam(profileName, teamID, homeRegionID, regionalGatewayURL)
+		if gatewayMode == config.GatewayModeGlobal {
+			refreshed, refreshErr := refreshProfileTeamGrants(cmd.Context(), cfg, profileName)
+			if refreshErr != nil || !refreshed {
+				printTeamGrantRefreshWarning("selecting team", refreshed, refreshErr)
+			}
+		}
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
- Refresh stored access tokens after global team creation or team selection so JWT grants include the selected team.
- Warn users when credentials cannot be refreshed and point them to re-login/select the team again.
- Add a stale-token hint for regional API key operations that return `not a member of selected team`.

Closes #31

## Testing
- go test ./internal/commands ./internal/client ./internal/config -count=1
- go test ./... -count=1