### PR TITLE
[codex] Add function autoscaling CLI flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.2-0.20260519212048-4b5a122aafc4
+	github.com/sandbox0-ai/sdk-go v0.4.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.1
+	github.com/sandbox0-ai/sdk-go v0.4.2-0.20260519212048-4b5a122aafc4
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.4.1 h1:5OPfT7ONJATZccWJx/zp+canCmVBSlpCCS3N7V3novI=
-github.com/sandbox0-ai/sdk-go v0.4.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.2-0.20260519212048-4b5a122aafc4 h1:R9Wk94Gz4QttNkTofuwEpGN2A/No/lZ1egmUYRIiN10=
+github.com/sandbox0-ai/sdk-go v0.4.2-0.20260519212048-4b5a122aafc4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.4.2-0.20260519212048-4b5a122aafc4 h1:R9Wk94Gz4QttNkTofuwEpGN2A/No/lZ1egmUYRIiN10=
-github.com/sandbox0-ai/sdk-go v0.4.2-0.20260519212048-4b5a122aafc4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.2 h1:k/akjUnMmJHCjze+RJewLsUGCmR3Afvtl9ehpyZJ1tE=
+github.com/sandbox0-ai/sdk-go v0.4.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/function.go
+++ b/internal/commands/function.go
@@ -9,10 +9,18 @@ import (
 )
 
 var (
-	functionName            string
-	functionUpdateName      string
-	functionUpdateEnabled   bool
-	functionRevisionPromote bool
+	functionName                        string
+	functionMinWarm                     int32
+	functionMaxActive                   int32
+	functionTargetConcurrency           int32
+	functionScaleDownAfterSeconds       int32
+	functionUpdateName                  string
+	functionUpdateEnabled               bool
+	functionUpdateMinWarm               int32
+	functionUpdateMaxActive             int32
+	functionUpdateTargetConcurrency     int32
+	functionUpdateScaleDownAfterSeconds int32
+	functionRevisionPromote             bool
 )
 
 // functionCmd represents the function command.
@@ -83,9 +91,26 @@ var functionCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		opts := make([]sandbox0.FunctionCreateOption, 0, 1)
+		opts := make([]sandbox0.FunctionCreateOption, 0, 2)
 		if functionName != "" {
 			opts = append(opts, sandbox0.WithFunctionName(functionName))
+		}
+		if functionAutoscalingFlagsChanged(cmd) {
+			if err := validateFunctionAutoscalingFlags(
+				functionMinWarm,
+				functionMaxActive,
+				functionTargetConcurrency,
+				functionScaleDownAfterSeconds,
+			); err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating function: %v\n", err)
+				os.Exit(1)
+			}
+			opts = append(opts, sandbox0.WithFunctionAutoscaling(sandbox0.FunctionAutoscaling(
+				functionMinWarm,
+				functionMaxActive,
+				functionTargetConcurrency,
+				functionScaleDownAfterSeconds,
+			)))
 		}
 
 		result, err := client.CreateFunctionFromSandbox(cmd.Context(), args[0], args[1], opts...)
@@ -113,15 +138,32 @@ var functionUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		opts := make([]sandbox0.FunctionUpdateOption, 0, 2)
+		opts := make([]sandbox0.FunctionUpdateOption, 0, 3)
 		if functionUpdateName != "" {
 			opts = append(opts, sandbox0.WithFunctionUpdateName(functionUpdateName))
 		}
 		if cmd.Flags().Changed("enabled") {
 			opts = append(opts, sandbox0.WithFunctionEnabled(functionUpdateEnabled))
 		}
+		if functionAutoscalingFlagsChanged(cmd) {
+			if err := validateFunctionAutoscalingFlags(
+				functionUpdateMinWarm,
+				functionUpdateMaxActive,
+				functionUpdateTargetConcurrency,
+				functionUpdateScaleDownAfterSeconds,
+			); err != nil {
+				fmt.Fprintf(os.Stderr, "Error updating function: %v\n", err)
+				os.Exit(1)
+			}
+			opts = append(opts, sandbox0.WithFunctionUpdateAutoscaling(sandbox0.FunctionAutoscaling(
+				functionUpdateMinWarm,
+				functionUpdateMaxActive,
+				functionUpdateTargetConcurrency,
+				functionUpdateScaleDownAfterSeconds,
+			)))
+		}
 		if len(opts) == 0 {
-			fmt.Fprintln(os.Stderr, "Error updating function: at least one of --name or --enabled is required")
+			fmt.Fprintln(os.Stderr, "Error updating function: at least one of --name, --enabled, --min-warm, --max-active, --target-concurrency, or --scale-down-after-seconds is required")
 			os.Exit(1)
 		}
 
