### PR TITLE
Split sandbox exec output streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.7.3-0.20260622073013-51fb9368677b
+	github.com/sandbox0-ai/sdk-go v0.7.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/olekukonko/tablewriter v1.1.3
-	github.com/sandbox0-ai/sdk-go v0.7.2
+	github.com/sandbox0-ai/sdk-go v0.7.3-0.20260622073013-51fb9368677b
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.7.2 h1:5z3lNYkfZTcOcIWYVCV4sUXvfmf/UViuZKSbc5b0/2k=
-github.com/sandbox0-ai/sdk-go v0.7.2/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.3-0.20260622073013-51fb9368677b h1:lmB1Wbv6p2TiOt3Sw7oH7+zPblX02VbvlojHF+YmTNg=
+github.com/sandbox0-ai/sdk-go v0.7.3-0.20260622073013-51fb9368677b/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/sandbox0-ai/sdk-go v0.7.3-0.20260622073013-51fb9368677b h1:lmB1Wbv6p2TiOt3Sw7oH7+zPblX02VbvlojHF+YmTNg=
-github.com/sandbox0-ai/sdk-go v0.7.3-0.20260622073013-51fb9368677b/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
+github.com/sandbox0-ai/sdk-go v0.7.3 h1:E8sZw/q3skOCLzKFTNii76r4NynJ559sgN4fXKXpUZM=
+github.com/sandbox0-ai/sdk-go v0.7.3/go.mod h1:aF/r6jQLiVTuFP3628yokTxOUoZESEDB50txzDrOgq4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/commands/sandbox_exec.go
+++ b/internal/commands/sandbox_exec.go
@@ -123,11 +123,26 @@ Examples:
 			os.Exit(1)
 		}
 
-		fmt.Print(result.OutputRaw)
+		if err := writeCmdResultOutput(os.Stdout, os.Stderr, result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing command output: %v\n", err)
+			os.Exit(1)
+		}
 		if code, failed := remoteExecFailureCode(result.ExitCode); failed {
 			os.Exit(code)
 		}
 	},
+}
+
+func writeCmdResultOutput(stdout io.Writer, stderr io.Writer, result sandbox0.CmdResult) error {
+	if result.Stdout == "" && result.Stderr == "" {
+		_, err := io.WriteString(stdout, result.OutputRaw)
+		return err
+	}
+	if _, err := io.WriteString(stdout, result.Stdout); err != nil {
+		return err
+	}
+	_, err := io.WriteString(stderr, result.Stderr)
+	return err
 }
 
 func remoteExecFailureCode(exitCode *int) (int, bool) {

--- a/internal/commands/sandbox_exec_test.go
+++ b/internal/commands/sandbox_exec_test.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
+
+	sandbox0 "github.com/sandbox0-ai/sdk-go"
 )
 
 func TestExtractExecCommand(t *testing.T) {
@@ -142,5 +145,47 @@ func TestRemoteExecFailureCode(t *testing.T) {
 	nonzero := 7
 	if code, failed := remoteExecFailureCode(&nonzero); !failed || code != 7 {
 		t.Fatalf("nonzero exit code = (%d, %v), want (7, true)", code, failed)
+	}
+}
+
+func TestWriteCmdResultOutputSplitsStreams(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := writeCmdResultOutput(&stdout, &stderr, sandbox0.CmdResult{
+		OutputRaw: "outerr",
+		Stdout:    "out",
+		Stderr:    "err",
+	})
+	if err != nil {
+		t.Fatalf("writeCmdResultOutput() error = %v", err)
+	}
+	if got := stdout.String(); got != "out" {
+		t.Fatalf("stdout = %q, want out", got)
+	}
+	if got := stderr.String(); got != "err" {
+		t.Fatalf("stderr = %q, want err", got)
+	}
+}
+
+func TestWriteCmdResultOutputFallsBackToOutputRaw(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := writeCmdResultOutput(&stdout, &stderr, sandbox0.CmdResult{
+		OutputRaw: "legacy",
+	})
+	if err != nil {
+		t.Fatalf("writeCmdResultOutput() error = %v", err)
+	}
+	if got := stdout.String(); got != "legacy" {
+		t.Fatalf("stdout = %q, want legacy", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Summary
- update sdk-go dependency to released `v0.7.3`
- make non-streaming `s0 sandbox exec` write stdout and stderr to separate local streams
- keep `OutputRaw` fallback for older servers and PTY-style responses
- add focused unit coverage for split and legacy output paths

Depends on sandbox0-ai/sandbox0#571 and sandbox0-ai/sdk-go#60, both merged.

## Tests
- go test ./...
- go build -buildvcs=false ./...

Note: plain `go build ./...` previously failed locally while obtaining VCS status from this worktree; `-buildvcs=false` verified the build path.
