### PR TITLE
Add API key scope flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.13
+	github.com/sandbox0-ai/sdk-go v0.2.14-0.20260416093653-f2a12df57470
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-faster/jx v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.2.14-0.20260416093653-f2a12df57470
+	github.com/sandbox0-ai/sdk-go v0.2.14
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.14-0.20260416093653-f2a12df57470 h1:ASxgXEOqwDj03mEHJh8QVnXykdN8jPPpbkzlZoAF7PA=
-github.com/sandbox0-ai/sdk-go v0.2.14-0.20260416093653-f2a12df57470/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.14 h1:BVmunr71q/EDwMufackY/TfpqP5t58fUMWZvNNh7lDc=
+github.com/sandbox0-ai/sdk-go v0.2.14/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.2.13 h1:e+zYGoZdQAJ5czW4NM7v4tVrAZJOQVEunFbshy9QN/s=
-github.com/sandbox0-ai/sdk-go v0.2.13/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.2.14-0.20260416093653-f2a12df57470 h1:ASxgXEOqwDj03mEHJh8QVnXykdN8jPPpbkzlZoAF7PA=
+github.com/sandbox0-ai/sdk-go v0.2.14-0.20260416093653-f2a12df57470/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/apikey.go
+++ b/internal/commands/apikey.go
@@ -13,9 +13,15 @@ import (
 
 var (
 	apiKeyName      string
+	apiKeyScope     string
 	apiKeyRoles     []string
 	apiKeyExpiresIn string
 	apiKeyRaw       bool
+)
+
+const (
+	apiKeyScopeTeam     = "team"
+	apiKeyScopePlatform = "platform"
 )
 
 var apiKeyCmd = &cobra.Command{
@@ -69,8 +75,13 @@ var apiKeyCreateCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Error: --name is required")
 			os.Exit(1)
 		}
-		if len(apiKeyRoles) == 0 {
-			fmt.Fprintln(os.Stderr, "Error: at least one --role is required")
+		scope, err := normalizeAPIKeyScope(apiKeyScope)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := validateAPIKeyCreateOptions(scope, apiKeyRoles); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -82,7 +93,10 @@ var apiKeyCreateCmd = &cobra.Command{
 
 		req := &apispec.CreateAPIKeyRequest{
 			Name:  apiKeyName,
-			Roles: apiKeyRoles,
+			Scope: apispec.NewOptString(scope),
+		}
+		if len(apiKeyRoles) > 0 {
+			req.Roles = apiKeyRoles
 		}
 		if strings.TrimSpace(apiKeyExpiresIn) != "" {
 			req.ExpiresIn = apispec.NewOptString(apiKeyExpiresIn)
@@ -208,6 +222,35 @@ func printCreatedAPIKeyRaw(w io.Writer, data *apispec.CreateAPIKeyResponse) erro
 	return err
 }
 
+func normalizeAPIKeyScope(scope string) (string, error) {
+	normalized := strings.TrimSpace(scope)
+	if normalized == "" {
+		return apiKeyScopeTeam, nil
+	}
+	switch normalized {
+	case apiKeyScopeTeam, apiKeyScopePlatform:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("--scope must be team or platform")
+	}
+}
+
+func validateAPIKeyCreateOptions(scope string, roles []string) error {
+	switch scope {
+	case apiKeyScopePlatform:
+		if len(roles) > 0 {
+			return fmt.Errorf("platform API keys do not support --role")
+		}
+	case apiKeyScopeTeam:
+		if len(roles) == 0 {
+			return fmt.Errorf("at least one --role is required for team API keys")
+		}
+	default:
+		return fmt.Errorf("--scope must be team or platform")
+	}
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(apiKeyCmd)
 
@@ -217,7 +260,8 @@ func init() {
 	apiKeyCmd.AddCommand(apiKeyDeleteCmd)
 
 	apiKeyCreateCmd.Flags().StringVar(&apiKeyName, "name", "", "API key name (required)")
-	apiKeyCreateCmd.Flags().StringArrayVar(&apiKeyRoles, "role", nil, "role to grant (admin, developer, viewer; can be repeated, required)")
+	apiKeyCreateCmd.Flags().StringVar(&apiKeyScope, "scope", apiKeyScopeTeam, "API key scope (team or platform)")
+	apiKeyCreateCmd.Flags().StringArrayVar(&apiKeyRoles, "role", nil, "role to grant (admin, developer, builder, viewer; can be repeated; required for team scope)")
 	apiKeyCreateCmd.Flags().StringVar(&apiKeyExpiresIn, "expires-in", "", "key expiry (30d, 90d, 180d, 365d, or never)")
 	apiKeyCreateCmd.Flags().BoolVar(&apiKeyRaw, "raw", false, "print only the API key value (for scripts/pipes)")
 }

--- a/internal/commands/apikey_test.go
+++ b/internal/commands/apikey_test.go
@@ -53,3 +53,61 @@ func TestPrintCreatedAPIKeyRaw(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeAPIKeyScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   string
+		want    string
+		wantErr bool
+	}{
+		{name: "defaults to team", want: apiKeyScopeTeam},
+		{name: "team", scope: "team", want: apiKeyScopeTeam},
+		{name: "platform", scope: "platform", want: apiKeyScopePlatform},
+		{name: "rejects unknown", scope: "system", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeAPIKeyScope(tt.scope)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeAPIKeyScope() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("scope = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAPIKeyCreateOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   string
+		roles   []string
+		wantErr bool
+	}{
+		{name: "team requires role", scope: apiKeyScopeTeam, wantErr: true},
+		{name: "team accepts roles", scope: apiKeyScopeTeam, roles: []string{"developer"}},
+		{name: "platform forbids roles", scope: apiKeyScopePlatform, roles: []string{"admin"}, wantErr: true},
+		{name: "platform accepts no roles", scope: apiKeyScopePlatform},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAPIKeyCreateOptions(tt.scope, tt.roles)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateAPIKeyCreateOptions() error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -1012,11 +1012,12 @@ func (f *TableFormatter) formatAPIKeyList(w io.Writer, keys []apispec.APIKey) er
 	}
 
 	t := newTable(w)
-	t.Header([]string{"ID", "NAME", "TEAM ID", "USER ID", "ROLES", "ACTIVE", "EXPIRES AT", "LAST USED"})
+	t.Header([]string{"ID", "NAME", "SCOPE", "TEAM ID", "USER ID", "ROLES", "ACTIVE", "EXPIRES AT", "LAST USED"})
 	for _, k := range keys {
 		_ = t.Append([]string{
 			k.ID,
 			k.Name,
+			formatAPIKeyScope(k.Scope),
 			k.TeamID,
 			formatOptNilString(k.UserID),
 			formatStringSlice(k.Roles),
@@ -1032,6 +1033,7 @@ func (f *TableFormatter) formatCreatedAPIKey(w io.Writer, k *apispec.CreateAPIKe
 	t := newTable(w)
 	_ = t.Append([]string{"ID:", k.ID})
 	_ = t.Append([]string{"Name:", k.Name})
+	_ = t.Append([]string{"Scope:", formatAPIKeyScope(k.Scope)})
 	_ = t.Append([]string{"Team ID:", k.TeamID})
 	_ = t.Append([]string{"Roles:", formatStringSlice(k.Roles)})
 	_ = t.Append([]string{"Expires At:", formatTimestamp(k.ExpiresAt)})
@@ -1043,6 +1045,14 @@ func (f *TableFormatter) formatCreatedAPIKey(w io.Writer, k *apispec.CreateAPIKe
 		_ = t.Append([]string{"Key:", key})
 	}
 	return t.Render()
+}
+
+func formatAPIKeyScope(scope string) string {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		return "team"
+	}
+	return scope
 }
 
 func (f *TableFormatter) formatTeamList(w io.Writer, teams []apispec.Team) error {


### PR DESCRIPTION
## Summary
- Add `s0 apikey create --scope team|platform` and validate platform keys do not send roles.
- Show API key scope in list/create table output.
- Pin sdk-go to the API key scope support commit from sandbox0-ai/sdk-go#23.

Depends on sandbox0-ai/sandbox0#211 and sandbox0-ai/sdk-go#23.

## Testing
- `go test ./... -count=1`
- `go build -o /tmp/s0-platform-api-key-scope ./cmd/s0`
- `/tmp/s0-platform-api-key-scope apikey create --help`