### PR TITLE
Support HTTP protocol rules in network CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ s0 sandbox exec <sandbox-id> --stream -- sh -c 'echo hello && sleep 1 && exit 7'
 ```bash
 s0 sandbox create -t <template-id> -f sandbox-config.yaml
 s0 sandbox network get -s <sandbox-id>
-s0 sandbox network update --mode allow-all|block-all [--allow-cidr <cidr>] [--allow-domain <domain>] [--allow-port <port[/proto]|start-end[/proto]>] [--deny-cidr <cidr>] [--deny-domain <domain>] [--deny-port <port[/proto]|start-end[/proto]>] [--traffic-rule '<json>'] [--credential-rule '<json>'] [--credential-binding '<json>'] -s <sandbox-id>
+s0 sandbox network update --mode allow-all|block-all [--allow-cidr <cidr>] [--allow-domain <domain>] [--allow-port <port[/proto]|start-end[/proto]>] [--deny-cidr <cidr>] [--deny-domain <domain>] [--deny-port <port[/proto]|start-end[/proto]>] [--traffic-rule '<json>'] [--protocol-rule '<json>'] [--credential-rule '<json>'] [--credential-binding '<json>'] -s <sandbox-id>
 s0 sandbox network update --policy-file network.yaml -s <sandbox-id>
 
 # Claim-time network policy via sandbox config file
@@ -375,6 +375,20 @@ egress:
       ports:
         - port: 22
           protocol: tcp
+  protocolRules:
+    - name: api-http-readonly
+      protocol: http
+      domains: [api.example.com]
+      ports:
+        - port: 8080
+          protocol: tcp
+      http:
+        methods:
+          allowed: [GET, HEAD]
+          denied: [POST]
+        paths:
+          allowedPrefixes: [/api/]
+          deniedPrefixes: [/admin/]
 credentialBindings:
   - ref: gh-token
     sourceRef: github-source
@@ -387,9 +401,10 @@ credentialBindings:
 EOF
 s0 sandbox network update --policy-file network.yaml -s <sandbox-id>
 
-# Script-oriented structured flags: allow SSH traffic first, then inject outbound auth for GitHub API
+# Script-oriented structured flags: allow SSH traffic, control HTTP operations, then inject outbound auth for GitHub API
 s0 sandbox network update --mode block-all \
   --traffic-rule '{"name":"allow-ssh","action":"allow","appProtocols":["ssh"],"ports":[{"port":22,"protocol":"tcp"}]}' \
+  --protocol-rule '{"name":"api-http-readonly","protocol":"http","domains":["api.example.com"],"ports":[{"port":8080,"protocol":"tcp"}],"http":{"methods":{"allowed":["GET","HEAD"],"denied":["POST"]},"paths":{"allowedPrefixes":["/api/"],"deniedPrefixes":["/admin/"]}}}' \
   --credential-binding '{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{token}}"}]}}}' \
   --credential-rule '{"name":"github-auth","credentialRef":"gh-token","protocol":"https","domains":["api.github.com"],"ports":[{"port":443,"protocol":"tcp"}]}' \
   -s <sandbox-id>

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.0
+	github.com/sandbox0-ai/sdk-go v0.6.1-0.20260612204657-31b0c19834e4
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.1-0.20260612204657-31b0c19834e4
+	github.com/sandbox0-ai/sdk-go v0.6.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.6.0 h1:4X8BKqo3nIEGn0IqBykoWoPcCsp5NHsAQts1QuXPHis=
 github.com/sandbox0-ai/sdk-go v0.6.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.6.1-0.20260612204657-31b0c19834e4 h1:fQDs45Pyb1ta4TDBkPpsmzv2YnZxUVmW9LwVW/De1b8=
+github.com/sandbox0-ai/sdk-go v0.6.1-0.20260612204657-31b0c19834e4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.6.0 h1:4X8BKqo3nIEGn0IqBykoWoPcCsp5NHsAQts1QuXPHis=
-github.com/sandbox0-ai/sdk-go v0.6.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.6.1-0.20260612204657-31b0c19834e4 h1:fQDs45Pyb1ta4TDBkPpsmzv2YnZxUVmW9LwVW/De1b8=
-github.com/sandbox0-ai/sdk-go v0.6.1-0.20260612204657-31b0c19834e4/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.6.1 h1:pKwFPlogggoEpQMlFs0T/gX5/SrOEDhlEjqxOipvtWU=
+github.com/sandbox0-ai/sdk-go v0.6.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_network_test.go
+++ b/internal/commands/sandbox_network_test.go
@@ -90,6 +90,7 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 			},
 			ProtocolRules: []string{
 				`{"name":"docs-mcp","protocol":"mcp","domains":["mcp.example.com"],"ports":[{"port":443,"protocol":"tcp"}],"tlsMode":"terminate-reoriginate","httpMatch":{"methods":["POST"],"paths":["/mcp"]},"mcp":{"tools":{"allowed":["read_file"],"denied":["run_command"]}}}`,
+				`{"name":"api-http-readonly","protocol":"http","domains":["api.example.com"],"ports":[{"port":8080,"protocol":"tcp"}],"http":{"methods":{"allowed":["GET","HEAD"],"denied":["POST"]},"paths":{"allowed":["/healthz"],"allowedPrefixes":["/api/"],"deniedPrefixes":["/admin/"]}}}`,
 			},
 			CredentialBinds: []string{
 				`{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{token}}"}]}}}`,
