### PR TITLE
Add sandbox function command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.5.2
+	github.com/sandbox0-ai/sdk-go v0.5.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.5.2 h1:ZvY2kSXIPpjt+mSEY0f2nVNHph7WURDxWiW6OfGxTLQ=
-github.com/sandbox0-ai/sdk-go v0.5.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.5.3 h1:ng33noTv5RNxw3vmEm/e0BM07pZmWaH/PkLnMPmrtu4=
+github.com/sandbox0-ai/sdk-go v0.5.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_function.go
+++ b/internal/commands/sandbox_function.go
@@ -1,0 +1,178 @@
+package commands
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	functionSandboxID  string
+	functionMethod     string
+	functionPath       string
+	functionHandler    string
+	functionHeader     []string
+	functionQuery      []string
+	functionBodyStdin  bool
+	functionBodyData   string
+	functionBodyBase64 string
+	functionTimeoutMS  int32
+)
+
+// sandboxFunctionCmd represents the sandbox function command group.
+var sandboxFunctionCmd = &cobra.Command{
+	Use:   "function",
+	Short: "Invoke sandbox functions",
+	Long:  `Invoke functions stored under /workspace/functions inside a sandbox.`,
+}
+
+// sandboxFunctionInvokeCmd invokes a sandbox function.
+var sandboxFunctionInvokeCmd = &cobra.Command{
+	Use:   "invoke <name>",
+	Short: "Invoke a sandbox function",
+	Long:  `Invoke /workspace/functions/<name>.py with the Python function runtime.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		req, err := buildFunctionInvokeRequest()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error building function request: %v\n", err)
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		resp, err := client.Sandbox(functionSandboxID).InvokeFunction(cmd.Context(), args[0], req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error invoking function: %v\n", err)
+			os.Exit(1)
+		}
+
+		if cfgFormat == "json" || cfgFormat == "yaml" {
+			if err := getFormatter().Format(os.Stdout, resp); err != nil {
+				fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+				os.Exit(1)
+			}
+			if resp.Status >= 400 {
+				os.Exit(1)
+			}
+			return
+		}
+
+		if bodyBase64, ok := resp.BodyBase64.Get(); ok && bodyBase64 != "" {
+			body, err := base64.StdEncoding.DecodeString(bodyBase64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error decoding function response body: %v\n", err)
+				os.Exit(1)
+			}
+			if _, err := os.Stdout.Write(body); err != nil {
+				fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Printf("Function returned status %d\n", resp.Status)
+		}
+		if resp.Status >= 400 {
+			os.Exit(1)
+		}
+	},
+}
+
+func buildFunctionInvokeRequest() (apispec.FunctionInvokeRequest, error) {
+	req := apispec.FunctionInvokeRequest{}
+	if functionMethod != "" {
+		req.Method = apispec.NewOptString(functionMethod)
+	}
+	if functionPath != "" {
+		req.Path = apispec.NewOptString(functionPath)
+	}
+	if functionHandler != "" {
+		req.Handler = apispec.NewOptString(functionHandler)
+	}
+	if functionTimeoutMS < 0 {
+		return req, fmt.Errorf("--timeout-ms must be >= 0")
+	}
+	if functionTimeoutMS > 0 {
+		req.TimeoutMs = apispec.NewOptInt32(functionTimeoutMS)
+	}
+	if len(functionHeader) > 0 {
+		headers, err := parseFunctionFields(functionHeader)
+		if err != nil {
+			return req, err
+		}
+		req.Headers = apispec.NewOptFunctionInvokeRequestHeaders(apispec.FunctionInvokeRequestHeaders(headers))
+	}
+	if len(functionQuery) > 0 {
+		query, err := parseFunctionFields(functionQuery)
+		if err != nil {
+			return req, err
+		}
+		req.Query = apispec.NewOptFunctionInvokeRequestQuery(apispec.FunctionInvokeRequestQuery(query))
+	}
+	bodyBase64, err := buildFunctionBodyBase64()
+	if err != nil {
+		return req, err
+	}
+	if bodyBase64 != "" {
+		req.BodyBase64 = apispec.NewOptString(bodyBase64)
+	}
+	return req, nil
+}
+
+func buildFunctionBodyBase64() (string, error) {
+	if functionBodyBase64 != "" {
+		if functionBodyStdin || functionBodyData != "" {
+			return "", fmt.Errorf("--body-base64 cannot be combined with --stdin or --body")
+		}
+		if _, err := base64.StdEncoding.DecodeString(functionBodyBase64); err != nil {
+			return "", fmt.Errorf("--body-base64 must be valid base64: %w", err)
+		}
+		return functionBodyBase64, nil
+	}
+	if !functionBodyStdin && functionBodyData == "" {
+		return "", nil
+	}
+	body, err := readCommandContent(functionBodyStdin, functionBodyData, os.Stdin)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(body), nil
+}
+
+func parseFunctionFields(values []string) (map[string][]string, error) {
+	out := make(map[string][]string, len(values))
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("invalid field %q, expected KEY=VALUE", value)
+		}
+		out[key] = append(out[key], val)
+	}
+	return out, nil
+}
+
+func init() {
+	sandboxFunctionCmd.AddCommand(sandboxFunctionInvokeCmd)
+
+	sandboxFunctionCmd.PersistentFlags().StringVarP(&functionSandboxID, "sandbox-id", "s", "", "sandbox ID (required)")
+	_ = sandboxFunctionCmd.MarkPersistentFlagRequired("sandbox-id")
+
+	sandboxFunctionInvokeCmd.Flags().StringVar(&functionMethod, "method", "", "logical request method")
+	sandboxFunctionInvokeCmd.Flags().StringVar(&functionPath, "path", "", "logical request path")
+	sandboxFunctionInvokeCmd.Flags().StringVar(&functionHandler, "handler", "", "handler name inside the Python module")
+	sandboxFunctionInvokeCmd.Flags().StringArrayVar(&functionHeader, "header", nil, "request header (KEY=VALUE, can be repeated)")
+	sandboxFunctionInvokeCmd.Flags().StringArrayVar(&functionQuery, "query", nil, "query parameter (KEY=VALUE, can be repeated)")
+	sandboxFunctionInvokeCmd.Flags().BoolVar(&functionBodyStdin, "stdin", false, "read request body from stdin")
+	sandboxFunctionInvokeCmd.Flags().StringVar(&functionBodyData, "body", "", "request body")
+	sandboxFunctionInvokeCmd.Flags().StringVar(&functionBodyBase64, "body-base64", "", "base64-encoded request body")
+	sandboxFunctionInvokeCmd.Flags().Int32Var(&functionTimeoutMS, "timeout-ms", 0, "per-invocation timeout in milliseconds")
+
+	sandboxCmd.AddCommand(sandboxFunctionCmd)
+}

--- a/internal/commands/sandbox_function_test.go
+++ b/internal/commands/sandbox_function_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import "testing"
+
+func TestBuildFunctionInvokeRequest(t *testing.T) {
+	resetFunctionFlags()
+	functionMethod = "POST"
+	functionPath = "/hello"
+	functionHandler = "custom_handler"
+	functionHeader = []string{"x-value=ok", "x-value=again"}
+	functionQuery = []string{"name=ada"}
+	functionBodyData = `{"ok":true}`
+	functionTimeoutMS = 1500
+	t.Cleanup(resetFunctionFlags)
+
+	req, err := buildFunctionInvokeRequest()
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if method, ok := req.Method.Get(); !ok || method != "POST" {
+		t.Fatalf("method = %q set=%v, want POST", method, ok)
+	}
+	if path, ok := req.Path.Get(); !ok || path != "/hello" {
+		t.Fatalf("path = %q set=%v, want /hello", path, ok)
+	}
+	if handler, ok := req.Handler.Get(); !ok || handler != "custom_handler" {
+		t.Fatalf("handler = %q set=%v, want custom_handler", handler, ok)
+	}
+	headers, ok := req.Headers.Get()
+	if !ok || len(headers["x-value"]) != 2 {
+		t.Fatalf("headers = %#v, want repeated x-value", headers)
+	}
+	query, ok := req.Query.Get()
+	if !ok || len(query["name"]) != 1 || query["name"][0] != "ada" {
+		t.Fatalf("query = %#v, want name=ada", query)
+	}
+	if body, ok := req.BodyBase64.Get(); !ok || body != "eyJvayI6dHJ1ZX0=" {
+		t.Fatalf("body = %q set=%v, want encoded JSON", body, ok)
+	}
+	if timeout, ok := req.TimeoutMs.Get(); !ok || timeout != 1500 {
+		t.Fatalf("timeout = %d set=%v, want 1500", timeout, ok)
+	}
+}
+
+func TestBuildFunctionInvokeRequestRejectsConflictingBodyFlags(t *testing.T) {
+	resetFunctionFlags()
+	functionBodyData = "body"
+	functionBodyBase64 = "Ym9keQ=="
+	t.Cleanup(resetFunctionFlags)
+
+	if _, err := buildFunctionInvokeRequest(); err == nil {
+		t.Fatal("expected conflicting body flags error")
+	}
+}
+
+func TestBuildFunctionInvokeRequestRejectsNegativeTimeout(t *testing.T) {
+	resetFunctionFlags()
+	functionTimeoutMS = -1
+	t.Cleanup(resetFunctionFlags)
+
+	if _, err := buildFunctionInvokeRequest(); err == nil {
+		t.Fatal("expected negative timeout error")
+	}
+}
+
+func resetFunctionFlags() {
+	functionMethod = ""
+	functionPath = ""
+	functionHandler = ""
+	functionHeader = nil
+	functionQuery = nil
+	functionBodyStdin = false
+	functionBodyData = ""
+	functionBodyBase64 = ""
+	functionTimeoutMS = 0
+}


### PR DESCRIPTION
## Summary
- add `s0 sandbox function invoke <name>`
- support method/path/handler/header/query/body/body-base64/stdin/timeout flags
- decode function body by default and preserve full response for `-o json`/`-o yaml`

## Dependency
Draft until sdk-go with `Sandbox.InvokeFunction` is released and `go.mod` can be updated from `github.com/sandbox0-ai/sdk-go v0.5.2`.

## Tests
- `go test -modfile=/tmp/s0-functions-go.mod ./internal/commands` with a local replace to `/root/sandbox0ai/worktrees/sdk-go-procd-python-functions`