### PR TITLE
Add sandbox filesystem CLI commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.5.5
+	github.com/sandbox0-ai/sdk-go v0.5.6-0.20260603211121-577fe8f2fde3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.5.5 h1:X+uDtVGYLejIIKVGwgFHhTqWq452sWX9Z8q43yTROHc=
 github.com/sandbox0-ai/sdk-go v0.5.5/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.5.6-0.20260603211121-577fe8f2fde3 h1:jpReVb8hXGujRwwCo/q4amxyHhmN3cHkH5euFiXuU4Y=
+github.com/sandbox0-ai/sdk-go v0.5.6-0.20260603211121-577fe8f2fde3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/filesystem.go
+++ b/internal/commands/filesystem.go
@@ -1,0 +1,205 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	filesystemCreateTemplate        string
+	filesystemCreateSnapshotID      string
+	filesystemCreateBaseImageDigest string
+	filesystemCreateS0FSHead        string
+	filesystemForkTemplate          string
+)
+
+// filesystemCmd represents the filesystem command.
+var filesystemCmd = &cobra.Command{
+	Use:   "filesystem",
+	Short: "Manage sandbox filesystems",
+	Long:  `List, get, create, fork, and delete persistent sandbox filesystems.`,
+}
+
+// filesystemListCmd lists all filesystems.
+var filesystemListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List filesystems",
+	Long:  `List all persistent sandbox filesystems.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		filesystems, err := client.ListFilesystems(cmd.Context())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing filesystems: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, filesystems); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// filesystemGetCmd gets a filesystem by ID.
+var filesystemGetCmd = &cobra.Command{
+	Use:   "get <filesystem-id>",
+	Short: "Get filesystem details",
+	Long:  `Get details of a persistent sandbox filesystem by its ID.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		filesystem, err := client.GetFilesystem(cmd.Context(), filesystemID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting filesystem: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, filesystem); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// filesystemCreateCmd creates a filesystem.
+var filesystemCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a filesystem",
+	Long:  `Create a persistent sandbox filesystem.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		req := buildCreateFilesystemRequest(
+			filesystemCreateTemplate,
+			filesystemCreateSnapshotID,
+			filesystemCreateBaseImageDigest,
+			filesystemCreateS0FSHead,
+		)
+
+		filesystem, err := client.CreateFilesystem(cmd.Context(), req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating filesystem: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, filesystem); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func buildCreateFilesystemRequest(templateID, snapshotID, baseImageDigest, s0fsHead string) apispec.CreateSandboxFilesystemRequest {
+	req := apispec.CreateSandboxFilesystemRequest{}
+	if templateID != "" {
+		req.Template = apispec.NewOptString(templateID)
+	}
+	if snapshotID != "" {
+		req.SnapshotID = apispec.NewOptString(snapshotID)
+	}
+	if baseImageDigest != "" {
+		req.BaseImageDigest = apispec.NewOptString(baseImageDigest)
+	}
+	if s0fsHead != "" {
+		req.S0fsHead = apispec.NewOptString(s0fsHead)
+	}
+	return req
+}
+
+// filesystemDeleteCmd deletes a filesystem.
+var filesystemDeleteCmd = &cobra.Command{
+	Use:   "delete <filesystem-id>",
+	Short: "Delete a filesystem",
+	Long:  `Delete a persistent sandbox filesystem by its ID.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		_, err = client.DeleteFilesystem(cmd.Context(), filesystemID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting filesystem: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Filesystem %s deleted successfully\n", filesystemID)
+	},
+}
+
+// filesystemForkCmd forks a filesystem.
+var filesystemForkCmd = &cobra.Command{
+	Use:   "fork <filesystem-id>",
+	Short: "Fork a filesystem",
+	Long:  `Create an independent persistent sandbox filesystem using Copy-On-Write.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		filesystem, err := client.ForkFilesystem(cmd.Context(), filesystemID, buildForkFilesystemRequest(filesystemForkTemplate))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error forking filesystem: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, filesystem); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func buildForkFilesystemRequest(templateID string) *apispec.ForkSandboxFilesystemRequest {
+	if templateID == "" {
+		return nil
+	}
+	return &apispec.ForkSandboxFilesystemRequest{
+		Template: apispec.NewOptString(templateID),
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(filesystemCmd)
+
+	filesystemCmd.AddCommand(filesystemListCmd)
+	filesystemCmd.AddCommand(filesystemGetCmd)
+	filesystemCmd.AddCommand(filesystemCreateCmd)
+	filesystemCmd.AddCommand(filesystemDeleteCmd)
+	filesystemCmd.AddCommand(filesystemForkCmd)
+
+	filesystemCreateCmd.Flags().StringVar(&filesystemCreateTemplate, "template", "", "template ID associated with the filesystem")
+	filesystemCreateCmd.Flags().StringVar(&filesystemCreateSnapshotID, "snapshot-id", "", "filesystem snapshot ID used to initialize the new filesystem")
+	filesystemCreateCmd.Flags().StringVar(&filesystemCreateBaseImageDigest, "base-image-digest", "", "resolved immutable base image digest")
+	filesystemCreateCmd.Flags().StringVar(&filesystemCreateS0FSHead, "s0fs-head", "", "initial s0fs head for low-level restore/import paths")
+
+	filesystemForkCmd.Flags().StringVar(&filesystemForkTemplate, "template", "", "template ID override for the forked filesystem")
+}

--- a/internal/commands/filesystem_snapshot.go
+++ b/internal/commands/filesystem_snapshot.go
@@ -1,0 +1,186 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	filesystemSnapshotName        string
+	filesystemSnapshotDescription string
+)
+
+// filesystemSnapshotCmd represents the filesystem snapshot command group.
+var filesystemSnapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Manage filesystem snapshots",
+	Long:  `List, get, create, delete, and restore persistent sandbox filesystem snapshots.`,
+}
+
+// filesystemSnapshotListCmd lists all snapshots for a filesystem.
+var filesystemSnapshotListCmd = &cobra.Command{
+	Use:   "list <filesystem-id>",
+	Short: "List snapshots",
+	Long:  `List all snapshots for a persistent sandbox filesystem.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		snapshots, err := client.ListFilesystemSnapshots(cmd.Context(), filesystemID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing filesystem snapshots: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, snapshots); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// filesystemSnapshotGetCmd gets a filesystem snapshot by ID.
+var filesystemSnapshotGetCmd = &cobra.Command{
+	Use:   "get <filesystem-id> <snapshot-id>",
+	Short: "Get snapshot details",
+	Long:  `Get details of a persistent sandbox filesystem snapshot by its ID.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+		snapshotID := args[1]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		snapshot, err := client.GetFilesystemSnapshot(cmd.Context(), filesystemID, snapshotID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting filesystem snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, snapshot); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// filesystemSnapshotCreateCmd creates a new filesystem snapshot.
+var filesystemSnapshotCreateCmd = &cobra.Command{
+	Use:   "create <filesystem-id>",
+	Short: "Create a snapshot",
+	Long:  `Create a new snapshot for a persistent sandbox filesystem.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+
+		if filesystemSnapshotName == "" {
+			fmt.Fprintln(os.Stderr, "Error: --name is required")
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		req := apispec.CreateSandboxFilesystemSnapshotRequest{
+			Name: filesystemSnapshotName,
+		}
+		if filesystemSnapshotDescription != "" {
+			req.Description = apispec.NewOptString(filesystemSnapshotDescription)
+		}
+
+		snapshot, err := client.CreateFilesystemSnapshot(cmd.Context(), filesystemID, req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating filesystem snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, snapshot); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// filesystemSnapshotDeleteCmd deletes a filesystem snapshot.
+var filesystemSnapshotDeleteCmd = &cobra.Command{
+	Use:   "delete <filesystem-id> <snapshot-id>",
+	Short: "Delete a snapshot",
+	Long:  `Delete a persistent sandbox filesystem snapshot by its ID.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+		snapshotID := args[1]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		_, err = client.DeleteFilesystemSnapshot(cmd.Context(), filesystemID, snapshotID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting filesystem snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Filesystem snapshot %s deleted successfully\n", snapshotID)
+	},
+}
+
+// filesystemSnapshotRestoreCmd restores a filesystem snapshot.
+var filesystemSnapshotRestoreCmd = &cobra.Command{
+	Use:   "restore <filesystem-id> <snapshot-id>",
+	Short: "Restore a snapshot",
+	Long:  `Restore a persistent sandbox filesystem to a specific snapshot.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		filesystemID := args[0]
+		snapshotID := args[1]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		filesystem, err := client.RestoreFilesystemSnapshot(cmd.Context(), filesystemID, snapshotID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error restoring filesystem snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, filesystem); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	filesystemCmd.AddCommand(filesystemSnapshotCmd)
+
+	filesystemSnapshotCreateCmd.Flags().StringVarP(&filesystemSnapshotName, "name", "n", "", "snapshot name (required)")
+	filesystemSnapshotCreateCmd.Flags().StringVarP(&filesystemSnapshotDescription, "description", "d", "", "snapshot description")
+
+	filesystemSnapshotCmd.AddCommand(filesystemSnapshotListCmd)
+	filesystemSnapshotCmd.AddCommand(filesystemSnapshotGetCmd)
+	filesystemSnapshotCmd.AddCommand(filesystemSnapshotCreateCmd)
+	filesystemSnapshotCmd.AddCommand(filesystemSnapshotDeleteCmd)
+	filesystemSnapshotCmd.AddCommand(filesystemSnapshotRestoreCmd)
+}

--- a/internal/commands/filesystem_snapshot_test.go
+++ b/internal/commands/filesystem_snapshot_test.go
@@ -1,0 +1,25 @@
+package commands
+
+import "testing"
+
+func TestFilesystemSnapshotCommandRegistration(t *testing.T) {
+	subcommands := map[string]bool{}
+	for _, cmd := range filesystemSnapshotCmd.Commands() {
+		subcommands[cmd.Name()] = true
+	}
+
+	for _, name := range []string{"list", "get", "create", "delete", "restore"} {
+		if !subcommands[name] {
+			t.Fatalf("expected filesystem snapshot subcommand %q to be registered", name)
+		}
+	}
+}
+
+func TestFilesystemSnapshotCommandFlags(t *testing.T) {
+	if flag := filesystemSnapshotCreateCmd.Flags().Lookup("name"); flag == nil {
+		t.Fatal("expected filesystem snapshot create --name flag")
+	}
+	if flag := filesystemSnapshotCreateCmd.Flags().Lookup("description"); flag == nil {
+		t.Fatal("expected filesystem snapshot create --description flag")
+	}
+}

--- a/internal/commands/filesystem_test.go
+++ b/internal/commands/filesystem_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import "testing"
+
+func TestBuildCreateFilesystemRequest(t *testing.T) {
+	req := buildCreateFilesystemRequest("ubuntu-24", "snap_123", "sha256:base", "manifests/0001.json")
+
+	if template, ok := req.Template.Get(); !ok || template != "ubuntu-24" {
+		t.Fatalf("Template = %q, %v; want ubuntu-24, true", template, ok)
+	}
+	if snapshotID, ok := req.SnapshotID.Get(); !ok || snapshotID != "snap_123" {
+		t.Fatalf("SnapshotID = %q, %v; want snap_123, true", snapshotID, ok)
+	}
+	if digest, ok := req.BaseImageDigest.Get(); !ok || digest != "sha256:base" {
+		t.Fatalf("BaseImageDigest = %q, %v; want sha256:base, true", digest, ok)
+	}
+	if head, ok := req.S0fsHead.Get(); !ok || head != "manifests/0001.json" {
+		t.Fatalf("S0fsHead = %q, %v; want manifests/0001.json, true", head, ok)
+	}
+}
+
+func TestBuildCreateFilesystemRequestLeavesFieldsUnsetByDefault(t *testing.T) {
+	req := buildCreateFilesystemRequest("", "", "", "")
+
+	if _, ok := req.Template.Get(); ok {
+		t.Fatal("Template is set; want unset")
+	}
+	if _, ok := req.SnapshotID.Get(); ok {
+		t.Fatal("SnapshotID is set; want unset")
+	}
+	if _, ok := req.BaseImageDigest.Get(); ok {
+		t.Fatal("BaseImageDigest is set; want unset")
+	}
+	if _, ok := req.S0fsHead.Get(); ok {
+		t.Fatal("S0fsHead is set; want unset")
+	}
+}
+
+func TestBuildForkFilesystemRequest(t *testing.T) {
+	if req := buildForkFilesystemRequest(""); req != nil {
+		t.Fatalf("buildForkFilesystemRequest(\"\") = %#v, want nil", req)
+	}
+
+	req := buildForkFilesystemRequest("ubuntu-24")
+	if req == nil {
+		t.Fatal("buildForkFilesystemRequest() = nil, want request")
+	}
+	if template, ok := req.Template.Get(); !ok || template != "ubuntu-24" {
+		t.Fatalf("Template = %q, %v; want ubuntu-24, true", template, ok)
+	}
+}
+
+func TestFilesystemCommandRegistration(t *testing.T) {
+	subcommands := map[string]bool{}
+	for _, cmd := range filesystemCmd.Commands() {
+		subcommands[cmd.Name()] = true
+	}
+
+	for _, name := range []string{"list", "get", "create", "delete", "fork", "snapshot"} {
+		if !subcommands[name] {
+			t.Fatalf("expected filesystem subcommand %q to be registered", name)
+		}
+	}
+}
+
+func TestFilesystemCommandFlags(t *testing.T) {
+	for _, name := range []string{"template", "snapshot-id", "base-image-digest", "s0fs-head"} {
+		if flag := filesystemCreateCmd.Flags().Lookup(name); flag == nil {
+			t.Fatalf("expected filesystem create --%s flag", name)
+		}
+	}
+	if flag := filesystemForkCmd.Flags().Lookup("template"); flag == nil {
+		t.Fatal("expected filesystem fork --template flag")
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -27,10 +27,10 @@ var (
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "s0",
-	Short: "Sandbox0 CLI - Manage sandboxes, templates, volumes, and images",
+	Short: "Sandbox0 CLI - Manage sandboxes, templates, filesystems, volumes, and images",
 	Long: `s0 is the command-line interface for Sandbox0.
 
-It provides comprehensive management of sandboxes, templates, volumes,
+It provides comprehensive management of sandboxes, templates, filesystems, volumes,
 snapshots, and container images.`,
 }
 
@@ -165,7 +165,7 @@ func buildUserAgent() string {
 func commandRouteScope(cmd *cobra.Command) client.RouteScope {
 	for current := cmd; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "sandbox", "template", "volume", "credential", "apikey", "image", "ssh-key":
+		case "sandbox", "template", "volume", "filesystem", "credential", "apikey", "image", "ssh-key":
 			return client.RouteScopeHomeRegion
 		case "auth", "team", "user":
 			return client.RouteScopeEntrypoint

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -19,6 +19,16 @@ func TestCommandRouteScopeRoutesUserSSHKeysToHomeRegion(t *testing.T) {
 	}
 }
 
+func TestCommandRouteScopeRoutesFilesystemToHomeRegion(t *testing.T) {
+	filesystem := &cobra.Command{Use: "filesystem"}
+	list := &cobra.Command{Use: "list"}
+	filesystem.AddCommand(list)
+
+	if got := commandRouteScope(list); got != client.RouteScopeHomeRegion {
+		t.Fatalf("commandRouteScope(filesystem list) = %q, want %q", got, client.RouteScopeHomeRegion)
+	}
+}
+
 func TestCommandRouteScopeKeepsUserProfileOnEntrypoint(t *testing.T) {
 	user := &cobra.Command{Use: "user"}
 	get := &cobra.Command{Use: "get"}

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -13,11 +13,12 @@ import (
 )
 
 var (
-	sandboxTemplate   string
-	sandboxTTL        int32
-	sandboxHardTTL    int32
-	sandboxConfigFile string
-	sandboxMounts     []string
+	sandboxTemplate     string
+	sandboxTTL          int32
+	sandboxHardTTL      int32
+	sandboxConfigFile   string
+	sandboxMounts       []string
+	sandboxFilesystemID string
 	// list flags
 	sandboxListStatus     string
 	sandboxListTemplateID string
@@ -177,6 +178,62 @@ var sandboxResumeCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Resume requested for sandbox %s\n", sandboxID)
+	},
+}
+
+// sandboxCleanCmd cleans a sandbox runtime while preserving durable state.
+var sandboxCleanCmd = &cobra.Command{
+	Use:   "clean <sandbox-id>",
+	Short: "Clean a sandbox runtime",
+	Long:  `Clean a sandbox runtime pod while preserving durable sandbox state.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		sandbox, err := client.CleanSandbox(cmd.Context(), sandboxID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error cleaning sandbox: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, sandbox); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// sandboxRestoreCmd restores a cleaned sandbox runtime.
+var sandboxRestoreCmd = &cobra.Command{
+	Use:   "restore <sandbox-id>",
+	Short: "Restore a cleaned sandbox",
+	Long:  `Restore a cleaned sandbox runtime from its durable sandbox state.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		sandbox, err := client.RestoreSandbox(cmd.Context(), sandboxID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error restoring sandbox: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, sandbox); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
 	},
 }
 
@@ -383,12 +440,15 @@ func init() {
 	sandboxCreateCmd.Flags().Int32Var(&sandboxTTL, "ttl", 0, "soft TTL in seconds")
 	sandboxCreateCmd.Flags().Int32Var(&sandboxHardTTL, "hard-ttl", 0, "hard TTL in seconds")
 	sandboxCreateCmd.Flags().StringArrayVar(&sandboxMounts, "mount", nil, "bootstrap mount in the form <sandboxvolume-id>:/absolute/path (repeatable)")
+	sandboxCreateCmd.Flags().StringVar(&sandboxFilesystemID, "filesystem-id", "", "persistent sandbox filesystem ID")
 
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxGetCmd)
 	sandboxCmd.AddCommand(sandboxDeleteCmd)
 	sandboxCmd.AddCommand(sandboxPauseCmd)
 	sandboxCmd.AddCommand(sandboxResumeCmd)
+	sandboxCmd.AddCommand(sandboxCleanCmd)
+	sandboxCmd.AddCommand(sandboxRestoreCmd)
 	sandboxCmd.AddCommand(sandboxRefreshCmd)
 	sandboxCmd.AddCommand(sandboxStatusCmd)
 	sandboxCmd.AddCommand(sandboxUpdateCmd)
@@ -429,6 +489,9 @@ func buildSandboxCreateRequest() (apispec.ClaimRequest, error) {
 	}
 	if sandboxTemplate != "" {
 		request.Template = apispec.NewOptString(sandboxTemplate)
+	}
+	if sandboxFilesystemID != "" {
+		request.FilesystemID = apispec.NewOptNilString(sandboxFilesystemID)
 	}
 
 	configOverrides, hasConfigOverrides, err := buildSandboxCreateConfigOverrides()
@@ -574,7 +637,7 @@ func isSandboxCreateClaimRequest(data []byte) (bool, error) {
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return false, fmt.Errorf("parse sandbox create file: %w", err)
 	}
-	for _, key := range []string{"template", "config", "mounts"} {
+	for _, key := range []string{"template", "config", "mounts", "filesystem_id"} {
 		if _, ok := raw[key]; ok {
 			return true, nil
 		}

--- a/internal/commands/sandbox_test.go
+++ b/internal/commands/sandbox_test.go
@@ -91,6 +91,7 @@ hard_ttl: 120
 		resetSandboxFlagsForTest()
 		sandboxConfigFile = writeTempFile(t, `
 template: from-file
+filesystem_id: fs_123
 mounts:
   - sandboxvolume_id: vol_123
     mount_point: /workspace/data
@@ -105,6 +106,10 @@ config:
 		template, ok := request.Template.Get()
 		if !ok || template != "from-file" {
 			t.Fatalf("template = %q, want from-file", template)
+		}
+		filesystemID, ok := request.FilesystemID.Get()
+		if !ok || filesystemID != "fs_123" {
+			t.Fatalf("filesystem_id = %q, want fs_123", filesystemID)
 		}
 		if len(request.Mounts) != 1 {
 			t.Fatalf("mount count = %d, want 1", len(request.Mounts))
@@ -125,6 +130,21 @@ config:
 		}
 		if len(request.Mounts) != 1 {
 			t.Fatalf("mount count = %d, want 1", len(request.Mounts))
+		}
+	})
+
+	t.Run("filesystem flag sets claim filesystem id", func(t *testing.T) {
+		resetSandboxFlagsForTest()
+		sandboxTemplate = "default"
+		sandboxFilesystemID = "fs_flag"
+
+		request, err := buildSandboxCreateRequest()
+		if err != nil {
+			t.Fatalf("buildSandboxCreateRequest() error = %v", err)
+		}
+		filesystemID, ok := request.FilesystemID.Get()
+		if !ok || filesystemID != "fs_flag" {
+			t.Fatalf("filesystem_id = %q, want fs_flag", filesystemID)
 		}
 	})
 
@@ -236,6 +256,22 @@ auto_resume: false
 	})
 }
 
+func TestSandboxFilesystemCommandRegistration(t *testing.T) {
+	subcommands := map[string]bool{}
+	for _, cmd := range sandboxCmd.Commands() {
+		subcommands[cmd.Name()] = true
+	}
+
+	for _, name := range []string{"clean", "restore"} {
+		if !subcommands[name] {
+			t.Fatalf("expected sandbox subcommand %q to be registered", name)
+		}
+	}
+	if flag := sandboxCreateCmd.Flags().Lookup("filesystem-id"); flag == nil {
+		t.Fatal("sandbox create --filesystem-id flag is not registered")
+	}
+}
+
 func writeTempFile(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "config.yaml")
@@ -251,6 +287,7 @@ func resetSandboxFlagsForTest() {
 	sandboxHardTTL = 0
 	sandboxConfigFile = ""
 	sandboxMounts = nil
+	sandboxFilesystemID = ""
 	sandboxListStatus = ""
 	sandboxListTemplateID = ""
 	sandboxListPaused = ""

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -37,6 +37,14 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatSnapshots(w, v)
 	case *apispec.Snapshot:
 		return f.formatSnapshot(w, v)
+	case []apispec.SandboxFilesystem:
+		return f.formatFilesystems(w, v)
+	case *apispec.SandboxFilesystem:
+		return f.formatFilesystem(w, v)
+	case []apispec.SandboxFilesystemSnapshot:
+		return f.formatFilesystemSnapshots(w, v)
+	case *apispec.SandboxFilesystemSnapshot:
+		return f.formatFilesystemSnapshot(w, v)
 	case *apispec.Sandbox:
 		return f.formatSandbox(w, v)
 	case *apispec.SandboxStatus:
@@ -260,6 +268,80 @@ func (f *TableFormatter) formatSnapshot(w io.Writer, s *apispec.Snapshot) error 
 	return t.Render()
 }
 
+func (f *TableFormatter) formatFilesystems(w io.Writer, filesystems []apispec.SandboxFilesystem) error {
+	if len(filesystems) == 0 {
+		_, _ = fmt.Fprintln(w, "No filesystems found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"ID", "TEMPLATE ID", "STATE", "BASE IMAGE DIGEST", "UPDATED AT"})
+
+	for _, filesystem := range filesystems {
+		_ = t.Append([]string{
+			filesystem.ID,
+			formatOptNilString(filesystem.TemplateID),
+			string(filesystem.State),
+			valueOrDash(filesystem.BaseImageDigest),
+			formatTimestamp(filesystem.UpdatedAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFilesystem(w io.Writer, filesystem *apispec.SandboxFilesystem) error {
+	t := newTable(w)
+	_ = t.Append([]string{"ID:", filesystem.ID})
+	_ = t.Append([]string{"Team ID:", filesystem.TeamID})
+	_ = t.Append([]string{"User ID:", filesystem.UserID})
+	_ = t.Append([]string{"Source Filesystem ID:", formatOptNilString(filesystem.SourceFilesystemID)})
+	_ = t.Append([]string{"Template ID:", formatOptNilString(filesystem.TemplateID)})
+	_ = t.Append([]string{"Base Image Digest:", valueOrDash(filesystem.BaseImageDigest)})
+	_ = t.Append([]string{"S0FS Head:", valueOrDash(filesystem.S0fsHead)})
+	_ = t.Append([]string{"State:", string(filesystem.State)})
+	_ = t.Append([]string{"Deleted At:", formatOptNilDateTime(filesystem.DeletedAt)})
+	_ = t.Append([]string{"Created At:", formatTimestamp(filesystem.CreatedAt)})
+	_ = t.Append([]string{"Updated At:", formatTimestamp(filesystem.UpdatedAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFilesystemSnapshots(w io.Writer, snapshots []apispec.SandboxFilesystemSnapshot) error {
+	if len(snapshots) == 0 {
+		_, _ = fmt.Fprintln(w, "No filesystem snapshots found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"ID", "FILESYSTEM ID", "NAME", "SIZE", "CREATED AT"})
+
+	for _, snapshot := range snapshots {
+		_ = t.Append([]string{
+			snapshot.ID,
+			snapshot.FilesystemID,
+			valueOrDash(snapshot.Name),
+			fmt.Sprintf("%d bytes", snapshot.SizeBytes),
+			formatTimestamp(snapshot.CreatedAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatFilesystemSnapshot(w io.Writer, snapshot *apispec.SandboxFilesystemSnapshot) error {
+	t := newTable(w)
+	_ = t.Append([]string{"ID:", snapshot.ID})
+	_ = t.Append([]string{"Filesystem ID:", snapshot.FilesystemID})
+	_ = t.Append([]string{"Team ID:", snapshot.TeamID})
+	_ = t.Append([]string{"User ID:", snapshot.UserID})
+	_ = t.Append([]string{"Base Image Digest:", valueOrDash(snapshot.BaseImageDigest)})
+	_ = t.Append([]string{"S0FS Head:", valueOrDash(snapshot.S0fsHead)})
+	_ = t.Append([]string{"Name:", valueOrDash(snapshot.Name)})
+	_ = t.Append([]string{"Description:", formatOptString(snapshot.Description)})
+	_ = t.Append([]string{"Size:", fmt.Sprintf("%d bytes", snapshot.SizeBytes)})
+	_ = t.Append([]string{"Created At:", formatTimestamp(snapshot.CreatedAt)})
+	_ = t.Append([]string{"Expires At:", formatOptNilDateTime(snapshot.ExpiresAt)})
+	return t.Render()
+}
+
 func (f *TableFormatter) formatSandbox(w io.Writer, s *apispec.Sandbox) error {
 	t := newTable(w)
 	_ = t.Append([]string{"ID:", s.ID})
@@ -268,9 +350,10 @@ func (f *TableFormatter) formatSandbox(w io.Writer, s *apispec.Sandbox) error {
 	if v, ok := s.UserID.Get(); ok {
 		_ = t.Append([]string{"User ID:", v})
 	}
+	_ = t.Append([]string{"Filesystem ID:", formatOptNilString(s.FilesystemID)})
 	_ = t.Append([]string{"Status:", string(s.Status)})
 	_ = t.Append([]string{"Paused:", fmt.Sprintf("%v", s.Paused)})
-	_ = t.Append([]string{"Pod Name:", s.PodName})
+	_ = t.Append([]string{"Pod Name:", formatNilString(s.PodName)})
 	_ = t.Append([]string{"Claimed At:", s.ClaimedAt.Format(timeLayout)})
 	_ = t.Append([]string{"Soft Expires At:", formatTimestamp(s.ExpiresAt)})
 	_ = t.Append([]string{"Hard Expires At:", formatTimestamp(s.HardExpiresAt)})
@@ -399,6 +482,9 @@ func (f *TableFormatter) formatSDKSandbox(w io.Writer, s *sandbox0.Sandbox) erro
 	}
 	if s.PodName != "" {
 		_ = t.Append([]string{"Pod Name:", s.PodName})
+	}
+	if s.FilesystemID != nil {
+		_ = t.Append([]string{"Filesystem ID:", *s.FilesystemID})
 	}
 	return t.Render()
 }
@@ -1008,6 +1094,16 @@ func formatOptInt64(v apispec.OptInt64) string {
 }
 
 func formatOptNilString(v apispec.OptNilString) string {
+	if v.IsNull() {
+		return "-"
+	}
+	if s, ok := v.Get(); ok && s != "" {
+		return s
+	}
+	return "-"
+}
+
+func formatNilString(v apispec.NilString) string {
 	if v.IsNull() {
 		return "-"
 	}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -163,14 +163,15 @@ func TestTableFormatterFormatRegion(t *testing.T) {
 func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 	formatter := &TableFormatter{}
 	sandbox := &apispec.Sandbox{
-		ID:         "sb_123",
-		TemplateID: "default",
-		TeamID:     "team_123",
-		Status:     "running",
-		Paused:     false,
-		PowerState: apispec.SandboxPowerState{},
-		AutoResume: true,
-		PodName:    "sb-123-pod",
+		ID:           "sb_123",
+		TemplateID:   "default",
+		TeamID:       "team_123",
+		Status:       "running",
+		Paused:       false,
+		PowerState:   apispec.SandboxPowerState{},
+		AutoResume:   true,
+		PodName:      apispec.NilString{Value: "sb-123-pod"},
+		FilesystemID: apispec.NewOptNilString("fs_123"),
 		SSH: apispec.NewOptSandboxSSHConnection(apispec.SandboxSSHConnection{
 			Host:     "aws-us-east-1.ssh.sandbox0.app",
 			Port:     30222,
@@ -194,6 +195,118 @@ func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 		"30222",
 		"SSH Username:",
 		"sb_123",
+		"Filesystem ID:",
+		"fs_123",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFilesystem(t *testing.T) {
+	formatter := &TableFormatter{}
+	filesystem := &apispec.SandboxFilesystem{
+		ID:                 "fs_123",
+		TeamID:             "team_123",
+		UserID:             "user_123",
+		SourceFilesystemID: apispec.NewOptNilString("fs_source"),
+		TemplateID:         apispec.NewOptNilString("ubuntu-24"),
+		BaseImageDigest:    "sha256:base",
+		S0fsHead:           "manifests/0001.json",
+		State:              apispec.SandboxFilesystemStateAvailable,
+		CreatedAt:          time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:          time.Date(2026, 6, 3, 13, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, filesystem); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ID:",
+		"fs_123",
+		"Source Filesystem ID:",
+		"fs_source",
+		"Template ID:",
+		"ubuntu-24",
+		"Base Image Digest:",
+		"sha256:base",
+		"S0FS Head:",
+		"manifests/0001.json",
+		"available",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFilesystemList(t *testing.T) {
+	formatter := &TableFormatter{}
+	filesystems := []apispec.SandboxFilesystem{
+		{
+			ID:              "fs_123",
+			TemplateID:      apispec.NewOptNilString("ubuntu-24"),
+			BaseImageDigest: "sha256:base",
+			State:           apispec.SandboxFilesystemStateAvailable,
+			UpdatedAt:       time.Date(2026, 6, 3, 13, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, filesystems); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ID",
+		"TEMPLATE ID",
+		"STATE",
+		"BASE IMAGE DIGEST",
+		"fs_123",
+		"ubuntu-24",
+		"available",
+		"sha256:base",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatFilesystemSnapshot(t *testing.T) {
+	formatter := &TableFormatter{}
+	snapshot := &apispec.SandboxFilesystemSnapshot{
+		ID:              "fssnap_123",
+		FilesystemID:    "fs_123",
+		TeamID:          "team_123",
+		UserID:          "user_123",
+		BaseImageDigest: "sha256:base",
+		S0fsHead:        "manifests/0001.json",
+		Name:            "before-upgrade",
+		Description:     apispec.NewOptString("before package changes"),
+		SizeBytes:       1024,
+		CreatedAt:       time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, snapshot); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ID:",
+		"fssnap_123",
+		"Filesystem ID:",
+		"fs_123",
+		"before-upgrade",
+		"before package changes",
+		"1024 bytes",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)


### PR DESCRIPTION
Adds CLI coverage for sandbox filesystem lifecycle from sandbox0 issue #400.

Changes:
- Add `s0 filesystem` CRUD/fork commands.
- Add `s0 filesystem snapshot` list/get/create/delete/restore commands.
- Add `s0 sandbox create --filesystem-id`, `s0 sandbox clean`, and `s0 sandbox restore`.
- Add table formatting for filesystem metadata and filesystem snapshots.
- Update sdk-go dependency to the issue #400 branch pseudo-version.

Tests:
- `go test ./...`