### PR TITLE
Show sandbox service public URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.5.0
+	github.com/sandbox0-ai/sdk-go v0.5.2-0.20260525202204-d9a45a7d7d3e
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.5.2-0.20260525202204-d9a45a7d7d3e
+	github.com/sandbox0-ai/sdk-go v0.5.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.5.0 h1:Iiz525j+I/ctbAb9Xan356e14amkd5jA0svilGbxr+8=
-github.com/sandbox0-ai/sdk-go v0.5.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.5.2-0.20260525202204-d9a45a7d7d3e h1:SlOco+JxaTXPIHNCFMCnrCDtWxUdJx0lhCNOBj0PjbM=
-github.com/sandbox0-ai/sdk-go v0.5.2-0.20260525202204-d9a45a7d7d3e/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.5.2 h1:ZvY2kSXIPpjt+mSEY0f2nVNHph7WURDxWiW6OfGxTLQ=
+github.com/sandbox0-ai/sdk-go v0.5.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.5.0 h1:Iiz525j+I/ctbAb9Xan356e14amkd5jA0svilGbxr+8=
 github.com/sandbox0-ai/sdk-go v0.5.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.5.2-0.20260525202204-d9a45a7d7d3e h1:SlOco+JxaTXPIHNCFMCnrCDtWxUdJx0lhCNOBj0PjbM=
+github.com/sandbox0-ai/sdk-go v0.5.2-0.20260525202204-d9a45a7d7d3e/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -672,7 +672,7 @@ func (f *TableFormatter) formatSandboxServices(w io.Writer, resp *sandbox0.Sandb
 	}
 
 	t := newTable(w)
-	t.Header([]string{"SERVICE", "PORT", "PUBLIC", "ROUTE", "PATH", "METHODS", "AUTH", "RATE LIMIT", "TIMEOUT", "RESUME", "PUBLISHABLE"})
+	t.Header([]string{"SERVICE", "PORT", "PUBLIC", "URL", "ROUTE", "PATH", "METHODS", "AUTH", "RATE LIMIT", "TIMEOUT", "RESUME", "PUBLISHABLE"})
 	for _, service := range resp.Services {
 		routes := service.Ingress.Routes
 		if len(routes) == 0 {
@@ -680,6 +680,7 @@ func (f *TableFormatter) formatSandboxServices(w io.Writer, resp *sandbox0.Sandb
 				service.ID,
 				fmt.Sprintf("%d", service.Port),
 				fmt.Sprintf("%v", service.Ingress.Public),
+				service.PublicURL.Or("-"),
 				"-",
 				"-",
 				"-",
@@ -696,6 +697,7 @@ func (f *TableFormatter) formatSandboxServices(w io.Writer, resp *sandbox0.Sandb
 				service.ID,
 				fmt.Sprintf("%d", service.Port),
 				fmt.Sprintf("%v", service.Ingress.Public),
+				service.PublicURL.Or("-"),
 				route.ID,
 				route.PathPrefix.Or("/"),
 				formatGatewayMethods(route.Methods),

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
 )
 
@@ -193,6 +194,46 @@ func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 		"30222",
 		"SSH Username:",
 		"sb_123",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatSandboxServicesIncludesPublicURL(t *testing.T) {
+	formatter := &TableFormatter{}
+	services := &sandbox0.SandboxServicesResponse{
+		SandboxID: "rs-default-api-abcde",
+		Services: []apispec.SandboxAppServiceView{
+			{
+				ID:   "api",
+				Port: 8080,
+				Ingress: apispec.SandboxAppServiceIngress{
+					Public: true,
+					Routes: []apispec.SandboxAppServiceRoute{
+						{
+							ID:         "api",
+							PathPrefix: apispec.NewOptString("/"),
+							Resume:     true,
+						},
+					},
+				},
+				Publishable: true,
+				PublicURL:   apispec.NewOptString("https://rs-default-api-abcde--p8080.us.sandbox0.app"),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, services); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"URL",
+		"https://rs-default-api-abcde--p8080.us.sandbox0.app",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)


### PR DESCRIPTION
## Summary
- bump sdk-go to the public_url branch pseudo-version
- show sandbox service PublicURL in the service table output
- add table coverage for the URL column

## Tests
- GOTOOLCHAIN=go1.25.0+auto go test ./internal/output

Depends on sandbox0-ai/sdk-go#43. Replace the pseudo-version with the release tag after sdk-go is released.