### PR TITLE
[codex] Align function autoscaling CLI validation

### DIFF
--- a/internal/commands/function.go
+++ b/internal/commands/function.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const minFunctionScaleDownAfterSeconds = 30
+
 var (
 	functionName                        string
 	functionMinWarm                     int32
@@ -192,8 +194,8 @@ func validateFunctionAutoscalingFlags(minWarm, maxActive, targetConcurrency, sca
 		return fmt.Errorf("--max-active must be greater than or equal to 1")
 	case targetConcurrency < 1:
 		return fmt.Errorf("--target-concurrency must be greater than or equal to 1")
-	case scaleDownAfterSeconds < 1:
-		return fmt.Errorf("--scale-down-after-seconds must be greater than or equal to 1")
+	case scaleDownAfterSeconds < minFunctionScaleDownAfterSeconds:
+		return fmt.Errorf("--scale-down-after-seconds must be greater than or equal to %d", minFunctionScaleDownAfterSeconds)
 	case minWarm > maxActive:
 		return fmt.Errorf("--min-warm must be less than or equal to --max-active")
 	default:
@@ -523,5 +525,5 @@ func addFunctionAutoscalingFlags(cmd *cobra.Command, minWarm, maxActive, targetC
 	cmd.Flags().Int32Var(minWarm, "min-warm", 0, "minimum ready runtime sandboxes to keep after traffic creates capacity")
 	cmd.Flags().Int32Var(maxActive, "max-active", 20, "maximum active runtime sandboxes for the function")
 	cmd.Flags().Int32Var(targetConcurrency, "target-concurrency", 80, "soft in-flight request target per runtime sandbox before scaling out")
-	cmd.Flags().Int32Var(scaleDownAfterSeconds, "scale-down-after-seconds", 300, "idle seconds before removing extra runtime sandboxes")
+	cmd.Flags().Int32Var(scaleDownAfterSeconds, "scale-down-after-seconds", 300, "idle seconds before removing extra runtime sandboxes; minimum 30")
 }

--- a/internal/commands/function_test.go
+++ b/internal/commands/function_test.go
@@ -27,10 +27,12 @@ func TestValidateFunctionAutoscalingFlags(t *testing.T) {
 	}{
 		{name: "default", minWarm: 0, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 300},
 		{name: "warm pool", minWarm: 2, maxActive: 4, targetConcurrency: 10, scaleDownSeconds: 60},
+		{name: "minimum scale down", minWarm: 0, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 30},
 		{name: "negative min warm", minWarm: -1, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 300, wantErr: true},
 		{name: "zero max active", minWarm: 0, maxActive: 0, targetConcurrency: 80, scaleDownSeconds: 300, wantErr: true},
 		{name: "zero target concurrency", minWarm: 0, maxActive: 20, targetConcurrency: 0, scaleDownSeconds: 300, wantErr: true},
 		{name: "zero scale down", minWarm: 0, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 0, wantErr: true},
+		{name: "below minimum scale down", minWarm: 0, maxActive: 20, targetConcurrency: 80, scaleDownSeconds: 29, wantErr: true},
 		{name: "min warm above max active", minWarm: 3, maxActive: 2, targetConcurrency: 80, scaleDownSeconds: 300, wantErr: true},
 	}
 


### PR DESCRIPTION
## Summary
- align --scale-down-after-seconds validation with the API minimum of 30 seconds
- update CLI flag help text to mention the minimum
- cover the 29/30 second boundary in command tests

## Validation
- GOTOOLCHAIN=go1.25.0+auto go test ./internal/commands
- GOTOOLCHAIN=go1.25.0+auto go test ./...