### PR TITLE
Propagate sandbox exec exit status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.7.1-0.20260618164024-e0a441ef53e2
+	github.com/sandbox0-ai/sdk-go v0.7.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.7.0
+	github.com/sandbox0-ai/sdk-go v0.7.1-0.20260618164024-e0a441ef53e2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.7.0 h1:+6bNBwykiqlCDBe3Zd/ic5xsyX7WwD+XWwYRVTJn6LM=
 github.com/sandbox0-ai/sdk-go v0.7.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.1-0.20260618164024-e0a441ef53e2 h1:eXeDGmc4BUphU/5DxGA+E27vsiGsFUhoKu3NNZDoJXs=
+github.com/sandbox0-ai/sdk-go v0.7.1-0.20260618164024-e0a441ef53e2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.7.0 h1:+6bNBwykiqlCDBe3Zd/ic5xsyX7WwD+XWwYRVTJn6LM=
-github.com/sandbox0-ai/sdk-go v0.7.0/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.7.1-0.20260618164024-e0a441ef53e2 h1:eXeDGmc4BUphU/5DxGA+E27vsiGsFUhoKu3NNZDoJXs=
-github.com/sandbox0-ai/sdk-go v0.7.1-0.20260618164024-e0a441ef53e2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.1 h1:MRvL68N0EJ+115f/YqUC8ImTJc5KNd/MTyPZgqXtljA=
+github.com/sandbox0-ai/sdk-go v0.7.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_exec.go
+++ b/internal/commands/sandbox_exec.go
@@ -124,7 +124,17 @@ Examples:
 		}
 
 		fmt.Print(result.OutputRaw)
+		if code, failed := remoteExecFailureCode(result.ExitCode); failed {
+			os.Exit(code)
+		}
 	},
+}
+
+func remoteExecFailureCode(exitCode *int) (int, bool) {
+	if exitCode == nil || *exitCode == 0 {
+		return 0, false
+	}
+	return *exitCode, true
 }
 
 func extractExecCommand(args []string) []string {

--- a/internal/commands/sandbox_exec_test.go
+++ b/internal/commands/sandbox_exec_test.go
@@ -126,3 +126,21 @@ func TestIsTerminalDoneExecMessage(t *testing.T) {
 		t.Fatal("process done should terminate exec stream")
 	}
 }
+
+func TestRemoteExecFailureCode(t *testing.T) {
+	t.Parallel()
+
+	if code, failed := remoteExecFailureCode(nil); failed || code != 0 {
+		t.Fatalf("nil exit code = (%d, %v), want (0, false)", code, failed)
+	}
+
+	zero := 0
+	if code, failed := remoteExecFailureCode(&zero); failed || code != 0 {
+		t.Fatalf("zero exit code = (%d, %v), want (0, false)", code, failed)
+	}
+
+	nonzero := 7
+	if code, failed := remoteExecFailureCode(&nonzero); !failed || code != 7 {
+		t.Fatalf("nonzero exit code = (%d, %v), want (7, true)", code, failed)
+	}
+}


### PR DESCRIPTION
## Summary
- update sdk-go dependency to the branch from sandbox0-ai/sdk-go#57
- make non-streaming `s0 sandbox exec` exit with the remote command exit code when available
- add unit coverage for exit-code mapping

Depends on sandbox0-ai/sdk-go#57.

## Tests
- `go test ./...`