### PR TITLE
Add placeholder substitution CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,39 @@ credentialBindings:
 EOF
 s0 sandbox network update --policy-file network.yaml -s <sandbox-id>
 
+# Placeholder substitution: sandbox code sends an opaque placeholder, and egress auth replaces it at the boundary
+cat <<'EOF' > placeholder-network.yaml
+mode: block-all
+egress:
+  trafficRules:
+    - name: allow-example-api
+      action: allow
+      domains: [api.example.com]
+      ports:
+        - port: 8080
+          protocol: tcp
+  credentialRules:
+    - name: api-token
+      credentialRef: api-token
+      protocol: http
+      domains: [api.example.com]
+      ports:
+        - port: 8080
+          protocol: tcp
+      failurePolicy: fail-closed
+credentialBindings:
+  - ref: api-token
+    sourceRef: api-token-source
+    projection:
+      type: placeholder_substitution
+      placeholderSubstitution:
+        replacements:
+          - placeholder: s0env_api_token
+            valueTemplate: "{{ .token }}"
+            locations: [query, header, body]
+EOF
+s0 sandbox network update --policy-file placeholder-network.yaml -s <sandbox-id>
+
 # Script-oriented structured flags: allow SSH traffic, control HTTP operations, then inject outbound auth for GitHub API
 s0 sandbox network update --mode block-all \
   --traffic-rule '{"name":"allow-ssh","action":"allow","appProtocols":["ssh"],"ports":[{"port":22,"protocol":"tcp"}]}' \

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ network:
         httpHeaders:
           headers:
             - name: Authorization
-              valueTemplate: "Bearer {{token}}"
+              valueTemplate: "Bearer {{ .token }}"
 EOF
 s0 sandbox create -t default -f sandbox-config.yaml
 
@@ -397,7 +397,7 @@ credentialBindings:
       httpHeaders:
         headers:
           - name: Authorization
-            valueTemplate: "Bearer {{token}}"
+            valueTemplate: "Bearer {{ .token }}"
 EOF
 s0 sandbox network update --policy-file network.yaml -s <sandbox-id>
 
@@ -438,7 +438,7 @@ s0 sandbox network update --policy-file placeholder-network.yaml -s <sandbox-id>
 s0 sandbox network update --mode block-all \
   --traffic-rule '{"name":"allow-ssh","action":"allow","appProtocols":["ssh"],"ports":[{"port":22,"protocol":"tcp"}]}' \
   --protocol-rule '{"name":"api-http-readonly","protocol":"http","domains":["api.example.com"],"ports":[{"port":8080,"protocol":"tcp"}],"http":{"methods":{"allowed":["GET","HEAD"],"denied":["POST"]},"paths":{"allowedPrefixes":["/api/"],"deniedPrefixes":["/admin/"]}}}' \
-  --credential-binding '{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{token}}"}]}}}' \
+  --credential-binding '{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{ .token }}"}]}}}' \
   --credential-rule '{"name":"github-auth","credentialRef":"gh-token","protocol":"https","domains":["api.github.com"],"ports":[{"port":443,"protocol":"tcp"}]}' \
   -s <sandbox-id>
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.2
+	github.com/sandbox0-ai/sdk-go v0.6.3-0.20260613181043-87bb9c040df3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.3-0.20260613181043-87bb9c040df3
+	github.com/sandbox0-ai/sdk-go v0.6.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.6.2 h1:uP6iBfESW1HU9n4vMVdZoCCNOCCAFwuUQ6E71GOkU4o=
 github.com/sandbox0-ai/sdk-go v0.6.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.6.3-0.20260613181043-87bb9c040df3 h1:xL6s8hTPUfq8jhFZUFGkofDHFGuArFqth8EbR/IhR8k=
