### PR TITLE
[codex] add protocol rules to sandbox network cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.2
+	github.com/sandbox0-ai/sdk-go v0.4.3-0.20260521182146-fd7cd3392a28
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.3-0.20260521182146-fd7cd3392a28
+	github.com/sandbox0-ai/sdk-go v0.4.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.4.2 h1:k/akjUnMmJHCjze+RJewLsUGCmR3Afvtl9ehpyZJ1tE=
-github.com/sandbox0-ai/sdk-go v0.4.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.4.3-0.20260521182146-fd7cd3392a28 h1:ooXQfVOCULl77Tz1mRoQijYp4dRnhJ8TMgF5Y1OfOkg=
-github.com/sandbox0-ai/sdk-go v0.4.3-0.20260521182146-fd7cd3392a28/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.3 h1:hf53T++UHs+AQu4FhB8/p3uIMxbwX3Lrii1v8gU6efg=
+github.com/sandbox0-ai/sdk-go v0.4.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.4.2 h1:k/akjUnMmJHCjze+RJewLsUGCmR3Afvtl9ehpyZJ1tE=
 github.com/sandbox0-ai/sdk-go v0.4.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.3-0.20260521182146-fd7cd3392a28 h1:ooXQfVOCULl77Tz1mRoQijYp4dRnhJ8TMgF5Y1OfOkg=
