### PR TITLE
[codex] switch sandbox gateway cli to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,35 +395,40 @@ s0 sandbox network update --mode block-all \
   -s <sandbox-id>
 ```
 
-### Sandbox Gateway
+### Sandbox Services
 
 ```bash
-s0 sandbox gateway get -s <sandbox-id>
-s0 sandbox gateway update --policy-file gateway.yaml -s <sandbox-id>
-s0 sandbox gateway clear -s <sandbox-id>
+s0 sandbox service get -s <sandbox-id>
+s0 sandbox service update --services-file services.yaml -s <sandbox-id>
+s0 sandbox service clear -s <sandbox-id>
 
-# Claim-time public gateway policy via sandbox config file
+# Claim-time sandbox services via sandbox config file
 cat <<'EOF' > sandbox-config.yaml
-public_gateway:
-  enabled: true
-  routes:
-    - id: app
-      port: 8080
-      path_prefix: /
-      resume: true
+services:
+  - id: app
+    port: 8080
+    ingress:
+      public: true
+      routes:
+        - id: app
+          path_prefix: /
+          resume: true
 EOF
 s0 sandbox create -t default -f sandbox-config.yaml
 
-# Update an existing sandbox policy
+# Update existing sandbox services
 cat <<'EOF' > gateway.yaml
-enabled: true
-routes:
+services:
   - id: app
     port: 8080
-    path_prefix: /
-    resume: true
+    ingress:
+      public: true
+      routes:
+        - id: app
+          path_prefix: /
+          resume: true
 EOF
-s0 sandbox gateway update --policy-file gateway.yaml -s <sandbox-id>
+s0 sandbox service update --services-file gateway.yaml -s <sandbox-id>
 ```
 
 ### Template
@@ -501,8 +506,8 @@ s0 volume files watch <volume-id> /docs --recursive
 s0 sandbox context create --type repl --alias python -s <sandbox-id>
 s0 sandbox context exec <ctx-id> "print('hello')" -s <sandbox-id>
 
-# Publish HTTP traffic through public gateway policy
-s0 sandbox gateway update --policy-file gateway.yaml -s <sandbox-id>
+# Publish HTTP traffic through sandbox services
+s0 sandbox service update --services-file services.yaml -s <sandbox-id>
 
 # Build and push a template image
 s0 template image build . -t my-image:v1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.3.7
+	github.com/sandbox0-ai/sdk-go v0.3.8
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.3.7 h1:JAzS+0RHyIw6JI5+pV8YQHMKjskE8V523CyxnJC4c64=
-github.com/sandbox0-ai/sdk-go v0.3.7/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.3.8 h1:qpPN3JWlL5yfk9Jao36czeY4VI7EgSXWGczcj4RjF1w=
+github.com/sandbox0-ai/sdk-go v0.3.8/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_gateway.go
+++ b/internal/commands/sandbox_gateway.go
@@ -15,18 +15,19 @@ var (
 	gatewayPolicyFile string
 )
 
-// sandboxGatewayCmd represents the sandbox gateway command group.
+// sandboxGatewayCmd represents the sandbox service command group.
 var sandboxGatewayCmd = &cobra.Command{
-	Use:   "gateway",
-	Short: "Manage public gateway policy",
-	Long:  `Get, update, and clear request-level public gateway policy for a sandbox.`,
+	Use:     "service",
+	Aliases: []string{"gateway"},
+	Short:   "Manage sandbox services",
+	Long:    `Get, update, and clear canonical services for a sandbox.`,
 }
 
-// sandboxGatewayGetCmd gets the public gateway policy.
+// sandboxGatewayGetCmd gets sandbox services.
 var sandboxGatewayGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get public gateway policy",
-	Long:  `Get the request-level public gateway policy for the sandbox.`,
+	Short: "Get sandbox services",
+	Long:  `Get canonical services configured for the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := getClientRaw(cmd)
 		if err != nil {
@@ -34,9 +35,9 @@ var sandboxGatewayGetCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		result, err := client.Sandbox(gatewaySandboxID).GetPublicGateway(cmd.Context())
+		result, err := client.Sandbox(gatewaySandboxID).GetServices(cmd.Context())
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting public gateway policy: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error getting sandbox services: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -47,11 +48,11 @@ var sandboxGatewayGetCmd = &cobra.Command{
 	},
 }
 
-// sandboxGatewayUpdateCmd updates the public gateway policy.
+// sandboxGatewayUpdateCmd updates sandbox services.
 var sandboxGatewayUpdateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update public gateway policy",
