### PR TITLE
Add sandbox rootfs snapshot commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.4-0.20260617082710-e2d12ec5491d
+	github.com/sandbox0-ai/sdk-go v0.7.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.6.3
+	github.com/sandbox0-ai/sdk-go v0.6.4-0.20260617082710-e2d12ec5491d
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.6.3 h1:8psLvimMlA1iZ9C7/OPv2XfVy/S0w3k7SU8jJG49/+o=
-github.com/sandbox0-ai/sdk-go v0.6.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.6.4-0.20260617082710-e2d12ec5491d h1:EPUyS+qXxjqSor2/J+DFKwJez/rCmOF5aKhlwhNgQl8=
-github.com/sandbox0-ai/sdk-go v0.6.4-0.20260617082710-e2d12ec5491d/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.0 h1:+6bNBwykiqlCDBe3Zd/ic5xsyX7WwD+XWwYRVTJn6LM=
+github.com/sandbox0-ai/sdk-go v0.7.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.6.3 h1:8psLvimMlA1iZ9C7/OPv2XfVy/S0w3k7SU8jJG49/+o=
 github.com/sandbox0-ai/sdk-go v0.6.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.6.4-0.20260617082710-e2d12ec5491d h1:EPUyS+qXxjqSor2/J+DFKwJez/rCmOF5aKhlwhNgQl8=
