### PR TITLE
Add function lifecycle commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.0
+	github.com/sandbox0-ai/sdk-go v0.4.1-0.20260515193742-2ba96648441c
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.1-0.20260515193742-2ba96648441c
+	github.com/sandbox0-ai/sdk-go v0.4.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.4.0 h1:HvmPHa7Zh2o4wlwR4A4v1Z7+BdUfnu/124g5NFXojOc=
 github.com/sandbox0-ai/sdk-go v0.4.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.1-0.20260515193742-2ba96648441c h1:kEmqMS6C/O4xd1Ued5aCVmwQoBcX3gSHistnVGUgdjQ=
+github.com/sandbox0-ai/sdk-go v0.4.1-0.20260515193742-2ba96648441c/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.4.0 h1:HvmPHa7Zh2o4wlwR4A4v1Z7+BdUfnu/124g5NFXojOc=
-github.com/sandbox0-ai/sdk-go v0.4.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.4.1-0.20260515193742-2ba96648441c h1:kEmqMS6C/O4xd1Ued5aCVmwQoBcX3gSHistnVGUgdjQ=
-github.com/sandbox0-ai/sdk-go v0.4.1-0.20260515193742-2ba96648441c/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.1 h1:5OPfT7ONJATZccWJx/zp+canCmVBSlpCCS3N7V3novI=
+github.com/sandbox0-ai/sdk-go v0.4.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/function.go
+++ b/internal/commands/function.go
@@ -10,6 +10,8 @@ import (
 
 var (
 	functionName            string
+	functionUpdateName      string
+	functionUpdateEnabled   bool
 	functionRevisionPromote bool
 )
 
@@ -99,10 +101,72 @@ var functionCreateCmd = &cobra.Command{
 	},
 }
 
