### PR TITLE
Add sandbox logs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,13 @@ s0 sandbox pause <sandbox-id>
 s0 sandbox resume <sandbox-id>
 s0 sandbox refresh <sandbox-id>
 s0 sandbox status <sandbox-id>
+s0 sandbox logs <sandbox-id> [--tail 200] [--container procd] [--follow]
 s0 sandbox list [--status <status>] [--template-id <id>] [--paused true|false] [--limit 50] [--offset 0]
 ```
 
 `s0 sandbox get <sandbox-id>` prints the SSH connection fields returned by sandbox detail when they are available, including `SSH Host`, `SSH Port`, and `SSH Username`.
+
+`s0 sandbox logs <sandbox-id>` prints raw sandbox pod logs for the selected container. Add `--follow` to stream logs until interrupted, or use `-o json` / `-o yaml` without `--follow` to include metadata such as pod and container name.
 
 Manage the current user's SSH public keys with:
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.11
+	github.com/sandbox0-ai/sdk-go v0.2.12-0.20260415061134-5ba1302d1621
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.12-0.20260415061134-5ba1302d1621
+	github.com/sandbox0-ai/sdk-go v0.2.12
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.11 h1:koboYSyGOaMkjzs232lRw/qqES23s4WjQNlGK7sJmbs=
-github.com/sandbox0-ai/sdk-go v0.2.11/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.12-0.20260415061134-5ba1302d1621 h1:6V0vYJhESKSLuWWs0gGUZ35pSNYoE4EC34dRGTThLGk=
+github.com/sandbox0-ai/sdk-go v0.2.12-0.20260415061134-5ba1302d1621/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.12-0.20260415061134-5ba1302d1621 h1:6V0vYJhESKSLuWWs0gGUZ35pSNYoE4EC34dRGTThLGk=
-github.com/sandbox0-ai/sdk-go v0.2.12-0.20260415061134-5ba1302d1621/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.12 h1:w0oRwCQNTLcaSACy7G9iYdJKb29Xqzag5OPdBbZhMUg=
+github.com/sandbox0-ai/sdk-go v0.2.12/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -26,6 +26,14 @@ var (
 	sandboxListPaused     string
 	sandboxListLimit      int
 	sandboxListOffset     int
+	// logs flags
+	sandboxLogsContainer    string
+	sandboxLogsTailLines    int64
+	sandboxLogsLimitBytes   int64
+	sandboxLogsFollow       bool
+	sandboxLogsPrevious     bool
+	sandboxLogsTimestamps   bool
+	sandboxLogsSinceSeconds int64
 	// update flags
 	sandboxUpdateTTL        int32
 	sandboxUpdateHardTTL    int32
@@ -316,6 +324,58 @@ var sandboxListCmd = &cobra.Command{
 	},
 }
 
+// sandboxLogsCmd gets sandbox pod logs.
+var sandboxLogsCmd = &cobra.Command{
+	Use:   "logs <sandbox-id>",
+	Short: "Get sandbox pod logs",
+	Long:  `Get Kubernetes pod logs for a sandbox container. Use --follow to stream logs until interrupted.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		options, err := buildSandboxLogsOptions(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error building sandbox logs request: %v\n", err)
+			os.Exit(1)
+		}
+
+		sandbox := client.Sandbox(sandboxID)
+		if sandboxLogsFollow {
+			stream, err := sandbox.StreamLogs(cmd.Context(), options)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error streaming sandbox logs: %v\n", err)
+				os.Exit(1)
+			}
+			defer stream.Close()
+			if _, err := io.Copy(os.Stdout, stream); err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading sandbox log stream: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+
+		logs, err := sandbox.GetLogs(cmd.Context(), options)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting sandbox logs: %v\n", err)
+			os.Exit(1)
+		}
+		if cfgFormat == "json" || cfgFormat == "yaml" {
+			if err := getFormatter().Format(os.Stdout, logs); err != nil {
+				fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+		_, _ = io.WriteString(os.Stdout, logs.Logs)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(sandboxCmd)
 
@@ -336,6 +396,7 @@ func init() {
 	sandboxCmd.AddCommand(sandboxRefreshCmd)
 	sandboxCmd.AddCommand(sandboxStatusCmd)
 	sandboxCmd.AddCommand(sandboxUpdateCmd)
+	sandboxCmd.AddCommand(sandboxLogsCmd)
 
 	// Update command flags
 	sandboxUpdateCmd.Flags().StringVarP(&sandboxUpdateConfigFile, "config-file", "f", "", "path to sandbox update config YAML/JSON file, or - for stdin")
@@ -350,6 +411,15 @@ func init() {
 	sandboxListCmd.Flags().IntVar(&sandboxListLimit, "limit", 50, "maximum number of results")
 	sandboxListCmd.Flags().IntVar(&sandboxListOffset, "offset", 0, "pagination offset")
 	sandboxCmd.AddCommand(sandboxListCmd)
+
+	// Logs command flags
+	sandboxLogsCmd.Flags().StringVar(&sandboxLogsContainer, "container", "", "pod container name (default: procd)")
+	sandboxLogsCmd.Flags().Int64Var(&sandboxLogsTailLines, "tail", 0, "maximum number of log lines from the end")
+	sandboxLogsCmd.Flags().Int64Var(&sandboxLogsLimitBytes, "limit-bytes", 0, "maximum snapshot log payload bytes")
+	sandboxLogsCmd.Flags().BoolVarP(&sandboxLogsFollow, "follow", "f", false, "stream logs until interrupted")
+	sandboxLogsCmd.Flags().BoolVar(&sandboxLogsPrevious, "previous", false, "return logs for the previously terminated container instance")
+	sandboxLogsCmd.Flags().BoolVar(&sandboxLogsTimestamps, "timestamps", false, "include Kubernetes log timestamps")
+	sandboxLogsCmd.Flags().Int64Var(&sandboxLogsSinceSeconds, "since-seconds", 0, "only return logs newer than this many seconds")
 }
 
 func buildSandboxCreateRequest(waitForMountsSet bool) (apispec.ClaimRequest, error) {
@@ -404,6 +474,38 @@ func buildSandboxCreateRequest(waitForMountsSet bool) (apispec.ClaimRequest, err
 		return apispec.ClaimRequest{}, fmt.Errorf("invalid sandbox create request: %w", err)
 	}
 	return request, nil
+}
+
+func buildSandboxLogsOptions(cmd *cobra.Command) (*sandbox0.SandboxLogsOptions, error) {
+	options := &sandbox0.SandboxLogsOptions{}
+	if sandboxLogsContainer != "" {
+		options.Container = sandboxLogsContainer
+	}
+	if cmd.Flags().Changed("tail") {
+		if sandboxLogsTailLines < 1 {
+			return nil, fmt.Errorf("--tail must be greater than 0")
+		}
+		options.TailLines = &sandboxLogsTailLines
+	}
+	if cmd.Flags().Changed("limit-bytes") {
+		if sandboxLogsLimitBytes < 1 {
+			return nil, fmt.Errorf("--limit-bytes must be greater than 0")
+		}
+		options.LimitBytes = &sandboxLogsLimitBytes
+	}
+	if sandboxLogsPrevious {
+		options.Previous = true
+	}
+	if sandboxLogsTimestamps {
+		options.Timestamps = true
+	}
+	if cmd.Flags().Changed("since-seconds") {
+		if sandboxLogsSinceSeconds < 1 {
+			return nil, fmt.Errorf("--since-seconds must be greater than 0")
+		}
+		options.SinceSeconds = &sandboxLogsSinceSeconds
+	}
+	return options, nil
 }
 
 func buildSandboxCreateConfigOverrides() (apispec.SandboxConfig, bool, error) {


### PR DESCRIPTION
## Summary
- Add `s0 sandbox logs <sandbox-id>` for raw snapshot logs.
- Add `--follow` streaming plus container, tail, limit, previous, timestamps, and since-seconds flags.
- Update sdk-go to the sandbox logs API pseudo-version and document the command.

## Testing
- `make build test`