@@ -108,8 +109,8 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 		if len(egress.TrafficRules) != 1 {
 			t.Fatalf("trafficRules count = %d, want 1", len(egress.TrafficRules))
 		}
-		if len(egress.ProtocolRules) != 1 {
-			t.Fatalf("protocolRules count = %d, want 1", len(egress.ProtocolRules))
+		if len(egress.ProtocolRules) != 2 {
+			t.Fatalf("protocolRules count = %d, want 2", len(egress.ProtocolRules))
 		}
 		if egress.ProtocolRules[0].Protocol != apispec.ProtocolRuleProtocolMcp {
 			t.Fatalf("protocol rule protocol = %q, want mcp", egress.ProtocolRules[0].Protocol)
@@ -121,6 +122,21 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 		tools, ok := mcp.Tools.Get()
 		if !ok || len(tools.Allowed) != 1 || tools.Allowed[0] != "read_file" {
 			t.Fatalf("mcp tools = %#v, want read_file allowed", mcp.Tools)
+		}
+		if egress.ProtocolRules[1].Protocol != apispec.ProtocolRuleProtocolHTTP {
+			t.Fatalf("protocol rule protocol = %q, want http", egress.ProtocolRules[1].Protocol)
+		}
+		httpRule, ok := egress.ProtocolRules[1].HTTP.Get()
+		if !ok {
+			t.Fatal("http policy not set")
+		}
+		methods, ok := httpRule.Methods.Get()
+		if !ok || len(methods.Allowed) != 2 || methods.Allowed[0] != "GET" || methods.Allowed[1] != "HEAD" {
+			t.Fatalf("http methods = %#v, want GET and HEAD allowed", httpRule.Methods)
+		}
+		paths, ok := httpRule.Paths.Get()
+		if !ok || len(paths.DeniedPrefixes) != 1 || paths.DeniedPrefixes[0] != "/admin/" {
+			t.Fatalf("http paths = %#v, want /admin/ denied prefix", httpRule.Paths)
 		}
 		if len(egress.CredentialRules) != 1 {
 			t.Fatalf("credentialRules count = %d, want 1", len(egress.CredentialRules))
@@ -268,6 +284,20 @@ egress:
         tools:
           allowed: [read_file]
           denied: [run_command]
+    - name: api-http-readonly
+      protocol: http
+      domains: [api.example.com]
+      ports:
+        - port: 8080
+          protocol: tcp
+      http:
+        methods:
+          allowed: [GET, HEAD]
+          denied: [POST]
+        paths:
+          allowed: [/healthz]
+          allowedPrefixes: [/api/]
+          deniedPrefixes: [/admin/]
   credentialRules:
     - name: github-auth
       credentialRef: gh-token
@@ -299,8 +329,19 @@ credentialBindings:
 	if len(egress.TrafficRules) != 1 {
 		t.Fatalf("trafficRules count = %d, want 1", len(egress.TrafficRules))
 	}
-	if len(egress.ProtocolRules) != 1 {
-		t.Fatalf("protocolRules count = %d, want 1", len(egress.ProtocolRules))
+	if len(egress.ProtocolRules) != 2 {
+		t.Fatalf("protocolRules count = %d, want 2", len(egress.ProtocolRules))
+	}
+	if egress.ProtocolRules[1].Protocol != apispec.ProtocolRuleProtocolHTTP {
+		t.Fatalf("protocol rule protocol = %q, want http", egress.ProtocolRules[1].Protocol)
+	}
+	httpRule, ok := egress.ProtocolRules[1].HTTP.Get()
+	if !ok {
+		t.Fatal("http policy not set")
+	}
+	paths, ok := httpRule.Paths.Get()
+	if !ok || len(paths.AllowedPrefixes) != 1 || paths.AllowedPrefixes[0] != "/api/" {
+		t.Fatalf("http paths = %#v, want /api/ allowed prefix", httpRule.Paths)
 	}
 	if len(egress.CredentialRules) != 1 {
 		t.Fatalf("credentialRules count = %d, want 1", len(egress.CredentialRules))


### PR DESCRIPTION
## Summary
- bump sdk-go to the released HTTP protocol controls API spec version v0.6.1
- document --protocol-rule with an HTTP protocol control example
- cover HTTP protocol rule parsing through structured flags and policy-file YAML

## Testing
- go test ./...
- go test -mod=mod ./...