### PR TITLE
Add snapshot-id to volume create

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ s0 template delete <template-id>
 ```bash
 s0 volume list
 s0 volume get <volume-id>
-s0 volume create [--access-mode RWO|RWX]
+s0 volume create [--access-mode RWO|ROX|RWX] [--snapshot-id <snapshot-id>]
 s0 volume delete <volume-id> [--force]
 ```
 

--- a/internal/commands/volume.go
+++ b/internal/commands/volume.go
@@ -11,8 +11,9 @@ import (
 
 // Volume create flags.
 var (
-	volumeAccessMode  string
-	volumeDeleteForce bool
+	volumeAccessMode       string
+	volumeCreateSnapshotID string
+	volumeDeleteForce      bool
 )
 
 // volumeCmd represents the volume command.
@@ -87,11 +88,7 @@ var volumeCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		req := apispec.CreateSandboxVolumeRequest{}
-
-		if volumeAccessMode != "" {
-			req.AccessMode = apispec.NewOptVolumeAccessMode(apispec.VolumeAccessMode(volumeAccessMode))
-		}
+		req := buildCreateVolumeRequest(volumeAccessMode, volumeCreateSnapshotID)
 
 		volume, err := client.CreateVolume(cmd.Context(), req)
 		if err != nil {
@@ -104,6 +101,19 @@ var volumeCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+func buildCreateVolumeRequest(accessMode, snapshotID string) apispec.CreateSandboxVolumeRequest {
+	req := apispec.CreateSandboxVolumeRequest{}
+
+	if accessMode != "" {
+		req.AccessMode = apispec.NewOptVolumeAccessMode(apispec.VolumeAccessMode(accessMode))
+	}
+	if snapshotID != "" {
+		req.SnapshotID = apispec.NewOptString(snapshotID)
+	}
+
+	return req
 }
 
 // volumeDeleteCmd deletes a volume.
@@ -179,9 +189,10 @@ func init() {
 	volumeCmd.AddCommand(volumeForkCmd)
 
 	// Volume create flags
-	volumeCreateCmd.Flags().StringVar(&volumeAccessMode, "access-mode", "", "access mode (RWO or RWX)")
+	volumeCreateCmd.Flags().StringVar(&volumeAccessMode, "access-mode", "", "access mode (RWO, ROX, or RWX)")
+	volumeCreateCmd.Flags().StringVar(&volumeCreateSnapshotID, "snapshot-id", "", "snapshot ID used to initialize the new volume")
 	volumeDeleteCmd.Flags().BoolVar(&volumeDeleteForce, "force", false, "force delete volume even if it has active mounts")
 
 	// Volume fork flags
-	volumeForkCmd.Flags().StringVar(&volumeAccessMode, "access-mode", "", "access mode override (RWO or RWX)")
+	volumeForkCmd.Flags().StringVar(&volumeAccessMode, "access-mode", "", "access mode override (RWO, ROX, or RWX)")
 }

--- a/internal/commands/volume_test.go
+++ b/internal/commands/volume_test.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+)
+
+func TestBuildCreateVolumeRequestSupportsSnapshotID(t *testing.T) {
+	req := buildCreateVolumeRequest("RWO", "snap_123")
+
+	snapshotID, ok := req.SnapshotID.Get()
+	if !ok || snapshotID != "snap_123" {
+		t.Fatalf("SnapshotID = %q, %v; want snap_123, true", snapshotID, ok)
+	}
+
+	accessMode, ok := req.AccessMode.Get()
+	if !ok || accessMode != apispec.VolumeAccessModeRWO {
+		t.Fatalf("AccessMode = %q, %v; want RWO, true", accessMode, ok)
+	}
+}
+
+func TestBuildCreateVolumeRequestLeavesSnapshotIDUnsetByDefault(t *testing.T) {
+	req := buildCreateVolumeRequest("", "")
+
+	if _, ok := req.SnapshotID.Get(); ok {
+		t.Fatal("SnapshotID is set; want unset")
+	}
+}
+
+func TestVolumeCreateCommandRegistersSnapshotIDFlag(t *testing.T) {
+	if flag := volumeCreateCmd.Flags().Lookup("snapshot-id"); flag == nil {
+		t.Fatal("volume create --snapshot-id flag is not registered")
+	}
+}


### PR DESCRIPTION
## Summary
- add `s0 volume create --snapshot-id` so a new Volume can be initialized from a snapshot
- route the flag through the generated SDK CreateSandboxVolumeRequest instead of hand-written HTTP
- update README command help and add command tests

## Tests
- go test ./internal/commands
- git diff --cached --check