### PR TITLE
Add revision spec function CLI support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.3
+	github.com/sandbox0-ai/sdk-go v0.4.4-0.20260521200322-cee9ba0d7954
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.4.4-0.20260521200322-cee9ba0d7954
+	github.com/sandbox0-ai/sdk-go v0.4.4
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.4.4-0.20260521200322-cee9ba0d7954 h1:RAz92T9lUijdcgxpbfw4OAM9k/9VGAaDI4heof+6hM4=
-github.com/sandbox0-ai/sdk-go v0.4.4-0.20260521200322-cee9ba0d7954/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.4 h1:J8MlG4OmntkAJCOm2JSJJFiD5Aw+3JqarSjOw6+9REU=
+github.com/sandbox0-ai/sdk-go v0.4.4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.4.3 h1:hf53T++UHs+AQu4FhB8/p3uIMxbwX3Lrii1v8gU6efg=
-github.com/sandbox0-ai/sdk-go v0.4.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.4.4-0.20260521200322-cee9ba0d7954 h1:RAz92T9lUijdcgxpbfw4OAM9k/9VGAaDI4heof+6hM4=
+github.com/sandbox0-ai/sdk-go v0.4.4-0.20260521200322-cee9ba0d7954/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/function.go
+++ b/internal/commands/function.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ghodss/yaml"
 	sandbox0 "github.com/sandbox0-ai/sdk-go"
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +18,7 @@ var (
 	functionMaxActive                   int32
 	functionTargetConcurrency           int32
 	functionScaleDownAfterSeconds       int32
+	functionSpecFile                    string
 	functionUpdateName                  string
 	functionUpdateEnabled               bool
 	functionUpdateMinWarm               int32
@@ -23,6 +26,7 @@ var (
 	functionUpdateTargetConcurrency     int32
 	functionUpdateScaleDownAfterSeconds int32
 	functionRevisionPromote             bool
+	functionRevisionSpecFile            string
 )
 
 // functionCmd represents the function command.
@@ -82,10 +86,10 @@ var functionGetCmd = &cobra.Command{
 }
 
 var functionCreateCmd = &cobra.Command{
-	Use:   "create <sandbox-id> <service-id>",
-	Short: "Create a function from a sandbox service",
-	Long:  `Create a function from an existing publishable sandbox service.`,
-	Args:  cobra.ExactArgs(2),
+	Use:   "create [sandbox-id] [service-id]",
+	Short: "Create a function",
+	Long:  `Create a function from an existing publishable sandbox service or a revision spec file.`,
+	Args:  validateFunctionCreateArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := getClientRaw(cmd)
 		if err != nil {
@@ -115,7 +119,17 @@ var functionCreateCmd = &cobra.Command{
 			)))
 		}
 
