### PR TITLE
Use SDK-generated team role enums

### DIFF
--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -637,29 +637,45 @@ var teamMemberRemoveCmd = &cobra.Command{
 }
 
 func parseAddTeamMemberRole(s string) (apispec.AddTeamMemberRequestRole, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", string(apispec.AddTeamMemberRequestRoleDeveloper):
-		return apispec.AddTeamMemberRequestRoleDeveloper, nil
-	case string(apispec.AddTeamMemberRequestRoleAdmin):
-		return apispec.AddTeamMemberRequestRoleAdmin, nil
-	case string(apispec.AddTeamMemberRequestRoleViewer):
-		return apispec.AddTeamMemberRequestRoleViewer, nil
-	default:
-		return "", fmt.Errorf("invalid --role %q, must be one of: admin, developer, viewer", s)
-	}
+	return parseTeamMemberRole(
+		s,
+		apispec.AddTeamMemberRequestRoleDeveloper,
+		apispec.AddTeamMemberRequestRole("").AllValues(),
+	)
 }
 
 func parseUpdateTeamMemberRole(s string) (apispec.UpdateTeamMemberRequestRole, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", string(apispec.UpdateTeamMemberRequestRoleDeveloper):
-		return apispec.UpdateTeamMemberRequestRoleDeveloper, nil
-	case string(apispec.UpdateTeamMemberRequestRoleAdmin):
-		return apispec.UpdateTeamMemberRequestRoleAdmin, nil
-	case string(apispec.UpdateTeamMemberRequestRoleViewer):
-		return apispec.UpdateTeamMemberRequestRoleViewer, nil
-	default:
-		return "", fmt.Errorf("invalid --role %q, must be one of: admin, developer, viewer", s)
+	return parseTeamMemberRole(
+		s,
+		apispec.UpdateTeamMemberRequestRoleDeveloper,
+		apispec.UpdateTeamMemberRequestRole("").AllValues(),
+	)
+}
+
+func parseTeamMemberRole[T ~string](s string, defaultRole T, values []T) (T, error) {
+	normalized := strings.ToLower(strings.TrimSpace(s))
+	if normalized == "" {
+		return defaultRole, nil
 	}
+	for _, value := range values {
+		if string(value) == normalized {
+			return value, nil
+		}
+	}
+	var zero T
+	return zero, fmt.Errorf("invalid --role %q, must be one of: %s", s, strings.Join(teamMemberRoleNames(values), ", "))
+}
+
+func teamMemberRoleNames[T ~string](values []T) []string {
+	names := make([]string, 0, len(values))
+	for _, value := range values {
+		names = append(names, string(value))
+	}
+	return names
+}
+
+func teamMemberRoleFlagHelp() string {
+	return fmt.Sprintf("member role (%s)", strings.Join(teamMemberRoleNames(apispec.AddTeamMemberRequestRole("").AllValues()), ", "))
 }
 
 func buildCreateTeamRequest(name, slug, homeRegion string) *apispec.CreateTeamRequest {
@@ -701,6 +717,6 @@ func init() {
 	teamUpdateCmd.Flags().StringVar(&teamSlug, "slug", "", "new team slug")
 
 	teamMemberAddCmd.Flags().StringVar(&teamMemberEmail, "email", "", "member email (required)")
-	teamMemberAddCmd.Flags().StringVar(&teamMemberRole, "role", "developer", "member role (admin, developer, viewer)")
-	teamMemberUpdateCmd.Flags().StringVar(&teamMemberRole, "role", "developer", "member role (admin, developer, viewer)")
+	teamMemberAddCmd.Flags().StringVar(&teamMemberRole, "role", "developer", teamMemberRoleFlagHelp())
+	teamMemberUpdateCmd.Flags().StringVar(&teamMemberRole, "role", "developer", teamMemberRoleFlagHelp())
 }

--- a/internal/commands/team_test.go
+++ b/internal/commands/team_test.go
@@ -46,6 +46,58 @@ func TestTeamCreateCommandDoesNotExposeActivateFlag(t *testing.T) {
 	}
 }
 
+func TestParseTeamMemberRolesUseGeneratedSDKEnums(t *testing.T) {
+	for _, value := range apispec.AddTeamMemberRequestRole("").AllValues() {
+		got, err := parseAddTeamMemberRole(strings.ToUpper(string(value)))
+		if err != nil {
+			t.Fatalf("parseAddTeamMemberRole(%q) error = %v", value, err)
+		}
+		if got != value {
+			t.Fatalf("parseAddTeamMemberRole(%q) = %q, want %q", value, got, value)
+		}
+	}
+
+	for _, value := range apispec.UpdateTeamMemberRequestRole("").AllValues() {
+		got, err := parseUpdateTeamMemberRole(strings.ToUpper(string(value)))
+		if err != nil {
+			t.Fatalf("parseUpdateTeamMemberRole(%q) error = %v", value, err)
+		}
+		if got != value {
+			t.Fatalf("parseUpdateTeamMemberRole(%q) = %q, want %q", value, got, value)
+		}
+	}
+}
+
+func TestParseTeamMemberRoleDefaultsToDeveloper(t *testing.T) {
+	addRole, err := parseAddTeamMemberRole(" ")
+	if err != nil {
+		t.Fatalf("parseAddTeamMemberRole() error = %v", err)
+	}
+	if addRole != apispec.AddTeamMemberRequestRoleDeveloper {
+		t.Fatalf("default add role = %q, want developer", addRole)
+	}
+
+	updateRole, err := parseUpdateTeamMemberRole(" ")
+	if err != nil {
+		t.Fatalf("parseUpdateTeamMemberRole() error = %v", err)
+	}
+	if updateRole != apispec.UpdateTeamMemberRequestRoleDeveloper {
+		t.Fatalf("default update role = %q, want developer", updateRole)
+	}
+}
+
+func TestParseTeamMemberRoleErrorIncludesGeneratedValues(t *testing.T) {
+	_, err := parseAddTeamMemberRole("owner")
+	if err == nil {
+		t.Fatal("expected invalid role error")
+	}
+	for _, want := range []string{"admin", "developer", "builder", "viewer"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
 func TestResolveTeamHomeRegionID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/teams/team-1" {


### PR DESCRIPTION
## Summary
- derive accepted team member roles from SDK-generated OpenAPI enum values
- include builder automatically in role validation and flag help
- cover add/update role parsing with generated enum values

## Tests
- GOTOOLCHAIN=go1.25.0+auto go test ./internal/commands

Fixes sandbox0-ai/sandbox0#450