### PR TITLE
Document claim-time volume mount requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ s0 user ssh-key delete <ssh-key-id>
 
 Bootstrap mounts can be requested as part of sandbox creation:
 
+Mount paths must be declared by the sandbox template's `volumeMounts`. If the template declares volume mounts, provide a `--mount` flag or `mounts` entry for every declared path in the claim request.
+
 ```bash
 s0 volume create
 s0 sandbox create -t default \

--- a/internal/commands/sandbox.go
+++ b/internal/commands/sandbox.go
@@ -383,7 +383,7 @@ func init() {
 	sandboxCreateCmd.Flags().StringVarP(&sandboxConfigFile, "config-file", "f", "", "path to sandbox config or claim request YAML/JSON file, or - for stdin")
 	sandboxCreateCmd.Flags().Int32Var(&sandboxTTL, "ttl", 0, "soft TTL in seconds")
 	sandboxCreateCmd.Flags().Int32Var(&sandboxHardTTL, "hard-ttl", 0, "hard TTL in seconds")
-	sandboxCreateCmd.Flags().StringArrayVar(&sandboxMounts, "mount", nil, "bootstrap mount in the form <sandboxvolume-id>:/absolute/path (repeatable)")
+	sandboxCreateCmd.Flags().StringArrayVar(&sandboxMounts, "mount", nil, "bind an existing volume to a template-declared mount point in the form <sandboxvolume-id>:/absolute/path (repeatable)")
 	sandboxCreateCmd.Flags().StringVar(&sandboxSnapshotID, "snapshot-id", "", "rootfs snapshot ID used to initialize the new sandbox")
 
 	sandboxCmd.AddCommand(sandboxCreateCmd)


### PR DESCRIPTION
## Summary
- document that claim-time mounts must target template-declared volumeMounts
- clarify the sandbox create --mount help for claim-time volume binding

## Tests
- go test ./...