+github.com/sandbox0-ai/sdk-go v0.6.3-0.20260613181043-87bb9c040df3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.6.2 h1:uP6iBfESW1HU9n4vMVdZoCCNOCCAFwuUQ6E71GOkU4o=
-github.com/sandbox0-ai/sdk-go v0.6.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.6.3-0.20260613181043-87bb9c040df3 h1:xL6s8hTPUfq8jhFZUFGkofDHFGuArFqth8EbR/IhR8k=
-github.com/sandbox0-ai/sdk-go v0.6.3-0.20260613181043-87bb9c040df3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.6.3 h1:8psLvimMlA1iZ9C7/OPv2XfVy/S0w3k7SU8jJG49/+o=
+github.com/sandbox0-ai/sdk-go v0.6.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_network_test.go
+++ b/internal/commands/sandbox_network_test.go
@@ -146,6 +146,62 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("placeholder substitution credential binding flag", func(t *testing.T) {
+		policy, err := buildNetworkPolicyFromUpdateOptions(networkUpdateOptions{
+			Mode: "block-all",
+			TrafficRules: []string{
+				`{"name":"allow-example-api","action":"allow","domains":["api.example.com"],"ports":[{"port":8080,"protocol":"tcp"}]}`,
+			},
+			CredentialRules: []string{
+				`{"name":"api-token","credentialRef":"api-token","protocol":"http","domains":["api.example.com"],"ports":[{"port":8080,"protocol":"tcp"}],"failurePolicy":"fail-closed"}`,
+			},
+			CredentialBinds: []string{
+				`{"ref":"api-token","sourceRef":"api-token-source","projection":{"type":"placeholder_substitution","placeholderSubstitution":{"replacements":[{"placeholder":"s0env_api_token","valueTemplate":"{{ .token }}","locations":["query","header","body"]}]}}}`,
+			},
+		})
+		if err != nil {
+			t.Fatalf("buildNetworkPolicyFromUpdateOptions() error = %v", err)
+		}
+		egress, ok := policy.Egress.Get()
+		if !ok {
+			t.Fatal("egress not set")
+		}
+		if len(egress.CredentialRules) != 1 {
+			t.Fatalf("credentialRules count = %d, want 1", len(egress.CredentialRules))
+		}
+		if egress.CredentialRules[0].CredentialRef != "api-token" {
+			t.Fatalf("credentialRef = %q, want api-token", egress.CredentialRules[0].CredentialRef)
+		}
+		protocol, ok := egress.CredentialRules[0].Protocol.Get()
+		if !ok || protocol != apispec.EgressAuthProtocolHTTP {
+			t.Fatalf("protocol = %q, want http", protocol)
+		}
+		if len(policy.CredentialBindings) != 1 {
+			t.Fatalf("credentialBindings count = %d, want 1", len(policy.CredentialBindings))
+		}
+		binding := policy.CredentialBindings[0]
+		if binding.Ref != "api-token" || binding.SourceRef != "api-token-source" {
+			t.Fatalf("credential binding = %#v, want api-token/api-token-source", binding)
+		}
+		if binding.Projection.Type != apispec.CredentialProjectionTypePlaceholderSubstitution {
+			t.Fatalf("projection type = %q, want placeholder_substitution", binding.Projection.Type)
+		}
+		placeholderProjection, ok := binding.Projection.PlaceholderSubstitution.Get()
+		if !ok {
+			t.Fatal("placeholderSubstitution projection not set")
+		}
+		if len(placeholderProjection.Replacements) != 1 {
+			t.Fatalf("replacement count = %d, want 1", len(placeholderProjection.Replacements))
+		}
+		replacement := placeholderProjection.Replacements[0]
+		if replacement.Placeholder != "s0env_api_token" {
+			t.Fatalf("placeholder = %q, want s0env_api_token", replacement.Placeholder)
+		}
+		if len(replacement.Locations) != 3 {
+			t.Fatalf("locations = %#v, want query/header/body", replacement.Locations)
+		}
+	})
+
 	t.Run("egress proxy flags create username password binding", func(t *testing.T) {
 		policy, err := buildNetworkPolicyFromUpdateOptions(networkUpdateOptions{
 			Mode:            "block-all",

--- a/internal/commands/sandbox_network_test.go
+++ b/internal/commands/sandbox_network_test.go
@@ -93,7 +93,7 @@ func TestBuildNetworkPolicyFromUpdateOptions(t *testing.T) {
 				`{"name":"api-http-readonly","protocol":"http","domains":["api.example.com"],"ports":[{"port":8080,"protocol":"tcp"}],"http":{"methods":{"allowed":["GET","HEAD"],"denied":["POST"]},"paths":{"allowed":["/healthz"],"allowedPrefixes":["/api/"],"deniedPrefixes":["/admin/"]}}}`,
 			},
 			CredentialBinds: []string{
-				`{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{token}}"}]}}}`,
+				`{"ref":"gh-token","sourceRef":"github-source","projection":{"type":"http_headers","httpHeaders":{"headers":[{"name":"Authorization","valueTemplate":"Bearer {{ .token }}"}]}}}`,
 			},
 			CredentialRules: []string{
 				`{"name":"github-auth","credentialRef":"gh-token","protocol":"https","domains":["api.github.com"],"ports":[{"port":443,"protocol":"tcp"}]}`,
@@ -370,7 +370,7 @@ credentialBindings:
       httpHeaders:
         headers:
           - name: Authorization
-            valueTemplate: "Bearer {{token}}"
+            valueTemplate: "Bearer {{ .token }}"
 `))
 	if err != nil {
 		t.Fatalf("parseNetworkPolicyUpdateFile() error = %v", err)

--- a/internal/commands/sandbox_test.go
+++ b/internal/commands/sandbox_test.go
@@ -33,7 +33,7 @@ network:
         httpHeaders:
           headers:
             - name: Authorization
-              valueTemplate: "Bearer {{token}}"
+              valueTemplate: "Bearer {{ .token }}"
 `)
 
 		request, err := buildSandboxCreateRequest()


### PR DESCRIPTION
## Summary
- update sdk-go to the placeholder_substitution API types from sandbox0-ai/sdk-go#54
- allow --credential-binding / policy files to parse placeholder_substitution projections
- document a CLI network policy example for placeholder substitution

Depends on sandbox0-ai/sdk-go#54.

## Tests
- go test ./...