@@ -136,6 +178,27 @@ var functionUpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+func functionAutoscalingFlagsChanged(cmd *cobra.Command) bool {
+	return flagChanged(cmd, "min-warm", "max-active", "target-concurrency", "scale-down-after-seconds")
+}
+
+func validateFunctionAutoscalingFlags(minWarm, maxActive, targetConcurrency, scaleDownAfterSeconds int32) error {
+	switch {
+	case minWarm < 0:
+		return fmt.Errorf("--min-warm must be greater than or equal to 0")
+	case maxActive < 1:
+		return fmt.Errorf("--max-active must be greater than or equal to 1")
+	case targetConcurrency < 1:
+		return fmt.Errorf("--target-concurrency must be greater than or equal to 1")
+	case scaleDownAfterSeconds < 1:
+		return fmt.Errorf("--scale-down-after-seconds must be greater than or equal to 1")
+	case minWarm > maxActive:
+		return fmt.Errorf("--min-warm must be less than or equal to --max-active")
+	default:
+		return nil
+	}
 }
 
 var functionDeleteCmd = &cobra.Command{
@@ -418,8 +481,22 @@ func init() {
 	rootCmd.AddCommand(functionCmd)
 
 	functionCreateCmd.Flags().StringVar(&functionName, "name", "", "function display name")
+	addFunctionAutoscalingFlags(
+		functionCreateCmd,
+		&functionMinWarm,
+		&functionMaxActive,
+		&functionTargetConcurrency,
+		&functionScaleDownAfterSeconds,
+	)
 	functionUpdateCmd.Flags().StringVar(&functionUpdateName, "name", "", "function display name")
 	functionUpdateCmd.Flags().BoolVar(&functionUpdateEnabled, "enabled", true, "whether the function should serve traffic")
+	addFunctionAutoscalingFlags(
+		functionUpdateCmd,
+		&functionUpdateMinWarm,
+		&functionUpdateMaxActive,
+		&functionUpdateTargetConcurrency,
+		&functionUpdateScaleDownAfterSeconds,
+	)
 	functionRevisionCreateCmd.Flags().BoolVar(&functionRevisionPromote, "promote", true, "move the production alias to the new revision")
 
 	functionRevisionCmd.AddCommand(functionRevisionListCmd)
@@ -440,4 +517,11 @@ func init() {
 	functionCmd.AddCommand(functionRevisionCmd)
 	functionCmd.AddCommand(functionAliasCmd)
 	functionCmd.AddCommand(functionRuntimeCmd)
+}
+
+func addFunctionAutoscalingFlags(cmd *cobra.Command, minWarm, maxActive, targetConcurrency, scaleDownAfterSeconds *int32) {
+	cmd.Flags().Int32Var(minWarm, "min-warm", 0, "minimum ready runtime sandboxes to keep after traffic creates capacity")
+	cmd.Flags().Int32Var(maxActive, "max-active", 20, "maximum active runtime sandboxes for the function")
+	cmd.Flags().Int32Var(targetConcurrency, "target-concurrency", 80, "soft in-flight request target per runtime sandbox before scaling out")
+	cmd.Flags().Int32Var(scaleDownAfterSeconds, "scale-down-after-seconds", 300, "idle seconds before removing extra runtime sandboxes")
 }

--- a/internal/commands/function_test.go
+++ b/internal/commands/function_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import "testing"
+
+func TestFunctionCommandsExposeAutoscalingFlags(t *testing.T) {
+	for _, cmd := range []string{"create", "update"} {
+		command := functionCreateCmd
+		if cmd == "update" {
+			command = functionUpdateCmd
+		}
+		for _, flag := range []string{"min-warm", "max-active", "target-concurrency", "scale-down-after-seconds"} {
+			if command.Flags().Lookup(flag) == nil {
+				t.Fatalf("function %s missing --%s flag", cmd, flag)
+			}
+		}
+	}
+}
+
+func TestValidateFunctionAutoscalingFlags(t *testing.T) {
+	tests := []struct {
+		name              string
+		minWarm           int32
+		maxActive         int32
+		targetConcurrency int32
+		scaleDownSeconds  int32
+		wantErr           bool
+	}{
+		{name: "default", minWarm: 0, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 300},
+		{name: "warm pool", minWarm: 2, maxActive: 4, targetConcurrency: 10, scaleDownSeconds: 60},
+		{name: "negative min warm", minWarm: -1, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 300, wantErr: true},
+		{name: "zero max active", minWarm: 0, maxActive: 0, targetConcurrency: 80, scaleDownSeconds: 300, wantErr: true},
+		{name: "zero target concurrency", minWarm: 0, maxActive: 20, targetConcurrency: 0, scaleDownSeconds: 300, wantErr: true},
+		{name: "zero scale down", minWarm: 0, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 0, wantErr: true},
+		{name: "min warm above max active", minWarm: 3, maxActive: 2, targetConcurrency: 80, scaleDownSeconds: 300, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFunctionAutoscalingFlags(tt.minWarm, tt.maxActive, tt.targetConcurrency, tt.scaleDownSeconds)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateFunctionAutoscalingFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add function autoscaling flags to `s0 function create` and `s0 function update`.
- Validate autoscaling flag bounds before sending requests.
- Update sdk-go dependency to the autoscaling SDK branch pseudo-version.

## Validation
- GOTOOLCHAIN=go1.25.0+auto go test ./internal/commands
- GOTOOLCHAIN=go1.25.0+auto go test ./...

Depends on sandbox0-ai/sandbox0#343 and sandbox0-ai/sdk-go#36.