+var functionUpdateCmd = &cobra.Command{
+	Use:   "update <function-id-or-slug>",
+	Short: "Update a function",
+	Long:  `Update mutable function metadata and serving state.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		opts := make([]sandbox0.FunctionUpdateOption, 0, 2)
+		if functionUpdateName != "" {
+			opts = append(opts, sandbox0.WithFunctionUpdateName(functionUpdateName))
+		}
+		if cmd.Flags().Changed("enabled") {
+			opts = append(opts, sandbox0.WithFunctionEnabled(functionUpdateEnabled))
+		}
+		if len(opts) == 0 {
+			fmt.Fprintln(os.Stderr, "Error updating function: at least one of --name or --enabled is required")
+			os.Exit(1)
+		}
+
+		function, err := client.UpdateFunctionWithOptions(cmd.Context(), args[0], opts...)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error updating function: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, function); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionDeleteCmd = &cobra.Command{
+	Use:   "delete <function-id-or-slug>",
+	Short: "Delete a function",
+	Long:  `Soft-delete a function and remove it from normal list, get, and host traffic.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		function, err := client.DeleteFunction(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting function: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, function); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 var functionRevisionCmd = &cobra.Command{
 	Use:   "revision",
 	Short: "Manage function revisions",
-	Long:  `List and create function revisions.`,
+	Long:  `List, get, and create function revisions.`,
 }
 
 var functionRevisionListCmd = &cobra.Command{
@@ -124,6 +188,32 @@ var functionRevisionListCmd = &cobra.Command{
 		}
 
 		if err := getFormatter().Format(os.Stdout, revisions); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionRevisionGetCmd = &cobra.Command{
+	Use:   "get <function-id-or-slug> <revision-number>",
+	Short: "Get a function revision",
+	Long:  `Get one function revision by revision number.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		revisionNumber := parseInt32(args[1], "revision number")
+		revision, err := client.GetFunctionRevision(cmd.Context(), args[0], revisionNumber)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting function revision: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, revision); err != nil {
 			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 			os.Exit(1)
 		}
@@ -164,7 +254,57 @@ var functionRevisionCreateCmd = &cobra.Command{
 var functionAliasCmd = &cobra.Command{
 	Use:   "alias",
 	Short: "Manage function aliases",
-	Long:  `Promote aliases to function revisions.`,
+	Long:  `List, get, and promote function aliases.`,
+}
+
+var functionAliasListCmd = &cobra.Command{
+	Use:   "list <function-id-or-slug>",
+	Short: "List function aliases",
+	Long:  `List aliases for a function.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		aliases, err := client.ListFunctionAliases(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing function aliases: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, aliases); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionAliasGetCmd = &cobra.Command{
+	Use:   "get <function-id-or-slug> <alias>",
+	Short: "Get a function alias",
+	Long:  `Get one alias for a function.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		alias, err := client.GetFunctionAlias(cmd.Context(), args[0], args[1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting function alias: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, alias); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
 }
 
 var functionAliasSetCmd = &cobra.Command{
@@ -193,19 +333,111 @@ var functionAliasSetCmd = &cobra.Command{
 	},
 }
 
+var functionRuntimeCmd = &cobra.Command{
+	Use:   "runtime",
+	Short: "Manage function runtime",
+	Long:  `Inspect and reset the restored runtime sandbox for a function.`,
+}
+
+var functionRuntimeGetCmd = &cobra.Command{
+	Use:   "get <function-id-or-slug>",
+	Short: "Get function runtime status",
+	Long:  `Get the currently restored runtime status for a function.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		runtime, err := client.GetFunctionRuntime(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting function runtime: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, runtime); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionRuntimeRestartCmd = &cobra.Command{
+	Use:   "restart <function-id-or-slug>",
+	Short: "Restart function runtime",
+	Long:  `Delete the current runtime sandbox and leave the function idle until the next host request.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		runtime, err := client.RestartFunctionRuntime(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error restarting function runtime: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, runtime); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var functionRuntimeRecycleCmd = &cobra.Command{
+	Use:   "recycle <function-id-or-slug>",
+	Short: "Recycle function runtime",
+	Long:  `Recycle the current runtime sandbox and leave the function idle until the next host request.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		runtime, err := client.RecycleFunctionRuntime(cmd.Context(), args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error recycling function runtime: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, runtime); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(functionCmd)
 
 	functionCreateCmd.Flags().StringVar(&functionName, "name", "", "function display name")
+	functionUpdateCmd.Flags().StringVar(&functionUpdateName, "name", "", "function display name")
+	functionUpdateCmd.Flags().BoolVar(&functionUpdateEnabled, "enabled", true, "whether the function should serve traffic")
 	functionRevisionCreateCmd.Flags().BoolVar(&functionRevisionPromote, "promote", true, "move the production alias to the new revision")
 
 	functionRevisionCmd.AddCommand(functionRevisionListCmd)
+	functionRevisionCmd.AddCommand(functionRevisionGetCmd)
 	functionRevisionCmd.AddCommand(functionRevisionCreateCmd)
+	functionAliasCmd.AddCommand(functionAliasListCmd)
+	functionAliasCmd.AddCommand(functionAliasGetCmd)
 	functionAliasCmd.AddCommand(functionAliasSetCmd)
+	functionRuntimeCmd.AddCommand(functionRuntimeGetCmd)
+	functionRuntimeCmd.AddCommand(functionRuntimeRestartCmd)
+	functionRuntimeCmd.AddCommand(functionRuntimeRecycleCmd)
 
 	functionCmd.AddCommand(functionListCmd)
 	functionCmd.AddCommand(functionGetCmd)
 	functionCmd.AddCommand(functionCreateCmd)
+	functionCmd.AddCommand(functionUpdateCmd)
+	functionCmd.AddCommand(functionDeleteCmd)
 	functionCmd.AddCommand(functionRevisionCmd)
 	functionCmd.AddCommand(functionAliasCmd)
+	functionCmd.AddCommand(functionRuntimeCmd)
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -93,10 +93,16 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatFunctionRevisionCreateResult(w, &v)
 	case *sandbox0.FunctionRevisionCreateResult:
 		return f.formatFunctionRevisionCreateResult(w, v)
+	case []apispec.FunctionAlias:
+		return f.formatFunctionAliasList(w, v)
 	case apispec.FunctionAlias:
 		return f.formatFunctionAlias(w, &v)
 	case *apispec.FunctionAlias:
 		return f.formatFunctionAlias(w, v)
+	case apispec.FunctionRuntimeStatus:
+		return f.formatFunctionRuntime(w, &v)
+	case *apispec.FunctionRuntimeStatus:
+		return f.formatFunctionRuntime(w, v)
 	case []apispec.MountStatus:
 		return f.formatMountStatusList(w, v)
 	case []apispec.APIKey:
@@ -773,13 +779,14 @@ func (f *TableFormatter) formatFunctionList(w io.Writer, functions []apispec.Fun
 	}
 
 	t := newTable(w)
-	t.Header([]string{"ID", "NAME", "SLUG", "HOST", "ACTIVE REVISION", "UPDATED AT"})
+	t.Header([]string{"ID", "NAME", "SLUG", "HOST", "ENABLED", "ACTIVE REVISION", "UPDATED AT"})
 	for _, fn := range functions {
 		_ = t.Append([]string{
 			fn.ID,
 			fn.Name,
 			fn.Slug,
 			fn.Host,
+			fmt.Sprintf("%v", fn.Enabled),
 			formatOptString(fn.ActiveRevisionID),
 			formatTimestamp(fn.UpdatedAt),
 		})
@@ -796,10 +803,12 @@ func (f *TableFormatter) formatFunction(w io.Writer, fn *apispec.FunctionRecord)
 	_ = t.Append([]string{"Domain Label:", fn.DomainLabel})
 	_ = t.Append([]string{"Host:", fn.Host})
 	_ = t.Append([]string{"URL:", fn.URL})
+	_ = t.Append([]string{"Enabled:", fmt.Sprintf("%v", fn.Enabled)})
 	_ = t.Append([]string{"Active Revision:", formatOptString(fn.ActiveRevisionID)})
 	_ = t.Append([]string{"Created By:", formatOptString(fn.CreatedBy)})
 	_ = t.Append([]string{"Created At:", formatTimestamp(fn.CreatedAt)})
 	_ = t.Append([]string{"Updated At:", formatTimestamp(fn.UpdatedAt)})
+	_ = t.Append([]string{"Deleted At:", formatOptDateTime(fn.DeletedAt)})
 	return t.Render()
 }
 
@@ -876,6 +885,38 @@ func (f *TableFormatter) formatFunctionAlias(w io.Writer, alias *apispec.Functio
 	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", alias.RevisionNumber)})
 	_ = t.Append([]string{"Updated By:", formatOptString(alias.UpdatedBy)})
 	_ = t.Append([]string{"Updated At:", formatTimestamp(alias.UpdatedAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionAliasList(w io.Writer, aliases []apispec.FunctionAlias) error {
+	if len(aliases) == 0 {
+		_, _ = fmt.Fprintln(w, "No function aliases found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"ALIAS", "FUNCTION ID", "REVISION", "REVISION ID", "UPDATED AT"})
+	for _, alias := range aliases {
+		_ = t.Append([]string{
+			alias.Alias,
+			alias.FunctionID,
+			fmt.Sprintf("%d", alias.RevisionNumber),
+			alias.RevisionID,
+			formatTimestamp(alias.UpdatedAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFunctionRuntime(w io.Writer, runtime *apispec.FunctionRuntimeStatus) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Function ID:", runtime.FunctionID})
+	_ = t.Append([]string{"Revision ID:", runtime.RevisionID})
+	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", runtime.RevisionNumber)})
+	_ = t.Append([]string{"State:", string(runtime.State)})
+	_ = t.Append([]string{"Runtime Sandbox ID:", formatOptString(runtime.RuntimeSandboxID)})
+	_ = t.Append([]string{"Runtime Context ID:", formatOptString(runtime.RuntimeContextID)})
+	_ = t.Append([]string{"Runtime Updated At:", formatOptDateTime(runtime.RuntimeUpdatedAt)})
 	return t.Render()
 }
 

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -283,6 +283,7 @@ func TestTableFormatterFormatFunctionList(t *testing.T) {
 			Name:             "API",
 			Slug:             "api",
 			Host:             "api.sandbox0.site",
+			Enabled:          true,
 			ActiveRevisionID: apispec.NewOptString("rev_1"),
 			UpdatedAt:        time.Date(2026, 5, 14, 8, 0, 0, 0, time.UTC),
 		},
@@ -300,8 +301,75 @@ func TestTableFormatterFormatFunctionList(t *testing.T) {
 		"ACTIVE REVISION",
 		"fn_123",
 		"api.sandbox0.site",
+		"true",
 		"rev_1",
 		"2026-05-14 08:00:00",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFunctionAliasList(t *testing.T) {
+	formatter := &TableFormatter{}
+	aliases := []apispec.FunctionAlias{
+		{
+			FunctionID:     "fn_123",
+			Alias:          "production",
+			RevisionID:     "rev_1",
+			RevisionNumber: 1,
+			UpdatedAt:      time.Date(2026, 5, 14, 8, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, aliases); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ALIAS",
+		"FUNCTION ID",
+		"production",
+		"fn_123",
+		"rev_1",
+		"2026-05-14 08:00:00",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFunctionRuntime(t *testing.T) {
+	formatter := &TableFormatter{}
+	runtime := &apispec.FunctionRuntimeStatus{
+		FunctionID:       "fn_123",
+		RevisionID:       "rev_1",
+		RevisionNumber:   1,
+		State:            apispec.FunctionRuntimeStateActive,
+		RuntimeSandboxID: apispec.NewOptString("sb_runtime"),
+		RuntimeContextID: apispec.NewOptString("ctx_runtime"),
+		RuntimeUpdatedAt: apispec.NewOptDateTime(time.Date(2026, 5, 14, 8, 0, 0, 0, time.UTC)),
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, runtime); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Function ID:",
+		"fn_123",
+		"Revision ID:",
+		"rev_1",
+		"State:",
+		"active",
+		"sb_runtime",
+		"ctx_runtime",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)


### PR DESCRIPTION
## Summary
- Add function update/delete commands
- Add revision get, alias list/get, and runtime get/restart/recycle commands
- Format alias lists and runtime status in table output
- Update sdk-go dependency to the function lifecycle API PR branch pseudo-version

Depends on sandbox0-ai/sandbox0#320 and sandbox0-ai/sdk-go#34.

## Tests
- go test ./internal/output -run Function -count=1
- go test ./internal/commands -run '^$' -count=1