-	Long:  `Replace the request-level public gateway policy for the sandbox.`,
+	Short: "Update sandbox services",
+	Long:  `Replace canonical services configured for the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := getClientRaw(cmd)
 		if err != nil {
@@ -59,15 +60,15 @@ var sandboxGatewayUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		policy, err := readPublicGatewayPolicyFile(gatewayPolicyFile)
+		services, err := readSandboxServicesFile(gatewayPolicyFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading public gateway policy: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error reading sandbox services: %v\n", err)
 			os.Exit(1)
 		}
 
-		result, err := client.Sandbox(gatewaySandboxID).UpdatePublicGateway(cmd.Context(), *policy)
+		result, err := client.Sandbox(gatewaySandboxID).UpdateServices(cmd.Context(), services.Services)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error updating public gateway policy: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error updating sandbox services: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -78,11 +79,11 @@ var sandboxGatewayUpdateCmd = &cobra.Command{
 	},
 }
 
-// sandboxGatewayClearCmd disables request-level public gateway enforcement.
+// sandboxGatewayClearCmd clears sandbox services.
 var sandboxGatewayClearCmd = &cobra.Command{
 	Use:   "clear",
-	Short: "Clear public gateway policy",
-	Long:  `Disable request-level public gateway enforcement for the sandbox.`,
+	Short: "Clear sandbox services",
+	Long:  `Remove all canonical services from the sandbox.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := getClientRaw(cmd)
 		if err != nil {
@@ -90,9 +91,9 @@ var sandboxGatewayClearCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		result, err := client.Sandbox(gatewaySandboxID).ClearPublicGateway(cmd.Context())
+		result, err := client.Sandbox(gatewaySandboxID).ClearServices(cmd.Context())
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error clearing public gateway policy: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error clearing sandbox services: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -103,26 +104,29 @@ var sandboxGatewayClearCmd = &cobra.Command{
 	},
 }
 