+github.com/sandbox0-ai/sdk-go v0.4.3-0.20260521182146-fd7cd3392a28/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_network.go
+++ b/internal/commands/sandbox_network.go
@@ -24,6 +24,7 @@ var (
 	networkDeniedDomains   []string
 	networkDeniedPorts     []string
 	networkTrafficRules    []string
+	networkProtocolRules   []string
 	networkCredentialRules []string
 	networkCredentialBinds []string
 	networkProxy           string
@@ -41,6 +42,7 @@ type networkUpdateOptions struct {
 	DeniedDomains   []string
 	DeniedPorts     []string
 	TrafficRules    []string
+	ProtocolRules   []string
 	CredentialRules []string
 	CredentialBinds []string
 	Proxy           string
@@ -102,6 +104,7 @@ var sandboxNetworkUpdateCmd = &cobra.Command{
 			DeniedDomains:   networkDeniedDomains,
 			DeniedPorts:     networkDeniedPorts,
 			TrafficRules:    networkTrafficRules,
+			ProtocolRules:   networkProtocolRules,
 			CredentialRules: networkCredentialRules,
 			CredentialBinds: networkCredentialBinds,
 			Proxy:           networkProxy,
@@ -155,6 +158,10 @@ func buildNetworkPolicyFromUpdateOptions(opts networkUpdateOptions) (*apispec.Sa
 	if err != nil {
 		return nil, err
 	}
+	protocolRules, err := parseNetworkObjects[apispec.ProtocolRule](opts.ProtocolRules, "--protocol-rule")
+	if err != nil {
+		return nil, err
+	}
 	credentialRules, err := parseNetworkObjects[apispec.EgressCredentialRule](opts.CredentialRules, "--credential-rule")
 	if err != nil {
 		return nil, err
@@ -182,7 +189,7 @@ func buildNetworkPolicyFromUpdateOptions(opts networkUpdateOptions) (*apispec.Sa
 		Mode: apispec.SandboxNetworkPolicyMode(mode),
 	}
 
-	if hasAnyNetworkEgressInputs(opts, allowedPorts, deniedPorts, trafficRules, credentialRules, proxySet) {
+	if hasAnyNetworkEgressInputs(opts, allowedPorts, deniedPorts, trafficRules, protocolRules, credentialRules, proxySet) {
 		egress := apispec.NetworkEgressPolicy{
 			AllowedCidrs:    opts.AllowedCidrs,
 			AllowedDomains:  opts.AllowedDomains,
@@ -191,6 +198,7 @@ func buildNetworkPolicyFromUpdateOptions(opts networkUpdateOptions) (*apispec.Sa
 			DeniedDomains:   opts.DeniedDomains,
 			DeniedPorts:     deniedPorts,
 			TrafficRules:    trafficRules,
+			ProtocolRules:   protocolRules,
 			CredentialRules: credentialRules,
 		}
 		if proxySet {
@@ -218,6 +226,7 @@ func hasNetworkNonFileInputs(opts networkUpdateOptions) bool {
 		len(opts.DeniedDomains) > 0 ||
 		len(opts.DeniedPorts) > 0 ||
 		len(opts.TrafficRules) > 0 ||
+		len(opts.ProtocolRules) > 0 ||
 		len(opts.CredentialRules) > 0 ||
 		len(opts.CredentialBinds) > 0 ||
 		strings.TrimSpace(opts.Proxy) != "" ||
@@ -239,6 +248,7 @@ func hasAnyNetworkEgressInputs(
 	allowedPorts []apispec.PortSpec,
 	deniedPorts []apispec.PortSpec,
 	trafficRules []apispec.TrafficRule,
+	protocolRules []apispec.ProtocolRule,
 	credentialRules []apispec.EgressCredentialRule,
 	proxySet bool,
 ) bool {
@@ -249,6 +259,7 @@ func hasAnyNetworkEgressInputs(
 		len(opts.DeniedDomains) > 0 ||
 		len(deniedPorts) > 0 ||
 		len(trafficRules) > 0 ||
+		len(protocolRules) > 0 ||
 		len(credentialRules) > 0 ||
 		proxySet
 }
@@ -499,6 +510,7 @@ func init() {
 	sandboxNetworkUpdateCmd.Flags().StringArrayVar(&networkDeniedDomains, "deny-domain", nil, "denied domain (can be repeated)")
 	sandboxNetworkUpdateCmd.Flags().StringArrayVar(&networkDeniedPorts, "deny-port", nil, "denied port spec: <port>[/tcp|udp] or <start>-<end>[/tcp|udp] (can be repeated)")
 	sandboxNetworkUpdateCmd.Flags().StringArrayVar(&networkTrafficRules, "traffic-rule", nil, "traffic rule object as JSON/YAML (can be repeated)")
+	sandboxNetworkUpdateCmd.Flags().StringArrayVar(&networkProtocolRules, "protocol-rule", nil, "protocol rule object as JSON/YAML (can be repeated)")
 	sandboxNetworkUpdateCmd.Flags().StringArrayVar(&networkCredentialRules, "credential-rule", nil, "credential rule object as JSON/YAML (can be repeated)")
 	sandboxNetworkUpdateCmd.Flags().StringArrayVar(&networkCredentialBinds, "credential-binding", nil, "credential binding object as JSON/YAML (can be repeated)")
 	sandboxNetworkUpdateCmd.Flags().StringVar(&networkProxy, "proxy", "", "SOCKS5 egress proxy endpoint: socks5://host:port or host:port")

--- a/internal/commands/sandbox_network_test.go
+++ b/internal/commands/sandbox_network_test.go
@@ -88,6 +88,9 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 			TrafficRules: []string{
 				`{"name":"allow-ssh","action":"allow","appProtocols":["ssh"],"ports":[{"port":22,"protocol":"tcp"}]}`,
 			},
+			ProtocolRules: []string{
+				`{"name":"docs-mcp","protocol":"mcp","domains":["mcp.example.com"],"ports":[{"port":443,"protocol":"tcp"}],"tlsMode":"terminate-reoriginate","httpMatch":{"methods":["POST"],"paths":["/mcp"]},"mcp":{"tools":{"allowed":["read_file"],"denied":["run_command"]}}}`,
+			},
 			CredentialBinds: []string{
 				`{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{token}}"}]}}}`,
 			},
@@ -104,6 +107,20 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 		}
 		if len(egress.TrafficRules) != 1 {
 			t.Fatalf("trafficRules count = %d, want 1", len(egress.TrafficRules))
+		}
+		if len(egress.ProtocolRules) != 1 {
+			t.Fatalf("protocolRules count = %d, want 1", len(egress.ProtocolRules))
+		}
+		if egress.ProtocolRules[0].Protocol != apispec.ProtocolRuleProtocolMcp {
+			t.Fatalf("protocol rule protocol = %q, want mcp", egress.ProtocolRules[0].Protocol)
+		}
+		mcp, ok := egress.ProtocolRules[0].Mcp.Get()
+		if !ok {
+			t.Fatal("mcp policy not set")
+		}
+		tools, ok := mcp.Tools.Get()
+		if !ok || len(tools.Allowed) != 1 || tools.Allowed[0] != "read_file" {
+			t.Fatalf("mcp tools = %#v, want read_file allowed", mcp.Tools)
 		}
 		if len(egress.CredentialRules) != 1 {
 			t.Fatalf("credentialRules count = %d, want 1", len(egress.CredentialRules))
@@ -236,6 +253,21 @@ egress:
       ports:
         - port: 22
           protocol: tcp
+  protocolRules:
+    - name: docs-mcp
+      protocol: mcp
+      domains: [mcp.example.com]
+      ports:
+        - port: 443
+          protocol: tcp
+      tlsMode: terminate-reoriginate
+      httpMatch:
+        methods: [POST]
+        paths: [/mcp]
+      mcp:
+        tools:
+          allowed: [read_file]
+          denied: [run_command]
   credentialRules:
     - name: github-auth
       credentialRef: gh-token
@@ -266,6 +298,9 @@ credentialBindings:
 	}
 	if len(egress.TrafficRules) != 1 {
 		t.Fatalf("trafficRules count = %d, want 1", len(egress.TrafficRules))
+	}
+	if len(egress.ProtocolRules) != 1 {
+		t.Fatalf("protocolRules count = %d, want 1", len(egress.ProtocolRules))
 	}
 	if len(egress.CredentialRules) != 1 {
 		t.Fatalf("credentialRules count = %d, want 1", len(egress.CredentialRules))

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -675,6 +675,9 @@ func (f *TableFormatter) formatSandboxNetworkPolicy(w io.Writer, policy *apispec
 		if len(egress.TrafficRules) > 0 {
 			_ = t.Append([]string{"Traffic Rules:", fmt.Sprintf("%d", len(egress.TrafficRules))})
 		}
+		if len(egress.ProtocolRules) > 0 {
+			_ = t.Append([]string{"Protocol Rules:", fmt.Sprintf("%d", len(egress.ProtocolRules))})
+		}
 		if len(egress.CredentialRules) > 0 {
 			_ = t.Append([]string{"Credential Rules:", fmt.Sprintf("%d", len(egress.CredentialRules))})
 		}


### PR DESCRIPTION
## Summary
- add `s0 sandbox network update --protocol-rule` for JSON/YAML protocol rule objects
- show protocol rule counts in network table output
- update the Go SDK dependency to the protocol-rule branch pseudo-version for this integration PR

## Validation
- `GOWORK=off go test ./...`

## Notes
- Replace the SDK pseudo-version with the released SDK tag before final merge if the SDK release flow requires it.
