### PR TITLE
Add sandbox service delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ s0 sandbox network update --mode block-all \
 ```bash
 s0 sandbox service get -s <sandbox-id>
 s0 sandbox service update --services-file services.yaml -s <sandbox-id>
+s0 sandbox service delete <service-id> -s <sandbox-id>
 s0 sandbox service clear -s <sandbox-id>
 
 # Claim-time sandbox services via sandbox config file

--- a/internal/commands/sandbox_gateway.go
+++ b/internal/commands/sandbox_gateway.go
@@ -19,7 +19,7 @@ var (
 var sandboxGatewayCmd = &cobra.Command{
 	Use:   "service",
 	Short: "Manage sandbox services",
-	Long:  `Get, update, and clear canonical services for a sandbox.`,
+	Long:  `Get, update, delete, and clear canonical services for a sandbox.`,
 }
 
 // sandboxGatewayGetCmd gets sandbox services.
@@ -103,6 +103,45 @@ var sandboxGatewayClearCmd = &cobra.Command{
 	},
 }
 
+// sandboxGatewayDeleteCmd deletes one sandbox service by replacing the service list.
+var sandboxGatewayDeleteCmd = &cobra.Command{
+	Use:   "delete <service-id>",
+	Short: "Delete a sandbox service",
+	Long:  `Delete one canonical sandbox service by service ID.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		serviceID := args[0]
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		sandbox := client.Sandbox(gatewaySandboxID)
+		current, err := sandbox.GetServices(cmd.Context())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting sandbox services: %v\n", err)
+			os.Exit(1)
+		}
+		remaining, err := deleteSandboxServiceByID(current.Services, serviceID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting sandbox service: %v\n", err)
+			os.Exit(1)
+		}
+
+		result, err := sandbox.UpdateServices(cmd.Context(), remaining)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error updating sandbox services: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func readSandboxServicesFile(path string) (*apispec.SandboxServicesUpdateRequest, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, fmt.Errorf("--services-file is required")
@@ -128,10 +167,42 @@ func parseSandboxServices(data []byte) (*apispec.SandboxServicesUpdateRequest, e
 	return &services, nil
 }
 
+func deleteSandboxServiceByID(services []apispec.SandboxAppServiceView, serviceID string) ([]apispec.SandboxAppService, error) {
+	serviceID = strings.TrimSpace(serviceID)
+	if serviceID == "" {
+		return nil, fmt.Errorf("service ID is required")
+	}
+	remaining := make([]apispec.SandboxAppService, 0, len(services))
+	found := false
+	for _, service := range services {
+		if service.ID == serviceID {
+			found = true
+			continue
+		}
+		remaining = append(remaining, sandboxServiceViewToService(service))
+	}
+	if !found {
+		return nil, fmt.Errorf("service %q not found", serviceID)
+	}
+	return remaining, nil
+}
+
+func sandboxServiceViewToService(service apispec.SandboxAppServiceView) apispec.SandboxAppService {
+	return apispec.SandboxAppService{
+		ID:          service.ID,
+		DisplayName: service.DisplayName,
+		Port:        service.Port,
+		Runtime:     service.Runtime,
+		Ingress:     service.Ingress,
+		HealthCheck: service.HealthCheck,
+	}
+}
+
 func init() {
 	sandboxGatewayCmd.AddCommand(sandboxGatewayGetCmd)
 	sandboxGatewayCmd.AddCommand(sandboxGatewayUpdateCmd)
 	sandboxGatewayCmd.AddCommand(sandboxGatewayClearCmd)
+	sandboxGatewayCmd.AddCommand(sandboxGatewayDeleteCmd)
 
 	sandboxGatewayCmd.PersistentFlags().StringVarP(&gatewaySandboxID, "sandbox-id", "s", "", "sandbox ID (required)")
 	_ = sandboxGatewayCmd.MarkPersistentFlagRequired("sandbox-id")

--- a/internal/commands/sandbox_gateway_test.go
+++ b/internal/commands/sandbox_gateway_test.go
@@ -118,3 +118,55 @@ func TestReadSandboxServicesFileRequiresPath(t *testing.T) {
 		t.Fatal("readSandboxServicesFile() error = nil, want error")
 	}
 }
+
+func TestDeleteSandboxServiceByID(t *testing.T) {
+	runtime := apispec.SandboxAppServiceRuntime{
+		Type: apispec.SandboxAppServiceRuntimeTypeFunction,
+		Function: apispec.NewOptSandboxFunction(apispec.SandboxFunction{
+			Runtime: apispec.SandboxFunctionRuntimePython,
+			Handler: apispec.NewOptString("handler"),
+			Source: apispec.SandboxFunctionSource{
+				Type: apispec.SandboxFunctionSourceTypeInline,
+				Code: "def handler(request):\n    return {'status': 200}\n",
+			},
+		}),
+	}
+	remaining, err := deleteSandboxServiceByID([]apispec.SandboxAppServiceView{
+		{
+			ID:      "api",
+			Port:    8080,
+			Ingress: apispec.SandboxAppServiceIngress{Public: true},
+		},
+		{
+			ID:      "hello",
+			Port:    49983,
+			Runtime: apispec.NewOptSandboxAppServiceRuntime(runtime),
+			Ingress: apispec.SandboxAppServiceIngress{
+				Public: true,
+				Routes: []apispec.SandboxAppServiceRoute{{
+					ID:         "hello",
+					PathPrefix: apispec.NewOptString("/hello"),
+					Resume:     true,
+				}},
+			},
+			Publishable: true,
+			PublicURL:   apispec.NewOptString("https://example.sandbox0.app"),
+		},
+	}, "hello")
+	if err != nil {
+		t.Fatalf("deleteSandboxServiceByID() error = %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("remaining count = %d, want 1", len(remaining))
+	}
+	if remaining[0].ID != "api" || remaining[0].Port != 8080 {
+		t.Fatalf("remaining service = %#v, want api service", remaining[0])
+	}
+}
+
+func TestDeleteSandboxServiceByIDNotFound(t *testing.T) {
+	_, err := deleteSandboxServiceByID([]apispec.SandboxAppServiceView{{ID: "api"}}, "missing")
+	if err == nil {
+		t.Fatal("deleteSandboxServiceByID() error = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary
- add `s0 sandbox service delete SERVICE_ID` for removing one configured sandbox service
- implement deletion by reading current services and replacing the list without the target service
- cover deletion filtering for function-backed services

## Tests
- `go test ./internal/commands -run "Test(ParseSandboxServices|DeleteSandboxServiceByID|ReadSandboxServicesFileRequiresPath)" -count=1`