-func readPublicGatewayPolicyFile(path string) (*apispec.PublicGatewayConfig, error) {
+func readSandboxServicesFile(path string) (*apispec.SandboxServicesUpdateRequest, error) {
 	if strings.TrimSpace(path) == "" {
-		return nil, fmt.Errorf("--policy-file is required")
+		return nil, fmt.Errorf("--services-file is required")
 	}
 	data, err := readConfigFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return parsePublicGatewayPolicy(data)
+	return parseSandboxServices(data)
 }
 
-func parsePublicGatewayPolicy(data []byte) (*apispec.PublicGatewayConfig, error) {
-	var policy apispec.PublicGatewayConfig
-	if err := yaml.Unmarshal(data, &policy); err != nil {
-		return nil, fmt.Errorf("parse public gateway policy file: %w", err)
+func parseSandboxServices(data []byte) (*apispec.SandboxServicesUpdateRequest, error) {
+	var services apispec.SandboxServicesUpdateRequest
+	if err := yaml.Unmarshal(data, &services); err != nil {
+		return nil, fmt.Errorf("parse sandbox services file: %w", err)
 	}
-	if err := policy.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid public gateway policy: %w", err)
+	if services.Services == nil {
+		services.Services = []apispec.SandboxAppService{}
 	}
-	return &policy, nil
+	if err := services.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid sandbox services: %w", err)
+	}
+	return &services, nil
 }
 
 func init() {
@@ -133,8 +137,9 @@ func init() {
 	sandboxGatewayCmd.PersistentFlags().StringVarP(&gatewaySandboxID, "sandbox-id", "s", "", "sandbox ID (required)")
 	_ = sandboxGatewayCmd.MarkPersistentFlagRequired("sandbox-id")
 
-	sandboxGatewayUpdateCmd.Flags().StringVarP(&gatewayPolicyFile, "policy-file", "f", "", "path to public gateway policy YAML/JSON file, or - for stdin")
-	_ = sandboxGatewayUpdateCmd.MarkFlagRequired("policy-file")
+	sandboxGatewayUpdateCmd.Flags().StringVarP(&gatewayPolicyFile, "services-file", "f", "", "path to sandbox services YAML/JSON file, or - for stdin")
+	sandboxGatewayUpdateCmd.Flags().StringVar(&gatewayPolicyFile, "policy-file", "", "deprecated alias for --services-file")
+	_ = sandboxGatewayUpdateCmd.Flags().MarkDeprecated("policy-file", "use --services-file")
 
 	sandboxCmd.AddCommand(sandboxGatewayCmd)
 }

--- a/internal/commands/sandbox_gateway_test.go
+++ b/internal/commands/sandbox_gateway_test.go
@@ -6,36 +6,43 @@ import (
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
-func TestParsePublicGatewayPolicy(t *testing.T) {
-	policy, err := parsePublicGatewayPolicy([]byte(`
-enabled: true
-routes:
+func TestParseSandboxServices(t *testing.T) {
+	services, err := parseSandboxServices([]byte(`
+services:
   - id: app
     port: 8080
-    path_prefix: /api
-    methods: [GET, POST]
-    auth:
-      mode: bearer
-      bearer_token_sha256: abc123
-    rate_limit:
-      rps: 10
-      burst: 20
-    timeout_seconds: 30
-    resume: true
+    ingress:
+      public: true
+      routes:
+        - id: app
+          path_prefix: /api
+          methods: [GET, POST]
+          auth:
+            mode: bearer
+            bearer_token_sha256: abc123
+          rate_limit:
+            rps: 10
+            burst: 20
+          timeout_seconds: 30
+          resume: true
 `))
 	if err != nil {
-		t.Fatalf("parsePublicGatewayPolicy() error = %v", err)
+		t.Fatalf("parseSandboxServices() error = %v", err)
 	}
 
-	if !policy.Enabled {
-		t.Fatal("enabled = false, want true")
+	if len(services.Services) != 1 {
+		t.Fatalf("services count = %d, want 1", len(services.Services))
 	}
-	if len(policy.Routes) != 1 {
-		t.Fatalf("routes count = %d, want 1", len(policy.Routes))
+	service := services.Services[0]
+	if service.ID != "app" || service.Port != 8080 {
+		t.Fatalf("service = %#v, want id app and port 8080", service)
 	}
-	route := policy.Routes[0]
-	if route.ID != "app" || route.Port != 8080 {
-		t.Fatalf("route = %#v, want id app and port 8080", route)
+	if !service.Ingress.Public || len(service.Ingress.Routes) != 1 {
+		t.Fatalf("ingress = %#v, want one public route", service.Ingress)
+	}
+	route := service.Ingress.Routes[0]
+	if route.ID != "app" {
+		t.Fatalf("route = %#v, want id app", route)
 	}
 	if route.PathPrefix.Or("") != "/api" {
 		t.Fatalf("path_prefix = %q, want /api", route.PathPrefix.Or(""))
@@ -49,9 +56,9 @@ routes:
 	}
 }
 
-func TestReadPublicGatewayPolicyFileRequiresPath(t *testing.T) {
-	_, err := readPublicGatewayPolicyFile("")
+func TestReadSandboxServicesFileRequiresPath(t *testing.T) {
+	_, err := readSandboxServicesFile("")
 	if err == nil {
-		t.Fatal("readPublicGatewayPolicyFile() error = nil, want error")
+		t.Fatal("readSandboxServicesFile() error = nil, want error")
 	}
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -71,6 +71,8 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatContextStats(w, v)
 	case *apispec.SandboxNetworkPolicy:
 		return f.formatSandboxNetworkPolicy(w, v)
+	case *sandbox0.SandboxServicesResponse:
+		return f.formatSandboxServices(w, v)
 	case *sandbox0.PublicGatewayResponse:
 		return f.formatPublicGateway(w, v)
 	case []apispec.FunctionRecord:
@@ -716,6 +718,61 @@ func (f *TableFormatter) formatPublicGateway(w io.Writer, resp *sandbox0.PublicG
 		_, _ = fmt.Fprintf(w, "Exposure Domain: %s\n", resp.ExposureDomain)
 	}
 	return nil
+}
+
+func (f *TableFormatter) formatSandboxServices(w io.Writer, resp *sandbox0.SandboxServicesResponse) error {
+	if len(resp.Services) == 0 {
+		_, _ = fmt.Fprintln(w, "No sandbox services configured.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"SERVICE", "PORT", "PUBLIC", "ROUTE", "PATH", "METHODS", "AUTH", "RATE LIMIT", "TIMEOUT", "RESUME", "PUBLISHABLE"})
+	for _, service := range resp.Services {
+		routes := service.Ingress.Routes
+		if len(routes) == 0 {
+			_ = t.Append([]string{
+				service.ID,
+				fmt.Sprintf("%d", service.Port),
+				fmt.Sprintf("%v", service.Ingress.Public),
+				"-",
+				"-",
+				"-",
+				"-",
+				"-",
+				"-",
+				"-",
+				formatPublishable(service),
+			})
+			continue
+		}
+		for _, route := range routes {
+			_ = t.Append([]string{
+				service.ID,
+				fmt.Sprintf("%d", service.Port),
+				fmt.Sprintf("%v", service.Ingress.Public),
+				route.ID,
+				route.PathPrefix.Or("/"),
+				formatGatewayMethods(route.Methods),
+				formatGatewayAuth(route.Auth),
+				formatGatewayRateLimit(route.RateLimit),
+				formatGatewayTimeout(route.TimeoutSeconds),
+				fmt.Sprintf("%v", route.Resume),
+				formatPublishable(service),
+			})
+		}
+	}
+	return t.Render()
+}
+
+func formatPublishable(service apispec.SandboxAppServiceView) string {
+	if service.Publishable {
+		return "true"
+	}
+	if len(service.PublishBlockers) == 0 {
+		return "false"
+	}
+	return "false: " + strings.Join(service.PublishBlockers, ",")
 }
 
 func formatGatewayMethods(methods []string) string {


### PR DESCRIPTION
## Summary
- Switch the sandbox gateway command group to sandbox service terminology and services payloads.
- Keep gateway and --policy-file as deprecated compatibility aliases.
- Add table formatting for SandboxServicesResponse and update README examples.

## Dependency note
- This PR depends on a sdk-go release containing SandboxServicesResponse and Sandbox.GetServices/UpdateServices/ClearServices.

## Validation
- GOFLAGS=-mod=mod go test ./internal/commands -run 'TestParseSandboxServices|TestReadSandboxServicesFileRequiresPath' -count=1 with a temporary local sdk-go replace
- GOFLAGS=-mod=mod go test ./internal/output -run Test -count=1 with a temporary local sdk-go replace
