### PR TITLE
[codex] remove legacy public gateway cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ EOF
 s0 sandbox create -t default -f sandbox-config.yaml
 
 # Update existing sandbox services
-cat <<'EOF' > gateway.yaml
+cat <<'EOF' > services.yaml
 services:
   - id: app
     port: 8080
@@ -428,7 +428,7 @@ services:
           path_prefix: /
           resume: true
 EOF
-s0 sandbox service update --services-file gateway.yaml -s <sandbox-id>
+s0 sandbox service update --services-file services.yaml -s <sandbox-id>
 ```
 
 ### Template

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.3.9-0.20260514200337-d096762927ae
+	github.com/sandbox0-ai/sdk-go v0.4.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.3.8
+	github.com/sandbox0-ai/sdk-go v0.3.9-0.20260514200337-d096762927ae
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.3.9-0.20260514200337-d096762927ae h1:XKlnyATlBkhWO/PdV4WuwV/IWn2a+9ozx8RPqHIZ9/4=
-github.com/sandbox0-ai/sdk-go v0.3.9-0.20260514200337-d096762927ae/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.0 h1:HvmPHa7Zh2o4wlwR4A4v1Z7+BdUfnu/124g5NFXojOc=
+github.com/sandbox0-ai/sdk-go v0.4.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.3.8 h1:qpPN3JWlL5yfk9Jao36czeY4VI7EgSXWGczcj4RjF1w=
-github.com/sandbox0-ai/sdk-go v0.3.8/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.3.9-0.20260514200337-d096762927ae h1:XKlnyATlBkhWO/PdV4WuwV/IWn2a+9ozx8RPqHIZ9/4=
+github.com/sandbox0-ai/sdk-go v0.3.9-0.20260514200337-d096762927ae/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_gateway.go
+++ b/internal/commands/sandbox_gateway.go
@@ -17,10 +17,9 @@ var (
 
 // sandboxGatewayCmd represents the sandbox service command group.
 var sandboxGatewayCmd = &cobra.Command{
-	Use:     "service",
-	Aliases: []string{"gateway"},
-	Short:   "Manage sandbox services",
-	Long:    `Get, update, and clear canonical services for a sandbox.`,
+	Use:   "service",
+	Short: "Manage sandbox services",
+	Long:  `Get, update, and clear canonical services for a sandbox.`,
 }
 
 // sandboxGatewayGetCmd gets sandbox services.
@@ -138,8 +137,6 @@ func init() {
 	_ = sandboxGatewayCmd.MarkPersistentFlagRequired("sandbox-id")
 
 	sandboxGatewayUpdateCmd.Flags().StringVarP(&gatewayPolicyFile, "services-file", "f", "", "path to sandbox services YAML/JSON file, or - for stdin")
-	sandboxGatewayUpdateCmd.Flags().StringVar(&gatewayPolicyFile, "policy-file", "", "deprecated alias for --services-file")
-	_ = sandboxGatewayUpdateCmd.Flags().MarkDeprecated("policy-file", "use --services-file")
 
 	sandboxCmd.AddCommand(sandboxGatewayCmd)
 }

--- a/internal/commands/sandbox_gateway_test.go
+++ b/internal/commands/sandbox_gateway_test.go
@@ -51,7 +51,7 @@ services:
 	if !ok {
 		t.Fatal("auth not set")
 	}
-	if auth.Mode != apispec.PublicGatewayAuthModeBearer {
+	if auth.Mode != apispec.SandboxAppServiceRouteAuthModeBearer {
 		t.Fatalf("auth mode = %q, want bearer", auth.Mode)
 	}
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -73,8 +73,6 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatSandboxNetworkPolicy(w, v)
 	case *sandbox0.SandboxServicesResponse:
 		return f.formatSandboxServices(w, v)
-	case *sandbox0.PublicGatewayResponse:
-		return f.formatPublicGateway(w, v)
 	case []apispec.FunctionRecord:
 		return f.formatFunctionList(w, v)
 	case apispec.FunctionRecord:
@@ -682,44 +680,6 @@ func (f *TableFormatter) formatSandboxNetworkPolicy(w io.Writer, policy *apispec
 	return t.Render()
 }
 
-func (f *TableFormatter) formatPublicGateway(w io.Writer, resp *sandbox0.PublicGatewayResponse) error {
-	policy := resp.PublicGateway
-	if !policy.Enabled || len(policy.Routes) == 0 {
-		state := "disabled"
-		if policy.Enabled {
-			state = "enabled with no routes"
-		}
-		_, _ = fmt.Fprintf(w, "Public Gateway: %s\n", state)
-		if resp.ExposureDomain != "" {
-			_, _ = fmt.Fprintf(w, "Exposure Domain: %s\n", resp.ExposureDomain)
-		}
-		return nil
-	}
-
-	t := newTable(w)
-	t.Header([]string{"ID", "PORT", "PATH", "METHODS", "AUTH", "RATE LIMIT", "TIMEOUT", "RESUME"})
-	for _, route := range policy.Routes {
-		_ = t.Append([]string{
-			route.ID,
-			fmt.Sprintf("%d", route.Port),
-			route.PathPrefix.Or("/"),
-			formatGatewayMethods(route.Methods),
-			formatGatewayAuth(route.Auth),
-			formatGatewayRateLimit(route.RateLimit),
-			formatGatewayTimeout(route.TimeoutSeconds),
-			fmt.Sprintf("%v", route.Resume),
-		})
-	}
-	if err := t.Render(); err != nil {
-		return err
-	}
-
-	if resp.ExposureDomain != "" {
-		_, _ = fmt.Fprintf(w, "Exposure Domain: %s\n", resp.ExposureDomain)
-	}
-	return nil
-}
-
 func (f *TableFormatter) formatSandboxServices(w io.Writer, resp *sandbox0.SandboxServicesResponse) error {
 	if len(resp.Services) == 0 {
 		_, _ = fmt.Fprintln(w, "No sandbox services configured.")
@@ -782,7 +742,7 @@ func formatGatewayMethods(methods []string) string {
 	return strings.Join(methods, ",")
 }
 
-func formatGatewayAuth(auth apispec.OptPublicGatewayAuth) string {
+func formatGatewayAuth(auth apispec.OptSandboxAppServiceRouteAuth) string {
 	value, ok := auth.Get()
 	if !ok {
 		return "none"
@@ -790,7 +750,7 @@ func formatGatewayAuth(auth apispec.OptPublicGatewayAuth) string {
 	return string(value.Mode)
 }
 
-func formatGatewayRateLimit(rateLimit apispec.OptPublicGatewayRateLimit) string {
+func formatGatewayRateLimit(rateLimit apispec.OptSandboxAppServiceRouteRateLimit) string {
 	value, ok := rateLimit.Get()
 	if !ok {
 		return "-"


### PR DESCRIPTION
## Summary
- update `s0` to the sdk-go public gateway removal commit
- remove the legacy `sandbox gateway` command alias and `--policy-file` service update alias
- drop public gateway table formatting while keeping sandbox service formatting

## Validation
- `go test ./...`

## Notes
- This PR currently depends on sandbox0-ai/sdk-go#33. The sdk-go dependency can be switched from the pseudo-version to the released version before merge if needed.
