### PR TITLE
Show team member profile fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.1
+	github.com/sandbox0-ai/sdk-go v0.6.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.6.1 h1:pKwFPlogggoEpQMlFs0T/gX5/SrOEDhlEjqxOipvtWU=
-github.com/sandbox0-ai/sdk-go v0.6.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.6.2 h1:uP6iBfESW1HU9n4vMVdZoCCNOCCAFwuUQ6E71GOkU4o=
+github.com/sandbox0-ai/sdk-go v0.6.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -952,11 +952,13 @@ func (f *TableFormatter) formatTeamMemberList(w io.Writer, members []apispec.Tea
 	}
 
 	t := newTable(w)
-	t.Header([]string{"ID", "USER ID", "ROLE", "JOINED AT"})
+	t.Header([]string{"ID", "USER ID", "EMAIL", "NAME", "ROLE", "JOINED AT"})
 	for _, m := range members {
 		_ = t.Append([]string{
 			m.ID,
 			m.UserID,
+			formatOptString(m.Email),
+			formatOptString(m.Name),
 			m.Role,
 			formatTimestamp(m.JoinedAt),
 		})
@@ -968,6 +970,9 @@ func (f *TableFormatter) formatTeamMember(w io.Writer, m *apispec.TeamMember) er
 	t := newTable(w)
 	_ = t.Append([]string{"ID:", m.ID})
 	_ = t.Append([]string{"User ID:", m.UserID})
+	_ = t.Append([]string{"Email:", formatOptString(m.Email)})
+	_ = t.Append([]string{"Name:", formatOptString(m.Name)})
+	_ = t.Append([]string{"Avatar URL:", formatOptString(m.AvatarURL)})
 	_ = t.Append([]string{"Role:", m.Role})
 	_ = t.Append([]string{"Joined At:", formatTimestamp(m.JoinedAt)})
 	return t.Render()

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -160,6 +160,76 @@ func TestTableFormatterFormatRegion(t *testing.T) {
 	}
 }
 
+func TestTableFormatterFormatTeamMemberListIncludesProfileFields(t *testing.T) {
+	formatter := &TableFormatter{}
+	members := []apispec.TeamMember{
+		{
+			ID:        "tm_123",
+			TeamID:    "team_123",
+			UserID:    "user_123",
+			Email:     apispec.NewOptString("dev@example.com"),
+			Name:      apispec.NewOptString("Dev User"),
+			AvatarURL: apispec.NewOptString("https://example.com/avatar.png"),
+			Role:      "developer",
+			JoinedAt:  time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, members); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"EMAIL",
+		"NAME",
+		"dev@example.com",
+		"Dev User",
+		"developer",
+		"2026-06-13 12:00:00",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatTeamMemberIncludesProfileFields(t *testing.T) {
+	formatter := &TableFormatter{}
+	member := &apispec.TeamMember{
+		ID:        "tm_123",
+		TeamID:    "team_123",
+		UserID:    "user_123",
+		Email:     apispec.NewOptString("dev@example.com"),
+		Name:      apispec.NewOptString("Dev User"),
+		AvatarURL: apispec.NewOptString("https://example.com/avatar.png"),
+		Role:      "developer",
+		JoinedAt:  time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, member); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"Email:",
+		"dev@example.com",
+		"Name:",
+		"Dev User",
+		"Avatar URL:",
+		"https://example.com/avatar.png",
+		"Role:",
+		"developer",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 	formatter := &TableFormatter{}
 	sandbox := &apispec.Sandbox{


### PR DESCRIPTION
## Summary
- bump sdk-go to v0.6.2 for TeamMember email/name/avatar_url fields
- show email and name in team member list table output
- show email, name, and avatar URL in single team member table output
- add table formatter coverage for member profile fields

## Tests
- go test ./internal/output
- go test ./...

## Notes
- Published sdk-go v0.6.2 tag from the merged OpenAPI/SDK update so this PR can depend on a stable module version.