### PR TITLE
add function commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.3.6
+	github.com/sandbox0-ai/sdk-go v0.3.7-0.20260514083842-f69150955000
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.3.7-0.20260514083842-f69150955000
+	github.com/sandbox0-ai/sdk-go v0.3.7
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.3.6 h1:1ojuNkcF/Vb8Pbzi1lVdpaCPUZrQVrxLDVlno27UYVo=
-github.com/sandbox0-ai/sdk-go v0.3.6/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.3.7-0.20260514083842-f69150955000 h1:oeNeBJ/+TSsNhIFpbWzCFNBlYVMXhVMpJw4pk3DtBNA=
+github.com/sandbox0-ai/sdk-go v0.3.7-0.20260514083842-f69150955000/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.3.7-0.20260514083842-f69150955000 h1:oeNeBJ/+TSsNhIFpbWzCFNBlYVMXhVMpJw4pk3DtBNA=
-github.com/sandbox0-ai/sdk-go v0.3.7-0.20260514083842-f69150955000/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.3.7 h1:JAzS+0RHyIw6JI5+pV8YQHMKjskE8V523CyxnJC4c64=
+github.com/sandbox0-ai/sdk-go v0.3.7/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/function.go
+++ b/internal/commands/function.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
+	"github.com/spf13/cobra"
+)
+
+var (
+	functionName            string
+	functionRevisionPromote bool
+)
+
+// functionCmd represents the function command.
+var functionCmd = &cobra.Command{
+	Use:   "function",
+	Short: "Manage functions",
+	Long:  `List, get, create, revise, and promote sandbox0 functions.`,
+}
+
+var functionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List functions",
+	Long:  `List functions for the current team.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		functions, err := client.ListFunctions(cmd.Context())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing functions: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, functions); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionGetCmd = &cobra.Command{
+	Use:   "get <function-id-or-slug>",
+	Short: "Get function details",
+	Long:  `Get function details by ID or slug.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		function, err := client.GetFunction(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting function: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, function); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionCreateCmd = &cobra.Command{
+	Use:   "create <sandbox-id> <service-id>",
+	Short: "Create a function from a sandbox service",
+	Long:  `Create a function from an existing publishable sandbox service.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		opts := make([]sandbox0.FunctionCreateOption, 0, 1)
+		if functionName != "" {
+			opts = append(opts, sandbox0.WithFunctionName(functionName))
+		}
+
+		result, err := client.CreateFunctionFromSandbox(cmd.Context(), args[0], args[1], opts...)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating function: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionRevisionCmd = &cobra.Command{
+	Use:   "revision",
+	Short: "Manage function revisions",
+	Long:  `List and create function revisions.`,
+}
+
+var functionRevisionListCmd = &cobra.Command{
+	Use:   "list <function-id-or-slug>",
+	Short: "List function revisions",
+	Long:  `List revisions for a function.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		revisions, err := client.ListFunctionRevisions(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing function revisions: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, revisions); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionRevisionCreateCmd = &cobra.Command{
+	Use:   "create <function-id-or-slug> <sandbox-id> <service-id>",
+	Short: "Create a function revision",
+	Long:  `Create a new function revision from an existing publishable sandbox service.`,
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		result, err := client.CreateFunctionRevisionFromSandbox(
+			cmd.Context(),
+			args[0],
+			args[1],
+			args[2],
+			sandbox0.WithFunctionRevisionPromote(functionRevisionPromote),
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating function revision: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionAliasCmd = &cobra.Command{
+	Use:   "alias",
+	Short: "Manage function aliases",
+	Long:  `Promote aliases to function revisions.`,
+}
+
+var functionAliasSetCmd = &cobra.Command{
+	Use:   "set <function-id-or-slug> <alias> <revision-number>",
+	Short: "Set a function alias",
+	Long:  `Point a function alias at a revision number.`,
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		revisionNumber := parseInt32(args[2], "revision number")
+		alias, err := client.SetFunctionAlias(cmd.Context(), args[0], args[1], revisionNumber)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error setting function alias: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, alias); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(functionCmd)
+
+	functionCreateCmd.Flags().StringVar(&functionName, "name", "", "function display name")
+	functionRevisionCreateCmd.Flags().BoolVar(&functionRevisionPromote, "promote", true, "move the production alias to the new revision")
+
+	functionRevisionCmd.AddCommand(functionRevisionListCmd)
+	functionRevisionCmd.AddCommand(functionRevisionCreateCmd)
+	functionAliasCmd.AddCommand(functionAliasSetCmd)
+
+	functionCmd.AddCommand(functionListCmd)
+	functionCmd.AddCommand(functionGetCmd)
+	functionCmd.AddCommand(functionCreateCmd)
+	functionCmd.AddCommand(functionRevisionCmd)
+	functionCmd.AddCommand(functionAliasCmd)
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -165,7 +165,7 @@ func buildUserAgent() string {
 func commandRouteScope(cmd *cobra.Command) client.RouteScope {
 	for current := cmd; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "sandbox", "template", "volume", "credential", "apikey", "image", "ssh-key":
+		case "sandbox", "template", "volume", "credential", "apikey", "image", "ssh-key", "function":
 			return client.RouteScopeHomeRegion
 		case "auth", "team", "user":
 			return client.RouteScopeEntrypoint

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -19,6 +19,16 @@ func TestCommandRouteScopeRoutesUserSSHKeysToHomeRegion(t *testing.T) {
 	}
 }
 
+func TestCommandRouteScopeRoutesFunctionsToHomeRegion(t *testing.T) {
+	function := &cobra.Command{Use: "function"}
+	create := &cobra.Command{Use: "create"}
+	function.AddCommand(create)
+
+	if got := commandRouteScope(create); got != client.RouteScopeHomeRegion {
+		t.Fatalf("commandRouteScope(function create) = %q, want %q", got, client.RouteScopeHomeRegion)
+	}
+}
+
 func TestCommandRouteScopeKeepsUserProfileOnEntrypoint(t *testing.T) {
 	user := &cobra.Command{Use: "user"}
 	get := &cobra.Command{Use: "get"}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -73,6 +73,30 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatSandboxNetworkPolicy(w, v)
 	case *sandbox0.PublicGatewayResponse:
 		return f.formatPublicGateway(w, v)
+	case []apispec.FunctionRecord:
+		return f.formatFunctionList(w, v)
+	case apispec.FunctionRecord:
+		return f.formatFunction(w, &v)
+	case *apispec.FunctionRecord:
+		return f.formatFunction(w, v)
+	case sandbox0.FunctionCreateResult:
+		return f.formatFunctionCreateResult(w, &v)
+	case *sandbox0.FunctionCreateResult:
+		return f.formatFunctionCreateResult(w, v)
+	case []apispec.FunctionRevision:
+		return f.formatFunctionRevisionList(w, v)
+	case apispec.FunctionRevision:
+		return f.formatFunctionRevision(w, &v)
+	case *apispec.FunctionRevision:
+		return f.formatFunctionRevision(w, v)
+	case sandbox0.FunctionRevisionCreateResult:
+		return f.formatFunctionRevisionCreateResult(w, &v)
+	case *sandbox0.FunctionRevisionCreateResult:
+		return f.formatFunctionRevisionCreateResult(w, v)
+	case apispec.FunctionAlias:
+		return f.formatFunctionAlias(w, &v)
+	case *apispec.FunctionAlias:
+		return f.formatFunctionAlias(w, v)
 	case []apispec.MountStatus:
 		return f.formatMountStatusList(w, v)
 	case []apispec.APIKey:
@@ -723,6 +747,142 @@ func formatGatewayTimeout(timeout apispec.OptInt32) string {
 		return "-"
 	}
 	return fmt.Sprintf("%ds", value)
+}
+
+func (f *TableFormatter) formatFunctionList(w io.Writer, functions []apispec.FunctionRecord) error {
+	if len(functions) == 0 {
+		_, _ = fmt.Fprintln(w, "No functions found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"ID", "NAME", "SLUG", "HOST", "ACTIVE REVISION", "UPDATED AT"})
+	for _, fn := range functions {
+		_ = t.Append([]string{
+			fn.ID,
+			fn.Name,
+			fn.Slug,
+			fn.Host,
+			formatOptString(fn.ActiveRevisionID),
+			formatTimestamp(fn.UpdatedAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunction(w io.Writer, fn *apispec.FunctionRecord) error {
+	t := newTable(w)
+	_ = t.Append([]string{"ID:", fn.ID})
+	_ = t.Append([]string{"Team ID:", fn.TeamID})
+	_ = t.Append([]string{"Name:", fn.Name})
+	_ = t.Append([]string{"Slug:", fn.Slug})
+	_ = t.Append([]string{"Domain Label:", fn.DomainLabel})
+	_ = t.Append([]string{"Host:", fn.Host})
+	_ = t.Append([]string{"URL:", fn.URL})
+	_ = t.Append([]string{"Active Revision:", formatOptString(fn.ActiveRevisionID)})
+	_ = t.Append([]string{"Created By:", formatOptString(fn.CreatedBy)})
+	_ = t.Append([]string{"Created At:", formatTimestamp(fn.CreatedAt)})
+	_ = t.Append([]string{"Updated At:", formatTimestamp(fn.UpdatedAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionCreateResult(w io.Writer, result *sandbox0.FunctionCreateResult) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Function ID:", result.Function.ID})
+	_ = t.Append([]string{"Name:", result.Function.Name})
+	_ = t.Append([]string{"Slug:", result.Function.Slug})
+	_ = t.Append([]string{"URL:", result.Function.URL})
+	_ = t.Append([]string{"Revision ID:", result.Revision.ID})
+	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", result.Revision.RevisionNumber)})
+	_ = t.Append([]string{"Alias:", result.Alias.Alias})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionRevisionList(w io.Writer, revisions []apispec.FunctionRevision) error {
+	if len(revisions) == 0 {
+		_, _ = fmt.Fprintln(w, "No function revisions found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"REVISION", "ID", "SOURCE", "PORT", "RUNTIME", "RUNTIME SANDBOX", "CREATED AT"})
+	for _, revision := range revisions {
+		_ = t.Append([]string{
+			fmt.Sprintf("%d", revision.RevisionNumber),
+			revision.ID,
+			formatFunctionRevisionSource(revision),
+			fmt.Sprintf("%d", revision.ServiceSnapshot.Port),
+			formatFunctionServiceRuntime(revision.ServiceSnapshot),
+			formatOptString(revision.RuntimeSandboxID),
+			formatTimestamp(revision.CreatedAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionRevision(w io.Writer, revision *apispec.FunctionRevision) error {
+	t := newTable(w)
+	_ = t.Append([]string{"ID:", revision.ID})
+	_ = t.Append([]string{"Function ID:", revision.FunctionID})
+	_ = t.Append([]string{"Team ID:", revision.TeamID})
+	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", revision.RevisionNumber)})
+	_ = t.Append([]string{"Source Sandbox ID:", revision.SourceSandboxID})
+	_ = t.Append([]string{"Source Service ID:", revision.SourceServiceID})
+	_ = t.Append([]string{"Source Template ID:", revision.SourceTemplateID})
+	_ = t.Append([]string{"Service Port:", fmt.Sprintf("%d", revision.ServiceSnapshot.Port)})
+	_ = t.Append([]string{"Service Runtime:", formatFunctionServiceRuntime(revision.ServiceSnapshot)})
+	_ = t.Append([]string{"Runtime Sandbox ID:", formatOptString(revision.RuntimeSandboxID)})
+	_ = t.Append([]string{"Runtime Context ID:", formatOptString(revision.RuntimeContextID)})
+	_ = t.Append([]string{"Runtime Updated At:", formatOptDateTime(revision.RuntimeUpdatedAt)})
+	_ = t.Append([]string{"Restore Mounts:", formatFunctionRestoreMounts(revision.RestoreMounts)})
+	_ = t.Append([]string{"Created By:", formatOptString(revision.CreatedBy)})
+	_ = t.Append([]string{"Created At:", formatTimestamp(revision.CreatedAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionRevisionCreateResult(w io.Writer, result *sandbox0.FunctionRevisionCreateResult) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Revision ID:", result.Revision.ID})
+	_ = t.Append([]string{"Function ID:", result.Revision.FunctionID})
+	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", result.Revision.RevisionNumber)})
+	_ = t.Append([]string{"Promoted:", fmt.Sprintf("%v", result.Promoted)})
+	_ = t.Append([]string{"Runtime Sandbox ID:", formatOptString(result.Revision.RuntimeSandboxID)})
+	_ = t.Append([]string{"Created At:", formatTimestamp(result.Revision.CreatedAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionAlias(w io.Writer, alias *apispec.FunctionAlias) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Function ID:", alias.FunctionID})
+	_ = t.Append([]string{"Alias:", alias.Alias})
+	_ = t.Append([]string{"Revision ID:", alias.RevisionID})
+	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", alias.RevisionNumber)})
+	_ = t.Append([]string{"Updated By:", formatOptString(alias.UpdatedBy)})
+	_ = t.Append([]string{"Updated At:", formatTimestamp(alias.UpdatedAt)})
+	return t.Render()
+}
+
+func formatFunctionRevisionSource(revision apispec.FunctionRevision) string {
+	return fmt.Sprintf("%s/%s", valueOrDash(revision.SourceSandboxID), valueOrDash(revision.SourceServiceID))
+}
+
+func formatFunctionServiceRuntime(service apispec.SandboxAppService) string {
+	runtime, ok := service.Runtime.Get()
+	if !ok || runtime.Type == "" {
+		return "-"
+	}
+	return string(runtime.Type)
+}
+
+func formatFunctionRestoreMounts(mounts []apispec.FunctionRestoreMount) string {
+	if len(mounts) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(mounts))
+	for _, mount := range mounts {
+		parts = append(parts, fmt.Sprintf("%s:%s", mount.SandboxvolumeID, mount.MountPoint))
+	}
+	return strings.Join(parts, ",")
 }
 
 func formatTimestamp(ts time.Time) string {

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
@@ -270,6 +271,117 @@ func TestTableFormatterFormatSSHPublicKey(t *testing.T) {
 	} {
 		if strings.Contains(output, unwanted) {
 			t.Fatalf("output contains %q:\n%s", unwanted, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFunctionList(t *testing.T) {
+	formatter := &TableFormatter{}
+	functions := []apispec.FunctionRecord{
+		{
+			ID:               "fn_123",
+			Name:             "API",
+			Slug:             "api",
+			Host:             "api.sandbox0.site",
+			ActiveRevisionID: apispec.NewOptString("rev_1"),
+			UpdatedAt:        time.Date(2026, 5, 14, 8, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, functions); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ID",
+		"NAME",
+		"ACTIVE REVISION",
+		"fn_123",
+		"api.sandbox0.site",
+		"rev_1",
+		"2026-05-14 08:00:00",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFunctionRevisionCreateResult(t *testing.T) {
+	formatter := &TableFormatter{}
+	result := &sandbox0.FunctionRevisionCreateResult{
+		Revision: apispec.FunctionRevision{
+			ID:             "rev_2",
+			FunctionID:     "fn_123",
+			RevisionNumber: 2,
+			RuntimeSandboxID: apispec.NewOptString(
+				"sb_runtime",
+			),
+			CreatedAt: time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		},
+		Promoted: true,
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Revision ID:",
+		"rev_2",
+		"Function ID:",
+		"fn_123",
+		"Revision Number:",
+		"2",
+		"Promoted:",
+		"true",
+		"sb_runtime",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFunctionRevisionList(t *testing.T) {
+	formatter := &TableFormatter{}
+	revisions := []apispec.FunctionRevision{
+		{
+			ID:              "rev_1",
+			RevisionNumber:  1,
+			SourceSandboxID: "sb_123",
+			SourceServiceID: "web",
+			ServiceSnapshot: apispec.SandboxAppService{
+				Port: 8080,
+				Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
+					Type: apispec.SandboxAppServiceRuntimeTypeWarmProcess,
+				}),
+			},
+			CreatedAt: time.Date(2026, 5, 14, 8, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, revisions); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"REVISION",
+		"SOURCE",
+		"RUNTIME",
+		"rev_1",
+		"sb_123/web",
+		"8080",
+		"warm_process",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add `s0 function` commands for list/get/create, revision creation/listing, and alias promotion
- add table output for functions, revisions, aliases, and function create results
- route function commands through the home-region target and update sdk-go to the function API pseudo-version

Depends on sandbox0-ai/sandbox0#309 and sandbox0-ai/sdk-go#31.

## Tests
- go test ./...
- git diff --check