-		result, err := client.CreateFunctionFromSandbox(cmd.Context(), args[0], args[1], opts...)
+		var result *sandbox0.FunctionCreateResult
+		if functionSpecFile != "" {
+			spec, err := readFunctionRevisionSpecFile(functionSpecFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating function: %v\n", err)
+				os.Exit(1)
+			}
+			result, err = client.CreateFunctionFromRevisionSpec(cmd.Context(), spec, opts...)
+		} else {
+			result, err = client.CreateFunctionFromSandbox(cmd.Context(), args[0], args[1], opts...)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating function: %v\n", err)
 			os.Exit(1)
@@ -126,6 +140,16 @@ var functionCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+func validateFunctionCreateArgs(cmd *cobra.Command, args []string) error {
+	if functionSpecFile != "" {
+		if len(args) != 0 {
+			return fmt.Errorf("when --spec-file is set, create expects no sandbox service arguments")
+		}
+		return nil
+	}
+	return cobra.ExactArgs(2)(cmd, args)
 }
 
 var functionUpdateCmd = &cobra.Command{
@@ -286,10 +310,10 @@ var functionRevisionGetCmd = &cobra.Command{
 }
 
 var functionRevisionCreateCmd = &cobra.Command{
-	Use:   "create <function-id-or-slug> <sandbox-id> <service-id>",
+	Use:   "create <function-id-or-slug> [sandbox-id] [service-id]",
 	Short: "Create a function revision",
-	Long:  `Create a new function revision from an existing publishable sandbox service.`,
-	Args:  cobra.ExactArgs(3),
+	Long:  `Create a new function revision from an existing publishable sandbox service or a revision spec file.`,
+	Args:  validateFunctionRevisionCreateArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := getClientRaw(cmd)
 		if err != nil {
@@ -297,13 +321,28 @@ var functionRevisionCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		result, err := client.CreateFunctionRevisionFromSandbox(
-			cmd.Context(),
-			args[0],
-			args[1],
-			args[2],
-			sandbox0.WithFunctionRevisionPromote(functionRevisionPromote),
-		)
+		var result *sandbox0.FunctionRevisionCreateResult
+		if functionRevisionSpecFile != "" {
+			spec, err := readFunctionRevisionSpecFile(functionRevisionSpecFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating function revision: %v\n", err)
+				os.Exit(1)
+			}
+			result, err = client.CreateFunctionRevisionFromSpec(
+				cmd.Context(),
+				args[0],
+				spec,
+				sandbox0.WithFunctionRevisionPromote(functionRevisionPromote),
+			)
+		} else {
+			result, err = client.CreateFunctionRevisionFromSandbox(
+				cmd.Context(),
+				args[0],
+				args[1],
+				args[2],
+				sandbox0.WithFunctionRevisionPromote(functionRevisionPromote),
+			)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating function revision: %v\n", err)
 			os.Exit(1)
@@ -314,6 +353,35 @@ var functionRevisionCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+func validateFunctionRevisionCreateArgs(cmd *cobra.Command, args []string) error {
+	if functionRevisionSpecFile != "" {
+		if len(args) != 1 {
+			return fmt.Errorf("when --spec-file is set, revision create expects only <function-id-or-slug>")
+		}
+		return nil
+	}
+	return cobra.ExactArgs(3)(cmd, args)
+}
+
+func readFunctionRevisionSpecFile(path string) (apispec.FunctionRevisionSpec, error) {
+	if path == "" {
+		return apispec.FunctionRevisionSpec{}, fmt.Errorf("spec file path is required")
+	}
+	data, err := readConfigFile(path)
+	if err != nil {
+		return apispec.FunctionRevisionSpec{}, err
+	}
+	return parseFunctionRevisionSpec(data)
+}
+
+func parseFunctionRevisionSpec(data []byte) (apispec.FunctionRevisionSpec, error) {
+	var spec apispec.FunctionRevisionSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return apispec.FunctionRevisionSpec{}, fmt.Errorf("parse function revision spec file: %w", err)
+	}
+	return spec, nil
 }
 
 var functionAliasCmd = &cobra.Command{
@@ -483,6 +551,7 @@ func init() {
 	rootCmd.AddCommand(functionCmd)
 
 	functionCreateCmd.Flags().StringVar(&functionName, "name", "", "function display name")
+	functionCreateCmd.Flags().StringVar(&functionSpecFile, "spec-file", "", "revision spec YAML or JSON file")
 	addFunctionAutoscalingFlags(
 		functionCreateCmd,
 		&functionMinWarm,
@@ -500,6 +569,7 @@ func init() {
 		&functionUpdateScaleDownAfterSeconds,
 	)
 	functionRevisionCreateCmd.Flags().BoolVar(&functionRevisionPromote, "promote", true, "move the production alias to the new revision")
+	functionRevisionCreateCmd.Flags().StringVar(&functionRevisionSpecFile, "spec-file", "", "revision spec YAML or JSON file")
 
 	functionRevisionCmd.AddCommand(functionRevisionListCmd)
 	functionRevisionCmd.AddCommand(functionRevisionGetCmd)

--- a/internal/commands/function_test.go
+++ b/internal/commands/function_test.go
@@ -1,6 +1,10 @@
 package commands
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
 
 func TestFunctionCommandsExposeAutoscalingFlags(t *testing.T) {
 	for _, cmd := range []string{"create", "update"} {
@@ -13,6 +17,15 @@ func TestFunctionCommandsExposeAutoscalingFlags(t *testing.T) {
 				t.Fatalf("function %s missing --%s flag", cmd, flag)
 			}
 		}
+	}
+}
+
+func TestFunctionCommandsExposeSpecFileFlags(t *testing.T) {
+	if functionCreateCmd.Flags().Lookup("spec-file") == nil {
+		t.Fatal("function create missing --spec-file flag")
+	}
+	if functionRevisionCreateCmd.Flags().Lookup("spec-file") == nil {
+		t.Fatal("function revision create missing --spec-file flag")
 	}
 }
 
@@ -43,5 +56,38 @@ func TestValidateFunctionAutoscalingFlags(t *testing.T) {
 				t.Fatalf("validateFunctionAutoscalingFlags() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestParseFunctionRevisionSpec(t *testing.T) {
+	spec, err := parseFunctionRevisionSpec([]byte(`
+template_id: default
+runtime_service:
+  id: web
+  port: 8080
+  ingress:
+    public: true
+  runtime:
+    type: warm_process
+mounts:
+  - mount_point: /data
+    source:
+      type: sandbox_volume
+      sandboxvolume_id: sv_123
+`))
+	if err != nil {
+		t.Fatalf("parseFunctionRevisionSpec() error = %v", err)
+	}
+	if spec.TemplateID != "default" {
+		t.Fatalf("template id = %q, want default", spec.TemplateID)
+	}
+	if spec.RuntimeService.ID != "web" || spec.RuntimeService.Port != 8080 {
+		t.Fatalf("runtime service = %#v, want web:8080", spec.RuntimeService)
+	}
+	if len(spec.Mounts) != 1 {
+		t.Fatalf("mounts count = %d, want 1", len(spec.Mounts))
+	}
+	if spec.Mounts[0].Source.Type != apispec.FunctionRevisionMountSourceTypeSandboxVolume {
+		t.Fatalf("mount source type = %q, want sandbox_volume", spec.Mounts[0].Source.Type)
 	}
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -846,8 +846,8 @@ func (f *TableFormatter) formatFunctionRevisionList(w io.Writer, revisions []api
 			fmt.Sprintf("%d", revision.RevisionNumber),
 			revision.ID,
 			formatFunctionRevisionSource(revision),
-			fmt.Sprintf("%d", revision.ServiceSnapshot.Port),
-			formatFunctionServiceRuntime(revision.ServiceSnapshot),
+			formatFunctionRevisionPort(revision),
+			formatFunctionRevisionRuntime(revision),
 			formatOptString(revision.RuntimeSandboxID),
 			formatTimestamp(revision.CreatedAt),
 		})
@@ -861,11 +861,13 @@ func (f *TableFormatter) formatFunctionRevision(w io.Writer, revision *apispec.F
 	_ = t.Append([]string{"Function ID:", revision.FunctionID})
 	_ = t.Append([]string{"Team ID:", revision.TeamID})
 	_ = t.Append([]string{"Revision Number:", fmt.Sprintf("%d", revision.RevisionNumber)})
-	_ = t.Append([]string{"Source Sandbox ID:", revision.SourceSandboxID})
-	_ = t.Append([]string{"Source Service ID:", revision.SourceServiceID})
-	_ = t.Append([]string{"Source Template ID:", revision.SourceTemplateID})
-	_ = t.Append([]string{"Service Port:", fmt.Sprintf("%d", revision.ServiceSnapshot.Port)})
-	_ = t.Append([]string{"Service Runtime:", formatFunctionServiceRuntime(revision.ServiceSnapshot)})
+	_ = t.Append([]string{"Source Type:", formatFunctionRevisionSourceType(revision.SourceType)})
+	_ = t.Append([]string{"Source Sandbox ID:", formatOptString(revision.SourceSandboxID)})
+	_ = t.Append([]string{"Source Service ID:", formatOptString(revision.SourceServiceID)})
+	_ = t.Append([]string{"Source Template ID:", formatOptString(revision.SourceTemplateID)})
+	_ = t.Append([]string{"Revision Template ID:", valueOrDash(revision.RevisionSpec.TemplateID)})
+	_ = t.Append([]string{"Service Port:", formatFunctionRevisionPort(*revision)})
+	_ = t.Append([]string{"Service Runtime:", formatFunctionRevisionRuntime(*revision)})
 	_ = t.Append([]string{"Runtime Sandbox ID:", formatOptString(revision.RuntimeSandboxID)})
 	_ = t.Append([]string{"Runtime Context ID:", formatOptString(revision.RuntimeContextID)})
 	_ = t.Append([]string{"Runtime Updated At:", formatOptDateTime(revision.RuntimeUpdatedAt)})
@@ -930,7 +932,43 @@ func (f *TableFormatter) formatFunctionRuntime(w io.Writer, runtime *apispec.Fun
 }
 
 func formatFunctionRevisionSource(revision apispec.FunctionRevision) string {
-	return fmt.Sprintf("%s/%s", valueOrDash(revision.SourceSandboxID), valueOrDash(revision.SourceServiceID))
+	if revision.SourceType == apispec.FunctionRevisionSourceTypeRevisionSpec {
+		return fmt.Sprintf("revision_spec/%s", valueOrDash(revision.RevisionSpec.TemplateID))
+	}
+	return fmt.Sprintf("%s/%s", formatOptString(revision.SourceSandboxID), formatOptString(revision.SourceServiceID))
+}
+
+func formatFunctionRevisionSourceType(sourceType apispec.FunctionRevisionSourceType) string {
+	if sourceType == "" {
+		return "-"
+	}
+	return string(sourceType)
+}
+
+func formatFunctionRevisionPort(revision apispec.FunctionRevision) string {
+	service, ok := functionRevisionService(revision)
+	if !ok || service.Port == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", service.Port)
+}
+
+func formatFunctionRevisionRuntime(revision apispec.FunctionRevision) string {
+	service, ok := functionRevisionService(revision)
+	if !ok {
+		return "-"
+	}
+	return formatFunctionServiceRuntime(service)
+}
+
+func functionRevisionService(revision apispec.FunctionRevision) (apispec.SandboxAppService, bool) {
+	if service, ok := revision.ServiceSnapshot.Get(); ok {
+		return service, true
+	}
+	if revision.RevisionSpec.RuntimeService.ID != "" || revision.RevisionSpec.RuntimeService.Port != 0 {
+		return revision.RevisionSpec.RuntimeService, true
+	}
+	return apispec.SandboxAppService{}, false
 }
 
 func formatFunctionServiceRuntime(service apispec.SandboxAppService) string {

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -421,14 +421,18 @@ func TestTableFormatterFormatFunctionRevisionList(t *testing.T) {
 		{
 			ID:              "rev_1",
 			RevisionNumber:  1,
-			SourceSandboxID: "sb_123",
-			SourceServiceID: "web",
-			ServiceSnapshot: apispec.SandboxAppService{
+			SourceType:      apispec.FunctionRevisionSourceTypeSandboxService,
+			SourceSandboxID: apispec.NewOptString("sb_123"),
+			SourceServiceID: apispec.NewOptString("web"),
+			RevisionSpec: apispec.FunctionRevisionSpec{
+				TemplateID: "default",
+			},
+			ServiceSnapshot: apispec.NewOptSandboxAppService(apispec.SandboxAppService{
 				Port: 8080,
 				Runtime: apispec.NewOptSandboxAppServiceRuntime(apispec.SandboxAppServiceRuntime{
 					Type: apispec.SandboxAppServiceRuntimeTypeWarmProcess,
 				}),
-			},
+			}),
 			CreatedAt: time.Date(2026, 5, 14, 8, 0, 0, 0, time.UTC),
 		},
 	}


### PR DESCRIPTION
Adds s0 function create/revision create --spec-file support for revision-spec function sources and updates table output for the new revision model. Depends on the sdk-go function revision spec update.\n\nValidation:\n- go test ./...\n- go build ./...\n- git diff --check