+github.com/sandbox0-ai/sdk-go v0.6.4-0.20260617082710-e2d12ec5491d/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_rootfs_snapshot.go
+++ b/internal/commands/sandbox_rootfs_snapshot.go
@@ -1,0 +1,238 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sandbox0-ai/sdk-go/pkg/apispec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sandboxRootFSSnapshotName        string
+	sandboxRootFSSnapshotDescription string
+	sandboxRootFSSnapshotExpiresAt   string
+)
+
+// sandboxSnapshotCmd represents the sandbox rootfs snapshot command group.
+var sandboxSnapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Manage sandbox rootfs snapshots",
+	Long:  `List, get, create, delete, and restore sandbox rootfs snapshots.`,
+}
+
+// sandboxSnapshotListCmd lists all rootfs snapshots for a sandbox.
+var sandboxSnapshotListCmd = &cobra.Command{
+	Use:   "list <sandbox-id>",
+	Short: "List sandbox rootfs snapshots",
+	Long:  `List all rootfs snapshots for a sandbox.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		snapshots, err := client.ListSandboxRootFSSnapshots(cmd.Context(), sandboxID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing sandbox rootfs snapshots: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, snapshots); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// sandboxSnapshotGetCmd gets a rootfs snapshot by ID.
+var sandboxSnapshotGetCmd = &cobra.Command{
+	Use:   "get <snapshot-id>",
+	Short: "Get sandbox rootfs snapshot details",
+	Long:  `Get details of a sandbox rootfs snapshot by its ID.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		snapshotID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		snapshot, err := client.GetSandboxRootFSSnapshot(cmd.Context(), snapshotID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting sandbox rootfs snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, snapshot); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// sandboxSnapshotCreateCmd creates a rootfs snapshot for a paused sandbox.
+var sandboxSnapshotCreateCmd = &cobra.Command{
+	Use:   "create <sandbox-id>",
+	Short: "Create a sandbox rootfs snapshot",
+	Long:  `Create a rootfs snapshot for a paused sandbox.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+
+		request, err := buildSandboxRootFSSnapshotCreateRequest()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error building sandbox rootfs snapshot request: %v\n", err)
+			os.Exit(1)
+		}
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		snapshot, err := client.CreateSandboxRootFSSnapshot(cmd.Context(), sandboxID, request)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating sandbox rootfs snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, snapshot); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// sandboxSnapshotDeleteCmd deletes a rootfs snapshot by ID.
+var sandboxSnapshotDeleteCmd = &cobra.Command{
+	Use:   "delete <snapshot-id>",
+	Short: "Delete a sandbox rootfs snapshot",
+	Long:  `Delete a sandbox rootfs snapshot by its ID.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		snapshotID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		_, err = client.DeleteSandboxRootFSSnapshot(cmd.Context(), snapshotID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting sandbox rootfs snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Sandbox rootfs snapshot %s deleted successfully\n", snapshotID)
+	},
+}
+
+// sandboxSnapshotRestoreCmd restores a paused sandbox from a rootfs snapshot.
+var sandboxSnapshotRestoreCmd = &cobra.Command{
+	Use:   "restore <sandbox-id> <snapshot-id>",
+	Short: "Restore sandbox rootfs from a snapshot",
+	Long:  `Restore a paused sandbox rootfs from a rootfs snapshot.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+		snapshotID := args[1]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		response, err := client.RestoreSandboxRootFS(cmd.Context(), sandboxID, apispec.RestoreSandboxRootFSRequest{
+			SnapshotID: snapshotID,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error restoring sandbox rootfs snapshot: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, response); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// sandboxForkCmd creates a paused sandbox fork from a paused source sandbox.
+var sandboxForkCmd = &cobra.Command{
+	Use:   "fork <sandbox-id>",
+	Short: "Fork a paused sandbox",
+	Long:  `Create a paused sandbox fork from a paused source sandbox rootfs.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sandboxID := args[0]
+
+		client, err := getClientRaw(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
+			os.Exit(1)
+		}
+
+		response, err := client.ForkSandbox(cmd.Context(), sandboxID, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error forking sandbox: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := getFormatter().Format(os.Stdout, response); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	sandboxSnapshotCreateCmd.Flags().StringVarP(&sandboxRootFSSnapshotName, "name", "n", "", "snapshot name")
+	sandboxSnapshotCreateCmd.Flags().StringVarP(&sandboxRootFSSnapshotDescription, "description", "d", "", "snapshot description")
+	sandboxSnapshotCreateCmd.Flags().StringVar(&sandboxRootFSSnapshotExpiresAt, "expires-at", "", "snapshot expiration timestamp (RFC3339)")
+
+	sandboxSnapshotCmd.AddCommand(sandboxSnapshotListCmd)
+	sandboxSnapshotCmd.AddCommand(sandboxSnapshotGetCmd)
+	sandboxSnapshotCmd.AddCommand(sandboxSnapshotCreateCmd)
+	sandboxSnapshotCmd.AddCommand(sandboxSnapshotDeleteCmd)
+	sandboxSnapshotCmd.AddCommand(sandboxSnapshotRestoreCmd)
+
+	sandboxCmd.AddCommand(sandboxSnapshotCmd)
+	sandboxCmd.AddCommand(sandboxForkCmd)
+}
+
+func buildSandboxRootFSSnapshotCreateRequest() (*apispec.CreateSandboxRootFSSnapshotRequest, error) {
+	var request apispec.CreateSandboxRootFSSnapshotRequest
+	hasRequest := false
+
+	if sandboxRootFSSnapshotName != "" {
+		request.Name = apispec.NewOptString(sandboxRootFSSnapshotName)
+		hasRequest = true
+	}
+	if sandboxRootFSSnapshotDescription != "" {
+		request.Description = apispec.NewOptString(sandboxRootFSSnapshotDescription)
+		hasRequest = true
+	}
+	if sandboxRootFSSnapshotExpiresAt != "" {
+		expiresAt, err := time.Parse(time.RFC3339, sandboxRootFSSnapshotExpiresAt)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --expires-at %q: expected RFC3339 timestamp", sandboxRootFSSnapshotExpiresAt)
+		}
+		request.ExpiresAt = apispec.NewOptDateTime(expiresAt)
+		hasRequest = true
+	}
+	if !hasRequest {
+		return nil, nil
+	}
+	return &request, nil
+}

--- a/internal/commands/sandbox_rootfs_snapshot_test.go
+++ b/internal/commands/sandbox_rootfs_snapshot_test.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildSandboxRootFSSnapshotCreateRequest(t *testing.T) {
+	resetSandboxFlagsForTest()
+
+	sandboxRootFSSnapshotName = "checkpoint"
+	sandboxRootFSSnapshotDescription = "before upgrade"
+	sandboxRootFSSnapshotExpiresAt = "2026-01-02T03:04:05Z"
+
+	request, err := buildSandboxRootFSSnapshotCreateRequest()
+	if err != nil {
+		t.Fatalf("buildSandboxRootFSSnapshotCreateRequest() error = %v", err)
+	}
+	if request == nil {
+		t.Fatal("request is nil")
+	}
+
+	name, ok := request.Name.Get()
+	if !ok || name != "checkpoint" {
+		t.Fatalf("Name = %q, %v; want checkpoint, true", name, ok)
+	}
+	description, ok := request.Description.Get()
+	if !ok || description != "before upgrade" {
+		t.Fatalf("Description = %q, %v; want before upgrade, true", description, ok)
+	}
+	expiresAt, ok := request.ExpiresAt.Get()
+	if !ok {
+		t.Fatal("ExpiresAt is not set")
+	}
+	wantExpiresAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	if !expiresAt.Equal(wantExpiresAt) {
+		t.Fatalf("ExpiresAt = %s, want %s", expiresAt, wantExpiresAt)
+	}
+}
+
+func TestBuildSandboxRootFSSnapshotCreateRequestReturnsNilWithoutMetadata(t *testing.T) {
+	resetSandboxFlagsForTest()
+
+	request, err := buildSandboxRootFSSnapshotCreateRequest()
+	if err != nil {
+		t.Fatalf("buildSandboxRootFSSnapshotCreateRequest() error = %v", err)
+	}
+	if request != nil {
+		t.Fatalf("request = %+v, want nil", request)
+	}
+}
+
+func TestBuildSandboxRootFSSnapshotCreateRequestRejectsInvalidExpiresAt(t *testing.T) {
+	resetSandboxFlagsForTest()
+
+	sandboxRootFSSnapshotExpiresAt = "tomorrow"
+
+	_, err := buildSandboxRootFSSnapshotCreateRequest()
+	if err == nil {
+		t.Fatal("buildSandboxRootFSSnapshotCreateRequest() error = nil, want error")
+	}
+}
+
+func TestSandboxRootFSCommandsRegistered(t *testing.T) {
+	if sandboxCmd.Commands() == nil {
+		t.Fatal("sandbox commands are not registered")
+	}
+	if cmd, _, err := sandboxCmd.Find([]string{"snapshot", "create"}); err != nil || cmd != sandboxSnapshotCreateCmd {
+		t.Fatalf("sandbox snapshot create command not registered: cmd=%v err=%v", cmd, err)
+	}
+	if cmd, _, err := sandboxCmd.Find([]string{"fork"}); err != nil || cmd != sandboxForkCmd {
+		t.Fatalf("sandbox fork command not registered: cmd=%v err=%v", cmd, err)
+	}
+	if flag := sandboxSnapshotCreateCmd.Flags().Lookup("expires-at"); flag == nil {
+		t.Fatal("sandbox snapshot create --expires-at flag is not registered")
+	}
+}

--- a/internal/commands/sandbox_test.go
+++ b/internal/commands/sandbox_test.go
@@ -260,4 +260,7 @@ func resetSandboxFlagsForTest() {
 	sandboxUpdateHardTTL = 0
 	sandboxUpdateAutoResume = ""
 	sandboxUpdateConfigFile = ""
+	sandboxRootFSSnapshotName = ""
+	sandboxRootFSSnapshotDescription = ""
+	sandboxRootFSSnapshotExpiresAt = ""
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -37,6 +37,16 @@ func (f *TableFormatter) Format(w io.Writer, data interface{}) error {
 		return f.formatSnapshots(w, v)
 	case *apispec.Snapshot:
 		return f.formatSnapshot(w, v)
+	case []apispec.SandboxRootFSSnapshot:
+		return f.formatSandboxRootFSSnapshots(w, v)
+	case *apispec.SandboxRootFSSnapshotList:
+		return f.formatSandboxRootFSSnapshotList(w, v)
+	case *apispec.SandboxRootFSSnapshot:
+		return f.formatSandboxRootFSSnapshot(w, v)
+	case *apispec.RestoreSandboxRootFSResponse:
+		return f.formatRestoreSandboxRootFSResponse(w, v)
+	case *apispec.ForkSandboxResponse:
+		return f.formatForkSandboxResponse(w, v)
 	case *apispec.Sandbox:
 		return f.formatSandbox(w, v)
 	case *apispec.SandboxStatus:
@@ -257,6 +267,69 @@ func (f *TableFormatter) formatSnapshot(w io.Writer, s *apispec.Snapshot) error 
 	}
 	_ = t.Append([]string{"Size:", fmt.Sprintf("%d bytes", s.SizeBytes)})
 	_ = t.Append([]string{"Created:", s.CreatedAt})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSandboxRootFSSnapshotList(w io.Writer, snapshots *apispec.SandboxRootFSSnapshotList) error {
+	if snapshots == nil {
+		_, _ = fmt.Fprintln(w, "No sandbox rootfs snapshots found.")
+		return nil
+	}
+	if err := f.formatSandboxRootFSSnapshots(w, snapshots.Snapshots); err != nil {
+		return err
+	}
+	if len(snapshots.Snapshots) > 0 {
+		_, _ = fmt.Fprintf(w, "Total: %d\n", snapshots.Count)
+	}
+	return nil
+}
+
+func (f *TableFormatter) formatSandboxRootFSSnapshots(w io.Writer, snapshots []apispec.SandboxRootFSSnapshot) error {
+	if len(snapshots) == 0 {
+		_, _ = fmt.Fprintln(w, "No sandbox rootfs snapshots found.")
+		return nil
+	}
+
+	t := newTable(w)
+	t.Header([]string{"ID", "SANDBOX ID", "NAME", "CREATED", "EXPIRES"})
+	for _, s := range snapshots {
+		_ = t.Append([]string{
+			s.ID,
+			s.SandboxID,
+			formatOptString(s.Name),
+			formatTimestamp(s.CreatedAt),
+			formatOptDateTime(s.ExpiresAt),
+		})
+	}
+	return t.Render()
+}
+
+func (f *TableFormatter) formatSandboxRootFSSnapshot(w io.Writer, s *apispec.SandboxRootFSSnapshot) error {
+	t := newTable(w)
+	_ = t.Append([]string{"ID:", s.ID})
+	_ = t.Append([]string{"Sandbox ID:", s.SandboxID})
+	_ = t.Append([]string{"Name:", formatOptString(s.Name)})
+	_ = t.Append([]string{"Description:", formatOptString(s.Description)})
+	_ = t.Append([]string{"Created At:", formatTimestamp(s.CreatedAt)})
+	_ = t.Append([]string{"Expires At:", formatOptDateTime(s.ExpiresAt)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatRestoreSandboxRootFSResponse(w io.Writer, r *apispec.RestoreSandboxRootFSResponse) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Sandbox ID:", r.SandboxID})
+	_ = t.Append([]string{"Snapshot ID:", r.SnapshotID})
+	_ = t.Append([]string{"Status:", string(r.Status)})
+	return t.Render()
+}
+
+func (f *TableFormatter) formatForkSandboxResponse(w io.Writer, r *apispec.ForkSandboxResponse) error {
+	t := newTable(w)
+	_ = t.Append([]string{"Source Sandbox ID:", r.SourceSandboxID})
+	_ = t.Append([]string{"Fork Sandbox ID:", r.Sandbox.ID})
+	_ = t.Append([]string{"Template ID:", r.Sandbox.TemplateID})
+	_ = t.Append([]string{"Status:", string(r.Sandbox.Status)})
+	_ = t.Append([]string{"Paused:", fmt.Sprintf("%v", r.Sandbox.Paused)})
 	return t.Render()
 }
 

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -270,6 +270,83 @@ func TestTableFormatterFormatSandboxIncludesSSHConnection(t *testing.T) {
 	}
 }
 
+func TestTableFormatterFormatSandboxRootFSSnapshotList(t *testing.T) {
+	formatter := &TableFormatter{}
+	snapshots := &apispec.SandboxRootFSSnapshotList{
+		Snapshots: []apispec.SandboxRootFSSnapshot{
+			{
+				ID:        "snap_123",
+				SandboxID: "sb_123",
+				Name:      apispec.NewOptString("checkpoint"),
+				CreatedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: apispec.NewOptDateTime(time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)),
+			},
+		},
+		Count: 1,
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, snapshots); err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{
+		"ID",
+		"SANDBOX ID",
+		"snap_123",
+		"sb_123",
+		"checkpoint",
+		"2026-04-10 12:00:00",
+		"2026-04-11 12:00:00",
+		"Total: 1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableFormatterFormatSandboxRootFSSnapshotActions(t *testing.T) {
+	formatter := &TableFormatter{}
+
+	restore := &apispec.RestoreSandboxRootFSResponse{
+		SandboxID:  "sb_123",
+		SnapshotID: "snap_123",
+		Status:     apispec.SandboxLifecycleStatusPaused,
+	}
+	var restoreBuf bytes.Buffer
+	if err := formatter.Format(&restoreBuf, restore); err != nil {
+		t.Fatalf("Format() restore error = %v", err)
+	}
+	restoreOutput := restoreBuf.String()
+	for _, want := range []string{"Sandbox ID:", "sb_123", "Snapshot ID:", "snap_123", "paused"} {
+		if !strings.Contains(restoreOutput, want) {
+			t.Fatalf("restore output missing %q:\n%s", want, restoreOutput)
+		}
+	}
+
+	fork := &apispec.ForkSandboxResponse{
+		SourceSandboxID: "sb_123",
+		Sandbox: apispec.Sandbox{
+			ID:         "sb_456",
+			TemplateID: "default",
+			Status:     apispec.SandboxLifecycleStatusPaused,
+			Paused:     true,
+		},
+	}
+	var forkBuf bytes.Buffer
+	if err := formatter.Format(&forkBuf, fork); err != nil {
+		t.Fatalf("Format() fork error = %v", err)
+	}
+	forkOutput := forkBuf.String()
+	for _, want := range []string{"Source Sandbox ID:", "sb_123", "Fork Sandbox ID:", "sb_456", "default", "paused", "true"} {
+		if !strings.Contains(forkOutput, want) {
+			t.Fatalf("fork output missing %q:\n%s", want, forkOutput)
+		}
+	}
+}
+
 func TestTableFormatterFormatSandboxServicesIncludesPublicURL(t *testing.T) {
 	formatter := &TableFormatter{}
 	services := &sandbox0.SandboxServicesResponse{


### PR DESCRIPTION
Summary:
- add s0 sandbox snapshot create/list/get/delete/restore commands
- add s0 sandbox fork command backed by sdk-go helpers
- add table output and unit coverage for new CLI request parsing and output
- update sdk-go dependency to v0.7.0

Tests:
- go test ./...
- go build ./...