### PR TITLE
Add sandbox claim snapshot flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ s0 admin region delete <region-id>
 
 ```bash
 s0 sandbox run <sandbox-id> <input> [--alias <alias>] [--context-id <ctx-id>]
-s0 sandbox create -t <template-id> [-f sandbox-config.yaml] [--ttl 3600] [--hard-ttl 7200] [--mount <volume-id>:/absolute/path] [--wait-for-mounts] [--mount-wait-timeout-ms 45000]
+s0 sandbox create -t <template-id> [-f sandbox-config.yaml] [--ttl 3600] [--hard-ttl 7200] [--snapshot-id <rootfs-snapshot-id>] [--mount <volume-id>:/absolute/path] [--wait-for-mounts] [--mount-wait-timeout-ms 45000]
 s0 sandbox get <sandbox-id>
 s0 sandbox update <sandbox-id> [-f sandbox-update.yaml] [--ttl 3600] [--hard-ttl 7200] [--auto-resume true|false]
 s0 sandbox delete <sandbox-id>
@@ -273,11 +273,13 @@ Bootstrap mounts can be requested as part of sandbox creation:
 ```bash
 s0 volume create
 s0 sandbox create -t default \
+  --snapshot-id <rootfs-snapshot-id> \
   --mount <volume-id>:/workspace/data
 
 # Or provide a full claim request file.
 cat <<'EOF' > sandbox-claim.yaml
 template: default
+snapshot_id: <rootfs-snapshot-id>
 mounts:
   - sandboxvolume_id: <volume-id>
     mount_point: /workspace/data

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.7.2-0.20260618214123-1a45439188b8
+	github.com/sandbox0-ai/sdk-go v0.7.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.7.1
+	github.com/sandbox0-ai/sdk-go v0.7.2-0.20260618214123-1a45439188b8
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sandbox0-ai/sdk-go v0.7.1 h1:MRvL68N0EJ+115f/YqUC8ImTJc5KNd/MTyPZgqXtljA=
 github.com/sandbox0-ai/sdk-go v0.7.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.2-0.20260618214123-1a45439188b8 h1:4c9YX22xaq6TmxA3xs+86WBpo/pJtNgEEvA5GP/WtGw=
+github.com/sandbox0-ai/sdk-go v0.7.2-0.20260618214123-1a45439188b8/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.7.1 h1:MRvL68N0EJ+115f/YqUC8ImTJc5KNd/MTyPZgqXtljA=
-github.com/sandbox0-ai/sdk-go v0.7.1/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
-github.com/sandbox0-ai/sdk-go v0.7.2-0.20260618214123-1a45439188b8 h1:4c9YX22xaq6TmxA3xs+86WBpo/pJtNgEEvA5GP/WtGw=
-github.com/sandbox0-ai/sdk-go v0.7.2-0.20260618214123-1a45439188b8/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.2 h1:5z3lNYkfZTcOcIWYVCV4sUXvfmf/UViuZKSbc5b0/2k=
+github.com/sandbox0-ai/sdk-go v0.7.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -18,6 +18,7 @@ var (
 	sandboxHardTTL    int32
 	sandboxConfigFile string
 	sandboxMounts     []string
+	sandboxSnapshotID string
 	// list flags
 	sandboxListStatus     string
 	sandboxListTemplateID string
@@ -383,6 +384,7 @@ func init() {
 	sandboxCreateCmd.Flags().Int32Var(&sandboxTTL, "ttl", 0, "soft TTL in seconds")
 	sandboxCreateCmd.Flags().Int32Var(&sandboxHardTTL, "hard-ttl", 0, "hard TTL in seconds")
 	sandboxCreateCmd.Flags().StringArrayVar(&sandboxMounts, "mount", nil, "bootstrap mount in the form <sandboxvolume-id>:/absolute/path (repeatable)")
+	sandboxCreateCmd.Flags().StringVar(&sandboxSnapshotID, "snapshot-id", "", "rootfs snapshot ID used to initialize the new sandbox")
 
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxGetCmd)
@@ -429,6 +431,9 @@ func buildSandboxCreateRequest() (apispec.ClaimRequest, error) {
 	}
 	if sandboxTemplate != "" {
 		request.Template = apispec.NewOptString(sandboxTemplate)
+	}
+	if sandboxSnapshotID != "" {
+		request.SnapshotID = apispec.NewOptString(sandboxSnapshotID)
 	}
 
 	configOverrides, hasConfigOverrides, err := buildSandboxCreateConfigOverrides()
@@ -574,7 +579,7 @@ func isSandboxCreateClaimRequest(data []byte) (bool, error) {
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return false, fmt.Errorf("parse sandbox create file: %w", err)
 	}
-	for _, key := range []string{"template", "config", "mounts"} {
+	for _, key := range []string{"template", "config", "mounts", "snapshot_id"} {
 		if _, ok := raw[key]; ok {
 			return true, nil
 		}

--- a/internal/commands/sandbox_test.go
+++ b/internal/commands/sandbox_test.go
@@ -91,6 +91,7 @@ hard_ttl: 120
 		resetSandboxFlagsForTest()
 		sandboxConfigFile = writeTempFile(t, `
 template: from-file
+snapshot_id: snap_file
 mounts:
   - sandboxvolume_id: vol_123
     mount_point: /workspace/data
@@ -105,6 +106,10 @@ config:
 		template, ok := request.Template.Get()
 		if !ok || template != "from-file" {
 			t.Fatalf("template = %q, want from-file", template)
+		}
+		snapshotID, ok := request.SnapshotID.Get()
+		if !ok || snapshotID != "snap_file" {
+			t.Fatalf("snapshot_id = %q, want snap_file", snapshotID)
 		}
 		if len(request.Mounts) != 1 {
 			t.Fatalf("mount count = %d, want 1", len(request.Mounts))
@@ -131,8 +136,10 @@ config:
 	t.Run("mount flags append to request file mounts and template flag overrides", func(t *testing.T) {
 		resetSandboxFlagsForTest()
 		sandboxTemplate = "flag-template"
+		sandboxSnapshotID = "snap_flag"
 		sandboxConfigFile = writeTempFile(t, `
 template: from-file
+snapshot_id: snap_file
 mounts:
   - sandboxvolume_id: vol_file
     mount_point: /workspace/from-file
@@ -146,6 +153,10 @@ mounts:
 		template, ok := request.Template.Get()
 		if !ok || template != "flag-template" {
 			t.Fatalf("template = %q, want flag-template", template)
+		}
+		snapshotID, ok := request.SnapshotID.Get()
+		if !ok || snapshotID != "snap_flag" {
+			t.Fatalf("snapshot_id = %q, want snap_flag", snapshotID)
 		}
 		if len(request.Mounts) != 2 {
 			t.Fatalf("mount count = %d, want 2", len(request.Mounts))
@@ -251,6 +262,7 @@ func resetSandboxFlagsForTest() {
 	sandboxHardTTL = 0
 	sandboxConfigFile = ""
 	sandboxMounts = nil
+	sandboxSnapshotID = ""
 	sandboxListStatus = ""
 	sandboxListTemplateID = ""
 	sandboxListPaused = ""


### PR DESCRIPTION
## Summary
- add s0 sandbox create --snapshot-id
- support snapshot_id in full claim request files
- update README usage and tests

## Dependency
- depends on sdk-go commit 1a45439188b8 via pseudo-version v0.7.2-0.20260618214123-1a45439188b8

## Tests
- go test ./internal/commands